### PR TITLE
features/eu-debug: Initial patches for eu-debug support for LNL/BMG

### DIFF
--- a/backport.sh
+++ b/backport.sh
@@ -69,6 +69,10 @@ create_kernel_tree () {
 
 	echo "Applying local patches"
 	while read p; do
+		case "$p" in \#*)
+			echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
+			continue;;
+		esac
 		git am -q -s "$p"
 		if [ $? -ne 0 ]; then
 			echo "Failed to apply patch $p"

--- a/backport/patches/features/eu-debug/0001-drm-xe-Add-EUDEBUG_ENABLE-exec-queue-property.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Add-EUDEBUG_ENABLE-exec-queue-property.patch
@@ -1,0 +1,266 @@
+From bf52a72ebe664dd97af97a18c754295235c0fb4e Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Fri, 2 Jun 2023 01:33:14 +0200
+Subject: drm/xe: Add EUDEBUG_ENABLE exec queue property
+
+Introduce exec queue immutable property of eudebug
+with a flags as value to enable eudebug specific feature(s).
+
+For now engine lrc will use this flag to set up runalone
+hw feature. Runalone is used to ensure that only one hw engine
+of group [rcs0, ccs0-3] is active on a tile.
+
+Note: unlike the i915, xe allows user to set runalone
+also on devices with single render/compute engine. It should not
+make much difference, but leave control to the user.
+
+v2: - check CONFIG_DRM_XE_EUDEBUG and LR mode (Matthew)
+    - disable preempt (Dominik)
+
+Cc: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit f4aa832e49574a6b667630e6bff9675cd6e7e538 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_eudebug.c          |  4 +--
+ drivers/gpu/drm/xe/xe_exec_queue.c       | 46 ++++++++++++++++++++++--
+ drivers/gpu/drm/xe/xe_exec_queue.h       |  2 ++
+ drivers/gpu/drm/xe/xe_exec_queue_types.h |  7 ++++
+ drivers/gpu/drm/xe/xe_hw_engine.c        |  2 +-
+ drivers/gpu/drm/xe/xe_lrc.c              | 16 +++++++--
+ drivers/gpu/drm/xe/xe_lrc.h              |  4 ++-
+ include/uapi/drm/xe_drm.h                |  3 +-
+ 8 files changed, 74 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 8c0599a10a3c..2c380622f586 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -1245,7 +1245,7 @@ static int exec_queue_create_event(struct xe_eudebug *d,
+ 	u64 h_lrc[XE_HW_ENGINE_MAX_INSTANCE], seqno;
+ 	int i;
+ 
+-	if (!xe_exec_queue_is_lr(q))
++	if (!xe_exec_queue_is_debuggable(q))
+ 		return 0;
+ 
+ 	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
+@@ -1297,7 +1297,7 @@ static int exec_queue_destroy_event(struct xe_eudebug *d,
+ 	u64 h_lrc[XE_HW_ENGINE_MAX_INSTANCE], seqno;
+ 	int i;
+ 
+-	if (!xe_exec_queue_is_lr(q))
++	if (!xe_exec_queue_is_debuggable(q))
+ 		return 0;
+ 
+ 	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index e9e32af1a8b4..e59017c2e158 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -107,6 +107,7 @@ static struct xe_exec_queue *__xe_exec_queue_alloc(struct xe_device *xe,
+ static int __xe_exec_queue_init(struct xe_exec_queue *q)
+ {
+ 	struct xe_vm *vm = q->vm;
++	u32 flags = 0;
+ 	int i, err;
+ 
+ 	if (vm) {
+@@ -115,8 +116,11 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q)
+ 			return err;
+ 	}
+ 
++	if (q->eudebug_flags & EXEC_QUEUE_EUDEBUG_FLAG_ENABLE)
++		flags |= LRC_CREATE_RUNALONE;
++
+ 	for (i = 0; i < q->width; ++i) {
+-		q->lrc[i] = xe_lrc_create(q->hwe, q->vm, SZ_16K);
++		q->lrc[i] = xe_lrc_create(q->hwe, q->vm, SZ_16K, flags);
+ 		if (IS_ERR(q->lrc[i])) {
+ 			err = PTR_ERR(q->lrc[i]);
+ 			goto err_unlock;
+@@ -389,6 +393,42 @@ static int exec_queue_set_timeslice(struct xe_device *xe, struct xe_exec_queue *
+ 	return 0;
+ }
+ 
++static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
++				  u64 value)
++{
++	const u64 known_flags = DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE;
++
++	if (XE_IOCTL_DBG(xe, (q->class != XE_ENGINE_CLASS_RENDER &&
++			      q->class != XE_ENGINE_CLASS_COMPUTE)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, (value & ~known_flags)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, !IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)))
++		return -EOPNOTSUPP;
++
++	if (XE_IOCTL_DBG(xe, !xe_exec_queue_is_lr(q)))
++		return -EINVAL;
++	/*
++	 * We want to explicitly set the global feature if
++	 * property is set.
++	 */
++	if (XE_IOCTL_DBG(xe,
++			 !(value & DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE)))
++		return -EINVAL;
++
++	q->eudebug_flags = EXEC_QUEUE_EUDEBUG_FLAG_ENABLE;
++	q->sched_props.preempt_timeout_us = 0;
++
++	return 0;
++}
++
++int xe_exec_queue_is_debuggable(struct xe_exec_queue *q)
++{
++	return q->eudebug_flags & EXEC_QUEUE_EUDEBUG_FLAG_ENABLE;
++}
++
+ typedef int (*xe_exec_queue_set_property_fn)(struct xe_device *xe,
+ 					     struct xe_exec_queue *q,
+ 					     u64 value);
+@@ -396,6 +436,7 @@ typedef int (*xe_exec_queue_set_property_fn)(struct xe_device *xe,
+ static const xe_exec_queue_set_property_fn exec_queue_set_property_funcs[] = {
+ 	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY] = exec_queue_set_priority,
+ 	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE] = exec_queue_set_timeslice,
++	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG] = exec_queue_set_eudebug,
+ };
+ 
+ static int exec_queue_user_ext_set_property(struct xe_device *xe,
+@@ -415,7 +456,8 @@ static int exec_queue_user_ext_set_property(struct xe_device *xe,
+ 			 ARRAY_SIZE(exec_queue_set_property_funcs)) ||
+ 	    XE_IOCTL_DBG(xe, ext.pad) ||
+ 	    XE_IOCTL_DBG(xe, ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY &&
+-			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE))
++			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE &&
++			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG))
+ 		return -EINVAL;
+ 
+ 	idx = array_index_nospec(ext.property, ARRAY_SIZE(exec_queue_set_property_funcs));
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.h b/drivers/gpu/drm/xe/xe_exec_queue.h
+index 99139368ba6e..10b4fee55d23 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue.h
+@@ -83,4 +83,6 @@ int xe_exec_queue_last_fence_test_dep(struct xe_exec_queue *q,
+ 				      struct xe_vm *vm);
+ void xe_exec_queue_update_run_ticks(struct xe_exec_queue *q);
+ 
++int xe_exec_queue_is_debuggable(struct xe_exec_queue *q);
++
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue_types.h b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+index fc2a1a20b7e4..b37642ebfc5e 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue_types.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+@@ -90,6 +90,13 @@ struct xe_exec_queue {
+ 	 */
+ 	unsigned long flags;
+ 
++	/**
++	 * @eudebug_flags: immutable eudebug flags for this exec queue.
++	 * Set up with DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG.
++	 */
++#define EXEC_QUEUE_EUDEBUG_FLAG_ENABLE		BIT(0)
++	unsigned long eudebug_flags;
++
+ 	union {
+ 		/** @multi_gt_list: list head for VM bind engines if multi-GT */
+ 		struct list_head multi_gt_list;
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
+index 9ed992adb136..aa75d762a658 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine.c
+@@ -559,7 +559,7 @@ static int hw_engine_init(struct xe_gt *gt, struct xe_hw_engine *hwe,
+ 		goto err_name;
+ 	}
+ 
+-	hwe->kernel_lrc = xe_lrc_create(hwe, NULL, SZ_16K);
++	hwe->kernel_lrc = xe_lrc_create(hwe, NULL, SZ_16K, 0);
+ 	if (IS_ERR(hwe->kernel_lrc)) {
+ 		err = PTR_ERR(hwe->kernel_lrc);
+ 		goto err_hwsp;
+diff --git a/drivers/gpu/drm/xe/xe_lrc.c b/drivers/gpu/drm/xe/xe_lrc.c
+index 58121821f081..605a7fbc8d3b 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.c
++++ b/drivers/gpu/drm/xe/xe_lrc.c
+@@ -890,7 +890,7 @@ static void xe_lrc_finish(struct xe_lrc *lrc)
+ #define PVC_CTX_ACC_CTR_THOLD	(0x2a + 1)
+ 
+ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+-		       struct xe_vm *vm, u32 ring_size)
++		       struct xe_vm *vm, u32 ring_size, u32 flags)
+ {
+ 	struct xe_gt *gt = hwe->gt;
+ 	struct xe_tile *tile = gt_to_tile(gt);
+@@ -1007,6 +1007,16 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+ 	map = __xe_lrc_start_seqno_map(lrc);
+ 	xe_map_write32(lrc_to_xe(lrc), &map, lrc->fence_ctx.next_seqno - 1);
+ 
++	if (flags & LRC_CREATE_RUNALONE) {
++		u32 ctx_control = xe_lrc_read_ctx_reg(lrc, CTX_CONTEXT_CONTROL);
++
++		drm_dbg(&xe->drm, "read CTX_CONTEXT_CONTROL: 0x%x\n", ctx_control);
++		ctx_control |= _MASKED_BIT_ENABLE(CTX_CTRL_RUN_ALONE);
++		drm_dbg(&xe->drm, "written CTX_CONTEXT_CONTROL: 0x%x\n", ctx_control);
++
++		xe_lrc_write_ctx_reg(lrc, CTX_CONTEXT_CONTROL, ctx_control);
++	}
++
+ 	return 0;
+ 
+ err_lrc_finish:
+@@ -1026,7 +1036,7 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+  * upon failure.
+  */
+ struct xe_lrc *xe_lrc_create(struct xe_hw_engine *hwe, struct xe_vm *vm,
+-			     u32 ring_size)
++			     u32 ring_size, u32 flags)
+ {
+ 	struct xe_lrc *lrc;
+ 	int err;
+@@ -1035,7 +1045,7 @@ struct xe_lrc *xe_lrc_create(struct xe_hw_engine *hwe, struct xe_vm *vm,
+ 	if (!lrc)
+ 		return ERR_PTR(-ENOMEM);
+ 
+-	err = xe_lrc_init(lrc, hwe, vm, ring_size);
++	err = xe_lrc_init(lrc, hwe, vm, ring_size, flags);
+ 	if (err) {
+ 		kfree(lrc);
+ 		return ERR_PTR(err);
+diff --git a/drivers/gpu/drm/xe/xe_lrc.h b/drivers/gpu/drm/xe/xe_lrc.h
+index c24542e89318..16a9264fdcfa 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.h
++++ b/drivers/gpu/drm/xe/xe_lrc.h
+@@ -22,8 +22,10 @@ struct xe_vm;
+ 
+ #define LRC_PPHWSP_SCRATCH_ADDR (0x34 * 4)
+ 
++#define LRC_CREATE_RUNALONE	BIT(0)
++
+ struct xe_lrc *xe_lrc_create(struct xe_hw_engine *hwe, struct xe_vm *vm,
+-			     u32 ring_size);
++			     u32 ring_size, u32 flags);
+ void xe_lrc_destroy(struct kref *ref);
+ 
+ /**
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index 7e66e9117f49..985dcf852458 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -1110,7 +1110,8 @@ struct drm_xe_exec_queue_create {
+ #define DRM_XE_EXEC_QUEUE_EXTENSION_SET_PROPERTY		0
+ #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY		0
+ #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE		1
+-
++#define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG		2
++#define     DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE		(1 << 0)
+ 	/** @extensions: Pointer to the first extension struct, if any */
+ 	__u64 extensions;
+ 
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-Add-PRELIM-infrastructure.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Add-PRELIM-infrastructure.patch
@@ -1,0 +1,149 @@
+From c1b2bdedb5131f7dc12ed858960b6478fff1763e Mon Sep 17 00:00:00 2001
+From: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Date: Mon, 11 Dec 2023 21:54:10 -0800
+Subject: drm/xe: Add PRELIM infrastructure
+
+* Add xe_drm_prelim.h for maintaining internal/downstream declarations
+  separate from upstream declarations in xe_drm.h. Because xe_drm_prelim.h
+  struct declarations can use upstream struct declarations, xe_drm_prelim.h
+  is included at the bottom of xe_drm.h.
+* Add some PRELIM ioctl helpers
+
+Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+(cherry picked from commit 79d1f6524d3d36c8c29340c7288e5666be7e5ed5 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ Documentation/gpu/driver-uapi.rst |  5 +++
+ drivers/gpu/drm/xe/xe_device.c    |  8 ++++
+ include/uapi/drm/xe_drm.h         |  1 +
+ include/uapi/drm/xe_drm_prelim.h  | 73 +++++++++++++++++++++++++++++++
+ 4 files changed, 87 insertions(+)
+ create mode 100644 include/uapi/drm/xe_drm_prelim.h
+
+diff --git a/Documentation/gpu/driver-uapi.rst b/Documentation/gpu/driver-uapi.rst
+index 971cdb4816fc..02192621b76e 100644
+--- a/Documentation/gpu/driver-uapi.rst
++++ b/Documentation/gpu/driver-uapi.rst
+@@ -27,3 +27,8 @@ drm/xe uAPI
+ ===========
+ 
+ .. kernel-doc:: include/uapi/drm/xe_drm.h
++
++drm/xe PRELIM uAPI
++==================
++
++.. kernel-doc:: include/uapi/drm/xe_drm_prelim.h
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 4ed7dd584a6d..ed56ec080b90 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -200,6 +200,14 @@ static void xe_file_close(struct drm_device *dev, struct drm_file *file)
+ 	xe_pm_runtime_put(xe);
+ }
+ 
++#define PRELIM_DRM_IOCTL_DEF_DRV(ioctl, _func, _flags)			\
++	[DRM_IOCTL_NR(PRELIM_DRM_IOCTL_##ioctl) - DRM_COMMAND_BASE] = {	\
++		.cmd = PRELIM_DRM_IOCTL_##ioctl,			\
++		.func = _func,						\
++		.flags = _flags,					\
++		.name = #ioctl						\
++	}
++
+ static const struct drm_ioctl_desc xe_ioctls[] = {
+ 	DRM_IOCTL_DEF_DRV(XE_DEVICE_QUERY, xe_query_ioctl, DRM_RENDER_ALLOW),
+ 	DRM_IOCTL_DEF_DRV(XE_GEM_CREATE, xe_gem_create_ioctl, DRM_RENDER_ALLOW),
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index 2416971fbf2d..430635249908 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -1785,6 +1785,7 @@ struct drm_xe_debug_metadata_destroy {
+ };
+ 
+ #include "xe_drm_eudebug.h"
++#include "xe_drm_prelim.h"
+ 
+ #if defined(__cplusplus)
+ }
+diff --git a/include/uapi/drm/xe_drm_prelim.h b/include/uapi/drm/xe_drm_prelim.h
+new file mode 100644
+index 000000000000..9c86f5969500
+--- /dev/null
++++ b/include/uapi/drm/xe_drm_prelim.h
+@@ -0,0 +1,73 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef _UAPI_XE_DRM_PRELIM_H_
++#define _UAPI_XE_DRM_PRELIM_H_
++
++#include "xe_drm.h"
++
++/**
++ * DOC: Xe PRELIM uAPI
++ *
++ * Reasoning:
++ *
++ * The DRM community imposes some strict requirements on the uAPI:
++ *
++ * - https://www.kernel.org/doc/html/latest/gpu/drm-uapi.html#open-source-userspace-requirements
++ * - "The open-source userspace must not be a toy/test application, but the real thing."
++ * - "The userspace patches must be against the canonical upstream, not some vendor fork."
++ *
++ * In some very specific cases, there will be a particular need to get a preliminary and
++ * non-upstream uAPI merged in some of our branches. When this happens, the uAPI cannot
++ * take a risk of conflicting IOCTL ranges with other preliminary uAPI or with a possible
++ * real user space uAPI that could win the race towards upstream.
++ *
++ * 'PRELIM' uAPIs are APIs that are not yet merged on upstream. They were designed to be
++ * in a different range in a way that the divergence with the upstream and other development
++ * branches can be controlled and the conflicts minimized.
++ *
++ * It is also a mechanism that prevents user space regressions since the prelim modification
++ * is always in a two-phase approach, where upstream and prelim can coexist for a period of
++ * time while the UMDs adjust to the changes.
++ *
++ * Rules:
++ *
++ * - Communication will happen on a specific Teams channel: KMD uAPI Changes
++ * - APIs to be considered Preliminary / WIP / Temporary to what will eventually be in upstream.
++ *   It's designed to allow kernel and userspace to work together and make sure it works with all
++ *   components before committing to support it forever in upstream (we don't want to break Linux's
++ *   rule about not breaking userspace).
++ * - IOCTL in separate file (this one).
++ * - IOCTL, flags, enums, or any number that might conflict should be in separated range
++ *   (i.e end of range like IOCTL numbers).
++ * - PRELIM prefix mandatory in any define, struct, or non-static functions in PRELIM source files
++ *   called by other source files (i.e xe_perf_ioctl -> prelim_xe_perf_ioctl)
++ * - Code .c/.h using PRELIM should also be placed in prelim/ sub-directory for easier rebase.
++ * - Two-Phase removal:
++ *
++ *   + When API needs to be modified in non-backwards compatible ways, the current PRELIM API
++ *     cannot be removed (yet).
++ *   + Either because it must change the behavior or because the final upstream one has landed.
++ *   + If a new PRELIM is needed, it needs to be added as a new PRELIM_V<n+1> without removing the
++ *     PRELIM_V<n>.
++ *   + The previous one can only be removed after all user space components confirmed they are not
++ *     using.
++ *
++ * Other prelim considerations:
++ *
++ * - Out of tree Sysfs and debugfs need to stay behind a 'prelim' directory.
++ * - Out of tree module-parameters need to be identified by a PRELIM prefix.
++ *   (xe.prelim_my_awesome_param=not_default)
++ * - Internal/downstream declarations must be added here, not to xe_drm.h.
++ * - The values in xe_drm_prelim.h must also be kept synchronized with values in xe_drm.h.
++ * - PRELIM ioctl's: IOCTL numbers go down from 0x5f
++ */
++
++/*
++ * IOCTL numbers listed below are reserved, they are taken up by other
++ * components. Please add an unreserved ioctl number here to reserve that
++ * number.
++ */
++#endif /* _UAPI_XE_DRM_PRELIM_H_ */
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-Attach-debug-metadata-to-vma.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Attach-debug-metadata-to-vma.patch
@@ -1,0 +1,454 @@
+From 9b63ecfcb8592e96e38594f40442dcd73a227d40 Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Sun, 17 Sep 2023 12:53:47 +0200
+Subject: drm/xe: Attach debug metadata to vma
+
+Introduces a vm_bind_op extension, enabling users to attach metadata objects
+to each [OP_MAP|OP_MAP_USERPTR] operation. This interface will be utilized
+by the EU debugger to relay information about the contents of specified
+VMAs from the debugee to the debugger process.
+
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 04a39b53c9ae129550cd60ec0c1668b5b44ec670 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_debug_metadata.c |  13 ++
+ drivers/gpu/drm/xe/xe_debug_metadata.h |   2 +
+ drivers/gpu/drm/xe/xe_vm.c             | 198 ++++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_vm_types.h       |  15 ++
+ include/uapi/drm/xe_drm.h              |  19 +++
+ 5 files changed, 243 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.c b/drivers/gpu/drm/xe/xe_debug_metadata.c
+index 8d99170d3591..daffc13c58d6 100644
+--- a/drivers/gpu/drm/xe/xe_debug_metadata.c
++++ b/drivers/gpu/drm/xe/xe_debug_metadata.c
+@@ -24,6 +24,19 @@ void xe_debug_metadata_put(struct xe_debug_metadata *mdata)
+ 	kref_put(&mdata->refcount, xe_debug_metadata_release);
+ }
+ 
++struct xe_debug_metadata *xe_debug_metadata_get(struct xe_file *xef, u32 id)
++{
++	struct xe_debug_metadata *mdata;
++
++	mutex_lock(&xef->debug_metadata.lock);
++	mdata = xa_load(&xef->debug_metadata.xa, id);
++	if (mdata)
++		kref_get(&mdata->refcount);
++	mutex_unlock(&xef->debug_metadata.lock);
++
++	return mdata;
++}
++
+ int xe_debug_metadata_create_ioctl(struct drm_device *dev,
+ 				   void *data,
+ 				   struct drm_file *file)
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.h b/drivers/gpu/drm/xe/xe_debug_metadata.h
+index abaea076c12d..deca24fa2cba 100644
+--- a/drivers/gpu/drm/xe/xe_debug_metadata.h
++++ b/drivers/gpu/drm/xe/xe_debug_metadata.h
+@@ -10,7 +10,9 @@
+ 
+ struct drm_device;
+ struct drm_file;
++struct xe_file;
+ 
++struct xe_debug_metadata *xe_debug_metadata_get(struct xe_file *xef, u32 id);
+ void xe_debug_metadata_put(struct xe_debug_metadata *mdata);
+ 
+ int xe_debug_metadata_create_ioctl(struct drm_device *dev,
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index f420cc4380f5..fdbf395bcd03 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -24,6 +24,7 @@
+ #include "regs/xe_gtt_defs.h"
+ #include "xe_assert.h"
+ #include "xe_bo.h"
++#include "xe_debug_metadata.h"
+ #include "xe_device.h"
+ #include "xe_drm_client.h"
+ #include "xe_exec_queue.h"
+@@ -940,6 +941,8 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+ 			vma->gpuva.gem.obj = &bo->ttm.base;
+ 	}
+ 
++	INIT_LIST_HEAD(&vma->debug_metadata);
++
+ 	INIT_LIST_HEAD(&vma->combined_links.rebind);
+ 
+ 	INIT_LIST_HEAD(&vma->gpuva.gem.entry);
+@@ -1003,6 +1006,48 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+ 	return vma;
+ }
+ 
++static void vma_free_debug_metadata(struct list_head *debug_metadata)
++{
++	struct xe_vma_debug_metadata *vmad, *tmp;
++
++	list_for_each_entry_safe(vmad, tmp, debug_metadata, link) {
++		list_del(&vmad->link);
++		kfree(vmad);
++	}
++}
++
++static struct xe_vma_debug_metadata *
++vma_new_debug_metadata(u32 metadata_id, u64 cookie)
++{
++	struct xe_vma_debug_metadata *vmad;
++
++	vmad = kzalloc(sizeof(*vmad), GFP_KERNEL);
++	if (!vmad)
++		return ERR_PTR(-ENOMEM);
++
++	INIT_LIST_HEAD(&vmad->link);
++
++	vmad->metadata_id = metadata_id;
++	vmad->cookie = cookie;
++
++	return vmad;
++}
++
++static int vma_debug_metadata_copy(struct xe_vma *from,
++				   struct xe_vma *to)
++{
++	struct xe_vma_debug_metadata *vmad, *vma;
++
++	list_for_each_entry(vmad, &from->debug_metadata, link) {
++		vma = vma_new_debug_metadata(vmad->metadata_id, vmad->cookie);
++		if (IS_ERR(vma))
++			return PTR_ERR(vma);
++
++		list_add_tail(&vmad->link, &to->debug_metadata);
++	}
++	return 0;
++}
++
+ static void xe_vma_destroy_late(struct xe_vma *vma)
+ {
+ 	struct xe_vm *vm = xe_vma_vm(vma);
+@@ -1032,6 +1077,7 @@ static void xe_vma_destroy_late(struct xe_vma *vma)
+ 		xe_bo_put(xe_vma_bo(vma));
+ 	}
+ 
++	vma_free_debug_metadata(&vma->debug_metadata);
+ 	xe_vma_free(vma);
+ }
+ 
+@@ -1999,6 +2045,8 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_bo *bo,
+ 			op->map.is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
+ 			op->map.dumpable = flags & DRM_XE_VM_BIND_FLAG_DUMPABLE;
+ 			op->map.pat_index = pat_index;
++
++			INIT_LIST_HEAD(&op->map.debug_metadata);
+ 		} else if (__op->op == DRM_GPUVA_OP_PREFETCH) {
+ 			op->prefetch.region = prefetch_region;
+ 		}
+@@ -2189,11 +2237,11 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 			flags |= op->map.dumpable ?
+ 				VMA_CREATE_FLAG_DUMPABLE : 0;
+ 
+-			vma = new_vma(vm, &op->base.map, op->map.pat_index,
+-				      flags);
++			vma = new_vma(vm, &op->base.map, op->map.pat_index, flags);
+ 			if (IS_ERR(vma))
+ 				return PTR_ERR(vma);
+ 
++			list_splice_tail_init(&op->map.debug_metadata, &vma->debug_metadata);
+ 			op->map.vma = vma;
+ 			if (op->map.immediate || !xe_vm_in_fault_mode(vm))
+ 				xe_vma_ops_incr_pt_update_ops(vops,
+@@ -2224,6 +2272,8 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 				if (IS_ERR(vma))
+ 					return PTR_ERR(vma);
+ 
++				list_splice_tail_init(&old->debug_metadata, &vma->debug_metadata);
++
+ 				op->remap.prev = vma;
+ 
+ 				/*
+@@ -2263,6 +2313,16 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 				if (IS_ERR(vma))
+ 					return PTR_ERR(vma);
+ 
++				if (op->base.remap.prev) {
++					err = vma_debug_metadata_copy(op->remap.prev,
++								      vma);
++					if (err)
++						return err;
++				} else {
++					list_splice_tail_init(&old->debug_metadata,
++							      &vma->debug_metadata);
++				}
++
+ 				op->remap.next = vma;
+ 
+ 				/*
+@@ -2313,6 +2373,7 @@ static void xe_vma_op_unwind(struct xe_vm *vm, struct xe_vma_op *op,
+ 	switch (op->base.op) {
+ 	case DRM_GPUVA_OP_MAP:
+ 		if (op->map.vma) {
++			vma_free_debug_metadata(&op->map.debug_metadata);
+ 			prep_vma_destroy(vm, op->map.vma, post_commit);
+ 			xe_vma_destroy_unlocked(op->map.vma);
+ 		}
+@@ -2551,6 +2612,120 @@ static int vm_ops_setup_tile_args(struct xe_vm *vm, struct xe_vma_ops *vops)
+ 	}
+ 
+ 	return number_tiles;
++};
++
++static int vma_new_debug_metadata_op(struct xe_vma_op *op,
++				     u32 metadata_id, u64 cookie,
++				     u64 flags)
++{
++	struct xe_vma_debug_metadata *vmad;
++
++	vmad = vma_new_debug_metadata(metadata_id, cookie);
++	if (IS_ERR(vmad))
++		return PTR_ERR(vmad);
++
++	list_add_tail(&vmad->link, &op->map.debug_metadata);
++	return 0;
++}
++
++typedef int (*xe_vm_bind_op_user_extension_fn)(struct xe_device *xe,
++					       struct xe_file *xef,
++					       struct drm_gpuva_ops *ops,
++					       u32 operation, u64 extension);
++
++static int vm_bind_op_ext_attach_debug(struct xe_device *xe,
++				       struct xe_file *xef,
++				       struct drm_gpuva_ops *ops,
++				       u32 operation, u64 extension)
++{
++	u64 __user *address = u64_to_user_ptr(extension);
++	struct drm_xe_vm_bind_op_ext_attach_debug ext;
++	struct xe_debug_metadata *mdata;
++	struct drm_gpuva_op *__op;
++	int err;
++
++	err = __copy_from_user(&ext, address, sizeof(ext));
++	if (XE_IOCTL_DBG(xe, err))
++		return -EFAULT;
++
++	if (XE_IOCTL_DBG(xe,
++			 operation != DRM_XE_VM_BIND_OP_MAP_USERPTR &&
++			 operation != DRM_XE_VM_BIND_OP_MAP))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, ext.flags))
++		return -EINVAL;
++
++	mdata = xe_debug_metadata_get(xef, (u32)ext.metadata_id);
++	if (XE_IOCTL_DBG(xe, !mdata))
++		return -ENOENT;
++
++	/* care about metadata existence only on the time of attach */
++	xe_debug_metadata_put(mdata);
++
++	if (!ops)
++		return 0;
++
++	drm_gpuva_for_each_op(__op, ops) {
++		struct xe_vma_op *op = gpuva_op_to_vma_op(__op);
++
++		if (op->base.op == DRM_GPUVA_OP_MAP) {
++			err = vma_new_debug_metadata_op(op,
++							ext.metadata_id,
++							ext.cookie,
++							ext.flags);
++			if (err)
++				return err;
++		}
++	}
++	return 0;
++}
++
++static const xe_vm_bind_op_user_extension_fn vm_bind_op_extension_funcs[] = {
++	[XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG] = vm_bind_op_ext_attach_debug,
++};
++
++#define MAX_USER_EXTENSIONS	16
++static int vm_bind_op_user_extensions(struct xe_device *xe,
++				      struct xe_file *xef,
++				      struct drm_gpuva_ops *ops,
++				      u32 operation,
++				      u64 extensions, int ext_number)
++{
++	u64 __user *address = u64_to_user_ptr(extensions);
++	struct drm_xe_user_extension ext;
++	int err;
++
++	if (XE_IOCTL_DBG(xe, ext_number >= MAX_USER_EXTENSIONS))
++		return -E2BIG;
++
++	err = __copy_from_user(&ext, address, sizeof(ext));
++	if (XE_IOCTL_DBG(xe, err))
++		return -EFAULT;
++
++	if (XE_IOCTL_DBG(xe, ext.pad) ||
++	    XE_IOCTL_DBG(xe, ext.name >=
++			 ARRAY_SIZE(vm_bind_op_extension_funcs)))
++		return -EINVAL;
++
++	err = vm_bind_op_extension_funcs[ext.name](xe, xef, ops,
++						   operation, extensions);
++	if (XE_IOCTL_DBG(xe, err))
++		return err;
++
++	if (ext.next_extension)
++		return vm_bind_op_user_extensions(xe, xef, ops,
++						  operation, ext.next_extension,
++						  ++ext_number);
++
++	return 0;
++}
++
++static int vm_bind_op_user_extensions_check(struct xe_device *xe,
++					    struct xe_file *xef,
++					    u32 operation, u64 extensions)
++{
++	return vm_bind_op_user_extensions(xe, xef, NULL, operation, extensions, 0);
+ }
+ 
+ static struct dma_fence *ops_execute(struct xe_vm *vm,
+@@ -2747,6 +2922,7 @@ static int vm_bind_ioctl_ops_execute(struct xe_vm *vm,
+ #define ALL_DRM_XE_SYNCS_FLAGS (DRM_XE_SYNCS_FLAG_WAIT_FOR_OP)
+ 
+ static int vm_bind_ioctl_check_args(struct xe_device *xe,
++				    struct xe_file *xef,
+ 				    struct drm_xe_vm_bind *args,
+ 				    struct drm_xe_vm_bind_op **bind_ops)
+ {
+@@ -2790,6 +2966,7 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe,
+ 		u64 obj_offset = (*bind_ops)[i].obj_offset;
+ 		u32 prefetch_region = (*bind_ops)[i].prefetch_mem_region_instance;
+ 		bool is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
++		u64 extensions = (*bind_ops)[i].extensions;
+ 		u16 pat_index = (*bind_ops)[i].pat_index;
+ 		u16 coh_mode;
+ 
+@@ -2850,6 +3027,13 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe,
+ 			err = -EINVAL;
+ 			goto free_bind_ops;
+ 		}
++
++		if (extensions) {
++			err = vm_bind_op_user_extensions_check(xe, xef, op, extensions);
++			if (err)
++				goto free_bind_ops;
++		}
++
+ 	}
+ 
+ 	return 0;
+@@ -2961,7 +3145,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 	int err;
+ 	int i;
+ 
+-	err = vm_bind_ioctl_check_args(xe, args, &bind_ops);
++	err = vm_bind_ioctl_check_args(xe, xef, args, &bind_ops);
+ 	if (err)
+ 		return err;
+ 
+@@ -3089,11 +3273,17 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		u64 obj_offset = bind_ops[i].obj_offset;
+ 		u32 prefetch_region = bind_ops[i].prefetch_mem_region_instance;
+ 		u16 pat_index = bind_ops[i].pat_index;
++		u64 extensions = bind_ops[i].extensions;
+ 
+ 		ops[i] = vm_bind_ioctl_ops_create(vm, bos[i], obj_offset,
+ 						  addr, range, op, flags,
+ 						  prefetch_region, pat_index);
+-		if (IS_ERR(ops[i])) {
++		if (!IS_ERR(ops[i]) && extensions) {
++			err = vm_bind_op_user_extensions(xe, xef, ops[i],
++							 op, extensions, 0);
++			if (err)
++				goto unwind_ops;
++		} else if (IS_ERR(ops[i])) {
+ 			err = PTR_ERR(ops[i]);
+ 			ops[i] = NULL;
+ 			goto unwind_ops;
+diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
+index da9d7ef6ab8f..fe64ce6ed1d9 100644
+--- a/drivers/gpu/drm/xe/xe_vm_types.h
++++ b/drivers/gpu/drm/xe/xe_vm_types.h
+@@ -121,6 +121,9 @@ struct xe_vma {
+ 	 * Needs to be signalled before UNMAP can be processed.
+ 	 */
+ 	struct xe_user_fence *ufence;
++
++	/** @debug_metadata: List of vma debug metadata */
++	struct list_head debug_metadata;
+ };
+ 
+ /**
+@@ -309,6 +312,8 @@ struct xe_vma_op_map {
+ 	bool dumpable;
+ 	/** @pat_index: The pat index to use for this operation. */
+ 	u16 pat_index;
++	/** @debug_metadata: List of attached debug metadata */
++	struct list_head debug_metadata;
+ };
+ 
+ /** struct xe_vma_op_remap - VMA remap operation */
+@@ -386,4 +391,14 @@ struct xe_vma_ops {
+ #endif
+ };
+ 
++struct xe_vma_debug_metadata {
++	/** @debug.metadata: id of attached xe_debug_metadata */
++	u32 metadata_id;
++	/** @debug.cookie: user defined cookie */
++	u64 cookie;
++
++	/** @link: list of metadata attached to vma */
++	struct list_head link;
++};
++
+ #endif
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index 0d75a072b838..2416971fbf2d 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -886,6 +886,23 @@ struct drm_xe_vm_destroy {
+ 	__u64 reserved[2];
+ };
+ 
++struct drm_xe_vm_bind_op_ext_attach_debug {
++	/** @base: base user extension */
++	struct drm_xe_user_extension base;
++
++	/** @id: Debug object id from create metadata */
++	__u64 metadata_id;
++
++	/** @flags: Flags */
++	__u64 flags;
++
++	/** @cookie: Cookie */
++	__u64 cookie;
++
++	/** @reserved: Reserved */
++	__u64 reserved;
++};
++
+ /**
+  * struct drm_xe_vm_bind_op - run bind operations
+  *
+@@ -910,7 +927,9 @@ struct drm_xe_vm_destroy {
+  *    handle MBZ, and the BO offset MBZ. This flag is intended to
+  *    implement VK sparse bindings.
+  */
++
+ struct drm_xe_vm_bind_op {
++#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG 0
+ 	/** @extensions: Pointer to the first extension struct, if any */
+ 	__u64 extensions;
+ 
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-Debug-metadata-create-destroy-ioctls.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Debug-metadata-create-destroy-ioctls.patch
@@ -1,0 +1,380 @@
+From e9c6b9d51526e1e2f5f9fe86351b7ce13104fa26 Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Fri, 8 Sep 2023 17:32:30 +0200
+Subject: drm/xe: Debug metadata create/destroy ioctls
+
+Ad a part of eu debug feature introduce debug metadata objects.
+These are to be used to pass metadata between client and debugger,
+by attaching them to vm_bind operations.
+
+todo: WORK_IN_PROGRESS_* defines need to be reworded/refined when
+      the real usage and need is established by l0+gdb.
+
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 9f5b5d1ee49f7acddacd92797df390aa192c0c4d eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/Makefile                  |   1 +
+ drivers/gpu/drm/xe/xe_debug_metadata.c       | 107 +++++++++++++++++++
+ drivers/gpu/drm/xe/xe_debug_metadata.h       |  23 ++++
+ drivers/gpu/drm/xe/xe_debug_metadata_types.h |  28 +++++
+ drivers/gpu/drm/xe/xe_device.c               |  17 +++
+ drivers/gpu/drm/xe/xe_device_types.h         |   8 ++
+ include/uapi/drm/xe_drm.h                    |  53 ++++++++-
+ 7 files changed, 236 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/gpu/drm/xe/xe_debug_metadata.c
+ create mode 100644 drivers/gpu/drm/xe/xe_debug_metadata.h
+ create mode 100644 drivers/gpu/drm/xe/xe_debug_metadata_types.h
+
+diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
+index b655c0e43834..e2aa65d4fa42 100644
+--- a/drivers/gpu/drm/xe/Makefile
++++ b/drivers/gpu/drm/xe/Makefile
+@@ -29,6 +29,7 @@ xe-y += xe_bb.o \
+ 	xe_bo.o \
+ 	xe_bo_evict.o \
+ 	xe_debugfs.o \
++	xe_debug_metadata.o \
+ 	xe_devcoredump.o \
+ 	xe_device.o \
+ 	xe_device_sysfs.o \
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.c b/drivers/gpu/drm/xe/xe_debug_metadata.c
+new file mode 100644
+index 000000000000..8d99170d3591
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_debug_metadata.c
+@@ -0,0 +1,107 @@
++// SPDX-License-Identifier: MIT
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++#include "xe_debug_metadata.h"
++
++#include <drm/drm_device.h>
++#include <drm/drm_file.h>
++#include <drm/xe_drm.h>
++
++#include "xe_device.h"
++#include "xe_macros.h"
++
++static void xe_debug_metadata_release(struct kref *ref)
++{
++	struct xe_debug_metadata *mdata = container_of(ref, struct xe_debug_metadata, refcount);
++
++	kvfree(mdata->ptr);
++	kfree(mdata);
++}
++
++void xe_debug_metadata_put(struct xe_debug_metadata *mdata)
++{
++	kref_put(&mdata->refcount, xe_debug_metadata_release);
++}
++
++int xe_debug_metadata_create_ioctl(struct drm_device *dev,
++				   void *data,
++				   struct drm_file *file)
++{
++	struct xe_device *xe = to_xe_device(dev);
++	struct xe_file *xef = to_xe_file(file);
++	struct drm_xe_debug_metadata_create *args = data;
++	struct xe_debug_metadata *mdata;
++	int err;
++	u32 id;
++
++	if (XE_IOCTL_DBG(xe, args->extensions))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, args->type > DRM_XE_DEBUG_METADATA_PROGRAM_MODULE))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, !args->user_addr || !args->len))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, !access_ok(u64_to_user_ptr(args->user_addr), args->len)))
++		return -EFAULT;
++
++	mdata = kzalloc(sizeof(*mdata), GFP_KERNEL);
++	if (!mdata)
++		return -ENOMEM;
++
++	mdata->len = args->len;
++	mdata->type = args->type;
++
++	mdata->ptr = kvmalloc(mdata->len, GFP_KERNEL);
++	if (!mdata->ptr) {
++		kfree(mdata);
++		return -ENOMEM;
++	}
++	kref_init(&mdata->refcount);
++
++	err = copy_from_user(mdata->ptr, u64_to_user_ptr(args->user_addr), mdata->len);
++	if (err) {
++		err = -EFAULT;
++		goto put_mdata;
++	}
++
++	mutex_lock(&xef->debug_metadata.lock);
++	err = xa_alloc(&xef->debug_metadata.xa, &id, mdata, xa_limit_32b, GFP_KERNEL);
++	mutex_unlock(&xef->debug_metadata.lock);
++
++	args->metadata_id = id;
++	mdata->id = id;
++
++	if (err)
++		goto put_mdata;
++
++	return 0;
++
++put_mdata:
++	xe_debug_metadata_put(mdata);
++	return err;
++}
++
++int xe_debug_metadata_destroy_ioctl(struct drm_device *dev,
++				    void *data,
++				    struct drm_file *file)
++{
++	struct xe_device *xe = to_xe_device(dev);
++	struct xe_file *xef = to_xe_file(file);
++	struct drm_xe_debug_metadata_destroy * const args = data;
++	struct xe_debug_metadata *mdata;
++
++	if (XE_IOCTL_DBG(xe, args->extensions))
++		return -EINVAL;
++
++	mutex_lock(&xef->debug_metadata.lock);
++	mdata = xa_erase(&xef->debug_metadata.xa, args->metadata_id);
++	mutex_unlock(&xef->debug_metadata.lock);
++	if (XE_IOCTL_DBG(xe, !mdata))
++		return -ENOENT;
++
++	xe_debug_metadata_put(mdata);
++	return 0;
++}
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.h b/drivers/gpu/drm/xe/xe_debug_metadata.h
+new file mode 100644
+index 000000000000..abaea076c12d
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_debug_metadata.h
+@@ -0,0 +1,23 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef _XE_DEBUG_METADATA_H_
++#define _XE_DEBUG_METADATA_H_
++
++#include "xe_debug_metadata_types.h"
++
++struct drm_device;
++struct drm_file;
++
++void xe_debug_metadata_put(struct xe_debug_metadata *mdata);
++
++int xe_debug_metadata_create_ioctl(struct drm_device *dev,
++				   void *data,
++				   struct drm_file *file);
++
++int xe_debug_metadata_destroy_ioctl(struct drm_device *dev,
++				    void *data,
++				    struct drm_file *file);
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata_types.h b/drivers/gpu/drm/xe/xe_debug_metadata_types.h
+new file mode 100644
+index 000000000000..508f2fdbbc42
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_debug_metadata_types.h
+@@ -0,0 +1,28 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef _XE_DEBUG_METADATA_TYPES_H_
++#define _XE_DEBUG_METADATA_TYPES_H_
++
++#include <linux/kref.h>
++
++struct xe_debug_metadata {
++	/** @type: type of given metadata */
++	u64 type;
++
++	/** @ptr: copy of userptr, given as a metadata payload */
++	void *ptr;
++
++	/** @len: length, in bytes of the metadata */
++	u64 len;
++
++	/** @id */
++	u64 id;
++
++	/** @ref: reference count */
++	struct kref refcount;
++};
++
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 22c87999f92d..c9c0f8d1df56 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -24,6 +24,7 @@
+ #include "xe_bo.h"
+ #include "xe_debugfs.h"
+ #include "xe_devcoredump.h"
++#include "xe_debug_metadata.h"
+ #include "xe_dma_buf.h"
+ #include "xe_drm_client.h"
+ #include "xe_drv.h"
+@@ -99,6 +100,9 @@ static int xe_file_open(struct drm_device *dev, struct drm_file *file)
+ 	xe->clients.count++;
+ 	spin_unlock(&xe->clients.lock);
+ 
++	mutex_init(&xef->debug_metadata.lock);
++	xa_init_flags(&xef->debug_metadata.xa, XA_FLAGS_ALLOC1);
++
+ 	file->driver_priv = xef;
+ 	kref_init(&xef->refcount);
+ 
+@@ -117,6 +121,9 @@ static void xe_file_destroy(struct kref *ref)
+ 	xa_destroy(&xef->vm.xa);
+ 	mutex_destroy(&xef->vm.lock);
+ 
++	xa_destroy(&xef->debug_metadata.xa);
++	mutex_destroy(&xef->debug_metadata.lock);
++
+ 	spin_lock(&xe->clients.lock);
+ 	xe->clients.count--;
+ 	spin_unlock(&xe->clients.lock);
+@@ -157,6 +164,7 @@ static void xe_file_close(struct drm_device *dev, struct drm_file *file)
+ 	struct xe_file *xef = file->driver_priv;
+ 	struct xe_vm *vm;
+ 	struct xe_exec_queue *q;
++	struct xe_debug_metadata *mdata;
+ 	unsigned long idx;
+ 
+ 	xe_pm_runtime_get(xe);
+@@ -182,6 +190,11 @@ static void xe_file_close(struct drm_device *dev, struct drm_file *file)
+ 		xe_vm_close_and_put(vm);
+ 	mutex_unlock(&xef->vm.lock);
+ 
++	mutex_lock(&xef->debug_metadata.lock);
++	xa_for_each(&xef->debug_metadata.xa, idx, mdata)
++		xe_debug_metadata_put(mdata);
++	mutex_unlock(&xef->debug_metadata.lock);
++
+ 	xe_file_put(xef);
+ 
+ 	xe_pm_runtime_put(xe);
+@@ -206,6 +219,10 @@ static const struct drm_ioctl_desc xe_ioctls[] = {
+ 			  DRM_RENDER_ALLOW),
+ 	DRM_IOCTL_DEF_DRV(XE_OBSERVATION, xe_observation_ioctl, DRM_RENDER_ALLOW),
+ 	DRM_IOCTL_DEF_DRV(XE_EUDEBUG_CONNECT, xe_eudebug_connect_ioctl, DRM_RENDER_ALLOW),
++	DRM_IOCTL_DEF_DRV(XE_DEBUG_METADATA_CREATE, xe_debug_metadata_create_ioctl,
++			  DRM_RENDER_ALLOW),
++	DRM_IOCTL_DEF_DRV(XE_DEBUG_METADATA_DESTROY, xe_debug_metadata_destroy_ioctl,
++			  DRM_RENDER_ALLOW),
+ };
+ 
+ static long xe_drm_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index fdc9ee0ad1c8..c812a21ed1f5 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -616,6 +616,14 @@ struct xe_file {
+ 
+ 	/** @id: id into xe_device.files.xa */
+ 	u32 id;
++
++	/** @debug_metadata: array of debug metadata for file */
++	struct {
++		/** @xa: xarray to store debug metadata */
++		struct xarray xa;
++		/** @lock: protects debug metadata xarray */
++		struct mutex lock;
++	} debug_metadata;
+ };
+ 
+ #endif
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index 985dcf852458..0d75a072b838 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -103,7 +103,8 @@ extern "C" {
+ #define DRM_XE_WAIT_USER_FENCE		0x0a
+ #define DRM_XE_OBSERVATION		0x0b
+ #define DRM_XE_EUDEBUG_CONNECT		0x0c
+-
++#define DRM_XE_DEBUG_METADATA_CREATE	0x0d
++#define DRM_XE_DEBUG_METADATA_DESTROY	0x0e
+ /* Must be kept compact -- no holes */
+ 
+ #define DRM_IOCTL_XE_DEVICE_QUERY		DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_DEVICE_QUERY, struct drm_xe_device_query)
+@@ -119,6 +120,8 @@ extern "C" {
+ #define DRM_IOCTL_XE_WAIT_USER_FENCE		DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_WAIT_USER_FENCE, struct drm_xe_wait_user_fence)
+ #define DRM_IOCTL_XE_OBSERVATION		DRM_IOW(DRM_COMMAND_BASE + DRM_XE_OBSERVATION, struct drm_xe_observation_param)
+ #define DRM_IOCTL_XE_EUDEBUG_CONNECT		DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_EUDEBUG_CONNECT, struct drm_xe_eudebug_connect)
++#define DRM_IOCTL_XE_DEBUG_METADATA_CREATE	 DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_DEBUG_METADATA_CREATE, struct drm_xe_debug_metadata_create)
++#define DRM_IOCTL_XE_DEBUG_METADATA_DESTROY	 DRM_IOW(DRM_COMMAND_BASE + DRM_XE_DEBUG_METADATA_DESTROY, struct drm_xe_debug_metadata_destroy)
+ 
+ /**
+  * DOC: Xe IOCTL Extensions
+@@ -1714,6 +1717,54 @@ struct drm_xe_eudebug_connect {
+ 	__u32 version; /* output: current ABI (ioctl / events) version */
+ };
+ 
++/*
++ * struct drm_xe_debug_metadata_create - Create debug metadata
++ *
++ * Add a region of user memory to be marked as debug metadata.
++ * When the debugger attaches, the metadata regions will be delivered
++ * for debugger. Debugger can then map these regions to help decode
++ * the program state.
++ *
++ * Returns handle to created metadata entry.
++ */
++struct drm_xe_debug_metadata_create {
++	/** @extensions: Pointer to the first extension struct, if any */
++	__u64 extensions;
++
++#define DRM_XE_DEBUG_METADATA_ELF_BINARY     0
++#define DRM_XE_DEBUG_METADATA_PROGRAM_MODULE 1
++#define WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_MODULE_AREA 2
++#define WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SBA_AREA 3
++#define WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SIP_AREA 4
++#define WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_NUM (1 + \
++	  WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SIP_AREA)
++
++	/** @type: Type of metadata */
++	__u64 type;
++
++	/** @user_addr: pointer to start of the metadata */
++	__u64 user_addr;
++
++	/** @len: length, in bytes of the medata */
++	__u64 len;
++
++	/** @metadata_id: created metadata handle (out) */
++	__u32 metadata_id;
++};
++
++/**
++ * struct drm_xe_debug_metadata_destroy - Destroy debug metadata
++ *
++ * Destroy debug metadata.
++ */
++struct drm_xe_debug_metadata_destroy {
++	/** @extensions: Pointer to the first extension struct, if any */
++	__u64 extensions;
++
++	/** @metadata_id: metadata handle to destroy */
++	__u32 metadata_id;
++};
++
+ #include "xe_drm_eudebug.h"
+ 
+ #if defined(__cplusplus)
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-Export-xe_hw_engine-s-mmio-accessors.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Export-xe_hw_engine-s-mmio-accessors.patch
@@ -1,0 +1,191 @@
+From d8454b7f66d2517d2547d973de3780058e18a638 Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Tue, 6 Aug 2024 18:30:08 +0300
+Subject: drm/xe: Export xe_hw_engine's mmio accessors
+
+Export hw engine's mmio accessors. This is in preparation
+to use these from eudebug code.
+
+v2: s/hw_engine_mmio/xe_hw_engine_mmio (Matthew)
+v3: kernel doc (Matthew)
+
+Cc: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20240806153009.1081382-1-mika.kuoppala@linux.intel.com
+(cherry picked from commit dae5d79a3bcc3101e1e02a1c2999ca74d1efde05 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_hw_engine.c | 88 +++++++++++++++++++------------
+ drivers/gpu/drm/xe/xe_hw_engine.h |  3 ++
+ 2 files changed, 57 insertions(+), 34 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
+index b311b3a07dca..f1e69ef2e27d 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine.c
+@@ -277,8 +277,18 @@ static void hw_engine_fini(void *arg)
+ 	hwe->gt = NULL;
+ }
+ 
+-static void hw_engine_mmio_write32(struct xe_hw_engine *hwe, struct xe_reg reg,
+-				   u32 val)
++/**
++ * xe_hw_engine_mmio_write32() - Write engine register
++ * @hwe: engine
++ * @reg: register to write into
++ * @val: desired 32-bit value to write
++ *
++ * This function will write val into an engine specific register.
++ * Forcewake must be held by the caller.
++ *
++ */
++void xe_hw_engine_mmio_write32(struct xe_hw_engine *hwe,
++			       struct xe_reg reg, u32 val)
+ {
+ 	xe_gt_assert(hwe->gt, !(reg.addr & hwe->mmio_base));
+ 	xe_force_wake_assert_held(gt_to_fw(hwe->gt), hwe->domain);
+@@ -288,7 +298,17 @@ static void hw_engine_mmio_write32(struct xe_hw_engine *hwe, struct xe_reg reg,
+ 	xe_mmio_write32(hwe->gt, reg, val);
+ }
+ 
+-static u32 hw_engine_mmio_read32(struct xe_hw_engine *hwe, struct xe_reg reg)
++/**
++ * xe_hw_engine_mmio_read32() - Read engine register
++ * @hwe: engine
++ * @reg: register to read from
++ *
++ * This function will read from an engine specific register.
++ * Forcewake must be held by the caller.
++ *
++ * Return: value of the 32-bit register.
++ */
++u32 xe_hw_engine_mmio_read32(struct xe_hw_engine *hwe, struct xe_reg reg)
+ {
+ 	xe_gt_assert(hwe->gt, !(reg.addr & hwe->mmio_base));
+ 	xe_force_wake_assert_held(gt_to_fw(hwe->gt), hwe->domain);
+@@ -307,14 +327,14 @@ void xe_hw_engine_enable_ring(struct xe_hw_engine *hwe)
+ 		xe_mmio_write32(hwe->gt, RCU_MODE,
+ 				_MASKED_BIT_ENABLE(RCU_MODE_CCS_ENABLE));
+ 
+-	hw_engine_mmio_write32(hwe, RING_HWSTAM(0), ~0x0);
+-	hw_engine_mmio_write32(hwe, RING_HWS_PGA(0),
++	xe_hw_engine_mmio_write32(hwe, RING_HWSTAM(0), ~0x0);
++	xe_hw_engine_mmio_write32(hwe, RING_HWS_PGA(0),
+ 			       xe_bo_ggtt_addr(hwe->hwsp));
+-	hw_engine_mmio_write32(hwe, RING_MODE(0),
++	xe_hw_engine_mmio_write32(hwe, RING_MODE(0),
+ 			       _MASKED_BIT_ENABLE(GFX_DISABLE_LEGACY_MODE));
+-	hw_engine_mmio_write32(hwe, RING_MI_MODE(0),
++	xe_hw_engine_mmio_write32(hwe, RING_MI_MODE(0),
+ 			       _MASKED_BIT_DISABLE(STOP_RING));
+-	hw_engine_mmio_read32(hwe, RING_MI_MODE(0));
++	xe_hw_engine_mmio_read32(hwe, RING_MI_MODE(0));
+ }
+ 
+ static bool xe_hw_engine_match_fixed_cslice_mode(const struct xe_gt *gt,
+@@ -800,7 +820,7 @@ xe_hw_engine_snapshot_instdone_capture(struct xe_hw_engine *hwe,
+ 	unsigned int dss;
+ 	u16 group, instance;
+ 
+-	snapshot->reg.instdone.ring = hw_engine_mmio_read32(hwe, RING_INSTDONE(0));
++	snapshot->reg.instdone.ring = xe_hw_engine_mmio_read32(hwe, RING_INSTDONE(0));
+ 
+ 	if (snapshot->hwe->class != XE_ENGINE_CLASS_RENDER)
+ 		return;
+@@ -896,53 +916,53 @@ xe_hw_engine_snapshot_capture(struct xe_hw_engine *hwe)
+ 		return snapshot;
+ 
+ 	snapshot->reg.ring_execlist_status =
+-		hw_engine_mmio_read32(hwe, RING_EXECLIST_STATUS_LO(0));
+-	val = hw_engine_mmio_read32(hwe, RING_EXECLIST_STATUS_HI(0));
++		xe_hw_engine_mmio_read32(hwe, RING_EXECLIST_STATUS_LO(0));
++	val = xe_hw_engine_mmio_read32(hwe, RING_EXECLIST_STATUS_HI(0));
+ 	snapshot->reg.ring_execlist_status |= val << 32;
+ 
+ 	snapshot->reg.ring_execlist_sq_contents =
+-		hw_engine_mmio_read32(hwe, RING_EXECLIST_SQ_CONTENTS_LO(0));
+-	val = hw_engine_mmio_read32(hwe, RING_EXECLIST_SQ_CONTENTS_HI(0));
++		xe_hw_engine_mmio_read32(hwe, RING_EXECLIST_SQ_CONTENTS_LO(0));
++	val = xe_hw_engine_mmio_read32(hwe, RING_EXECLIST_SQ_CONTENTS_HI(0));
+ 	snapshot->reg.ring_execlist_sq_contents |= val << 32;
+ 
+-	snapshot->reg.ring_acthd = hw_engine_mmio_read32(hwe, RING_ACTHD(0));
+-	val = hw_engine_mmio_read32(hwe, RING_ACTHD_UDW(0));
++	snapshot->reg.ring_acthd = xe_hw_engine_mmio_read32(hwe, RING_ACTHD(0));
++	val = xe_hw_engine_mmio_read32(hwe, RING_ACTHD_UDW(0));
+ 	snapshot->reg.ring_acthd |= val << 32;
+ 
+-	snapshot->reg.ring_bbaddr = hw_engine_mmio_read32(hwe, RING_BBADDR(0));
+-	val = hw_engine_mmio_read32(hwe, RING_BBADDR_UDW(0));
++	snapshot->reg.ring_bbaddr = xe_hw_engine_mmio_read32(hwe, RING_BBADDR(0));
++	val = xe_hw_engine_mmio_read32(hwe, RING_BBADDR_UDW(0));
+ 	snapshot->reg.ring_bbaddr |= val << 32;
+ 
+ 	snapshot->reg.ring_dma_fadd =
+-		hw_engine_mmio_read32(hwe, RING_DMA_FADD(0));
+-	val = hw_engine_mmio_read32(hwe, RING_DMA_FADD_UDW(0));
++		xe_hw_engine_mmio_read32(hwe, RING_DMA_FADD(0));
++	val = xe_hw_engine_mmio_read32(hwe, RING_DMA_FADD_UDW(0));
+ 	snapshot->reg.ring_dma_fadd |= val << 32;
+ 
+-	snapshot->reg.ring_hwstam = hw_engine_mmio_read32(hwe, RING_HWSTAM(0));
+-	snapshot->reg.ring_hws_pga = hw_engine_mmio_read32(hwe, RING_HWS_PGA(0));
+-	snapshot->reg.ring_start = hw_engine_mmio_read32(hwe, RING_START(0));
++	snapshot->reg.ring_hwstam = xe_hw_engine_mmio_read32(hwe, RING_HWSTAM(0));
++	snapshot->reg.ring_hws_pga = xe_hw_engine_mmio_read32(hwe, RING_HWS_PGA(0));
++	snapshot->reg.ring_start = xe_hw_engine_mmio_read32(hwe, RING_START(0));
+ 	if (GRAPHICS_VERx100(hwe->gt->tile->xe) >= 2000) {
+-		val = hw_engine_mmio_read32(hwe, RING_START_UDW(0));
++		val = xe_hw_engine_mmio_read32(hwe, RING_START_UDW(0));
+ 		snapshot->reg.ring_start |= val << 32;
+ 	}
+ 	if (xe_gt_has_indirect_ring_state(hwe->gt)) {
+ 		snapshot->reg.indirect_ring_state =
+-			hw_engine_mmio_read32(hwe, INDIRECT_RING_STATE(0));
++			xe_hw_engine_mmio_read32(hwe, INDIRECT_RING_STATE(0));
+ 	}
+ 
+ 	snapshot->reg.ring_head =
+-		hw_engine_mmio_read32(hwe, RING_HEAD(0)) & HEAD_ADDR;
++		xe_hw_engine_mmio_read32(hwe, RING_HEAD(0)) & HEAD_ADDR;
+ 	snapshot->reg.ring_tail =
+-		hw_engine_mmio_read32(hwe, RING_TAIL(0)) & TAIL_ADDR;
+-	snapshot->reg.ring_ctl = hw_engine_mmio_read32(hwe, RING_CTL(0));
++		xe_hw_engine_mmio_read32(hwe, RING_TAIL(0)) & TAIL_ADDR;
++	snapshot->reg.ring_ctl = xe_hw_engine_mmio_read32(hwe, RING_CTL(0));
+ 	snapshot->reg.ring_mi_mode =
+-		hw_engine_mmio_read32(hwe, RING_MI_MODE(0));
+-	snapshot->reg.ring_mode = hw_engine_mmio_read32(hwe, RING_MODE(0));
+-	snapshot->reg.ring_imr = hw_engine_mmio_read32(hwe, RING_IMR(0));
+-	snapshot->reg.ring_esr = hw_engine_mmio_read32(hwe, RING_ESR(0));
+-	snapshot->reg.ring_emr = hw_engine_mmio_read32(hwe, RING_EMR(0));
+-	snapshot->reg.ring_eir = hw_engine_mmio_read32(hwe, RING_EIR(0));
+-	snapshot->reg.ipehr = hw_engine_mmio_read32(hwe, RING_IPEHR(0));
++		xe_hw_engine_mmio_read32(hwe, RING_MI_MODE(0));
++	snapshot->reg.ring_mode = xe_hw_engine_mmio_read32(hwe, RING_MODE(0));
++	snapshot->reg.ring_imr = xe_hw_engine_mmio_read32(hwe, RING_IMR(0));
++	snapshot->reg.ring_esr = xe_hw_engine_mmio_read32(hwe, RING_ESR(0));
++	snapshot->reg.ring_emr = xe_hw_engine_mmio_read32(hwe, RING_EMR(0));
++	snapshot->reg.ring_eir = xe_hw_engine_mmio_read32(hwe, RING_EIR(0));
++	snapshot->reg.ipehr = xe_hw_engine_mmio_read32(hwe, RING_IPEHR(0));
+ 	xe_hw_engine_snapshot_instdone_capture(hwe, snapshot);
+ 
+ 	if (snapshot->hwe->class == XE_ENGINE_CLASS_COMPUTE)
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine.h b/drivers/gpu/drm/xe/xe_hw_engine.h
+index d227ffe557eb..022819a4a8eb 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine.h
++++ b/drivers/gpu/drm/xe/xe_hw_engine.h
+@@ -78,4 +78,7 @@ const char *xe_hw_engine_class_to_str(enum xe_engine_class class);
+ u64 xe_hw_engine_read_timestamp(struct xe_hw_engine *hwe);
+ enum xe_force_wake_domains xe_hw_engine_to_fw_domain(struct xe_hw_engine *hwe);
+ 
++void xe_hw_engine_mmio_write32(struct xe_hw_engine *hwe, struct xe_reg reg, u32 val);
++u32 xe_hw_engine_mmio_read32(struct xe_hw_engine *hwe, struct xe_reg reg);
++
+ #endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-UFENCE-events-with-acks.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-UFENCE-events-with-acks.patch
@@ -1,0 +1,691 @@
+From ed40ccc76a846bfa1993c3409476ad64f08dfddf Mon Sep 17 00:00:00 2001
+From: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Date: Fri, 8 Mar 2024 14:34:01 +0200
+Subject: drm/xe/eudebug: Add UFENCE events with acks
+
+When vma is in place, debugger needs to intercept before
+userspace proceeds with the workload. For example to install
+a breakpoint in a eu shader.
+
+Attach debugger in xe_user_fence, send UFENCE event
+and stall normal user fence signal path to yield if
+there is debugger attached to ufence.
+
+When ack (ioctl) is received for the corresponding seqno,
+signal ufence.
+
+v2: - use lock for bind ref
+    - return err instead of 0 to guarantee signalling (Dominik)
+    - checkpatch (Tilak)
+
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 80209ee996fc143373815a8bb1988c052590dd6f eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_eudebug.c       | 241 +++++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_eudebug.h       |  11 ++
+ drivers/gpu/drm/xe/xe_eudebug_types.h |  14 ++
+ drivers/gpu/drm/xe/xe_exec.c          |   2 +-
+ drivers/gpu/drm/xe/xe_sync.c          |  56 ++++--
+ drivers/gpu/drm/xe/xe_sync.h          |   8 +-
+ drivers/gpu/drm/xe/xe_sync_types.h    |  26 ++-
+ drivers/gpu/drm/xe/xe_vm.c            |   4 +-
+ include/uapi/drm/xe_drm_eudebug.h     |  13 ++
+ 9 files changed, 347 insertions(+), 28 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 12b0d29d995a..3e607a1eea01 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -36,6 +36,7 @@
+ #include "xe_pm.h"
+ #include "xe_rtp.h"
+ #include "xe_gt_mcr.h"
++#include "xe_sync.h"
+ 
+ #include "xe_eudebug_types.h"
+ #include "xe_eudebug.h"
+@@ -244,11 +245,115 @@ static void xe_eudebug_free(struct kref *ref)
+ 	kfree_rcu(d, rcu);
+ }
+ 
+-static void xe_eudebug_put(struct xe_eudebug *d)
++void xe_eudebug_put(struct xe_eudebug *d)
+ {
+ 	kref_put(&d->ref, xe_eudebug_free);
+ }
+ 
++struct xe_eudebug_ack {
++	struct rb_node rb_node;
++	u64 seqno;
++	u64 ts_insert;
++	struct xe_user_fence *ufence;
++};
++
++#define fetch_ack(x) rb_entry(x, struct xe_eudebug_ack, rb_node)
++
++static int compare_ack(const u64 a, const u64 b)
++{
++	if (a < b)
++		return -1;
++	else if (a > b)
++		return 1;
++
++	return 0;
++}
++
++static int ack_insert_cmp(struct rb_node * const node,
++			  const struct rb_node * const p)
++{
++	return compare_ack(fetch_ack(node)->seqno,
++			   fetch_ack(p)->seqno);
++}
++
++static int ack_lookup_cmp(const void * const key,
++			  const struct rb_node * const node)
++{
++	return compare_ack(*(const u64 *)key,
++			   fetch_ack(node)->seqno);
++}
++
++static struct xe_eudebug_ack *remove_ack(struct xe_eudebug *d, u64 seqno)
++{
++	struct rb_root * const root = &d->acks.tree;
++	struct rb_node *node;
++
++	spin_lock(&d->acks.lock);
++	node = rb_find(&seqno, root, ack_lookup_cmp);
++	if (node)
++		rb_erase(node, root);
++	spin_unlock(&d->acks.lock);
++
++	if (!node)
++		return NULL;
++
++	return rb_entry_safe(node, struct xe_eudebug_ack, rb_node);
++}
++
++static void ufence_signal_worker(struct work_struct *w)
++{
++	struct xe_user_fence * const ufence =
++		container_of(w, struct xe_user_fence, eudebug.worker);
++
++	if (READ_ONCE(ufence->signalled))
++		xe_sync_ufence_signal(ufence);
++
++	xe_sync_ufence_put(ufence);
++}
++
++static void kick_ufence_worker(struct xe_user_fence *f)
++{
++	INIT_WORK(&f->eudebug.worker, ufence_signal_worker);
++	queue_work(f->xe->eudebug.ordered_wq, &f->eudebug.worker);
++}
++
++static void handle_ack(struct xe_eudebug *d, struct xe_eudebug_ack *ack,
++		       bool on_disconnect)
++{
++	struct xe_user_fence *f = ack->ufence;
++	u64 signaller_ack, signalled_by;
++
++	signaller_ack = cmpxchg64(&f->eudebug.signalled_seqno, 0, ack->seqno);
++	signalled_by = f->eudebug.signalled_seqno;
++
++	if (!signaller_ack)
++		kick_ufence_worker(f);
++	else
++		xe_sync_ufence_put(f);
++
++	eu_dbg(d, "ACK: seqno=%llu: %ssignalled by %s (%llu) (held %lluus)",
++	       ack->seqno, signaller_ack ? "already " : "",
++	       on_disconnect ? "disconnect" : "debugger",
++	       signalled_by,
++	       ktime_us_delta(ktime_get(), ack->ts_insert));
++
++	kfree(ack);
++}
++
++static void release_acks(struct xe_eudebug *d)
++{
++	struct xe_eudebug_ack *ack, *n;
++	struct rb_root root;
++
++	spin_lock(&d->acks.lock);
++	root = d->acks.tree;
++	d->acks.tree = RB_ROOT;
++	spin_unlock(&d->acks.lock);
++
++	rbtree_postorder_for_each_entry_safe(ack, n, &root, rb_node)
++		handle_ack(d, ack, true);
++}
++
+ static struct task_struct *find_get_target(const pid_t nr)
+ {
+ 	struct task_struct *task;
+@@ -332,6 +437,8 @@ static bool xe_eudebug_detach(struct xe_device *xe,
+ 
+ 	eu_dbg(d, "session %lld detached with %d", d->session, err);
+ 
++	release_acks(d);
++
+ 	/* Our ref with the connection_link */
+ 	xe_eudebug_put(d);
+ 
+@@ -432,7 +539,7 @@ static struct task_struct *find_task_get(struct xe_file *xef)
+ 	return task;
+ }
+ 
+-static struct xe_eudebug *
++struct xe_eudebug *
+ xe_eudebug_get(struct xe_file *xef)
+ {
+ 	struct task_struct *task;
+@@ -822,7 +929,7 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 		u64_to_user_ptr(arg);
+ 	struct drm_xe_eudebug_event user_event;
+ 	struct xe_eudebug_event *event;
+-	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_VM_BIND_OP;
++	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE;
+ 	long ret = 0;
+ 
+ 	if (XE_IOCTL_DBG(xe, copy_from_user(&user_event, user_orig, sizeof(user_event))))
+@@ -897,6 +1004,44 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 	return ret;
+ }
+ 
++static long
++xe_eudebug_ack_event_ioctl(struct xe_eudebug *d,
++			   const unsigned int cmd,
++			   const u64 arg)
++{
++	struct drm_xe_eudebug_ack_event __user * const user_ptr =
++		u64_to_user_ptr(arg);
++	struct drm_xe_eudebug_ack_event user_arg;
++	struct xe_eudebug_ack *ack;
++	struct xe_device *xe = d->xe;
++
++	if (XE_IOCTL_DBG(xe, _IOC_SIZE(cmd) < sizeof(user_arg)))
++		return -EINVAL;
++
++	/* Userland write */
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(cmd) & _IOC_WRITE)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, copy_from_user(&user_arg,
++					    user_ptr,
++					    sizeof(user_arg))))
++		return -EFAULT;
++
++	if (XE_IOCTL_DBG(xe, user_arg.flags))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, xe_eudebug_detached(d)))
++		return -ENOTCONN;
++
++	ack = remove_ack(d, user_arg.seqno);
++	if (XE_IOCTL_DBG(xe, !ack))
++		return -EINVAL;
++
++	handle_ack(d, ack, false);
++
++	return 0;
++}
++
+ static int do_eu_control(struct xe_eudebug *d,
+ 			 const struct drm_xe_eudebug_eu_control * const arg,
+ 			 struct drm_xe_eudebug_eu_control __user * const user_ptr)
+@@ -1077,7 +1222,10 @@ static long xe_eudebug_ioctl(struct file *file,
+ 		ret = xe_eudebug_eu_control(d, arg);
+ 		eu_dbg(d, "ioctl cmd=EU_CONTROL ret=%ld\n", ret);
+ 		break;
+-
++	case DRM_XE_EUDEBUG_IOCTL_ACK_EVENT:
++		ret = xe_eudebug_ack_event_ioctl(d, cmd, arg);
++		eu_dbg(d, "ioctl cmd=EVENT_ACK ret=%ld\n", ret);
++		break;
+ 	default:
+ 		ret = -EINVAL;
+ 	}
+@@ -1764,6 +1912,9 @@ xe_eudebug_connect(struct xe_device *xe,
+ 	INIT_KFIFO(d->events.fifo);
+ 	INIT_WORK(&d->discovery_work, discovery_work_fn);
+ 
++	spin_lock_init(&d->acks.lock);
++	d->acks.tree = RB_ROOT;
++
+ 	d->res = xe_eudebug_resources_alloc();
+ 	if (IS_ERR(d->res)) {
+ 		err = PTR_ERR(d->res);
+@@ -2377,6 +2528,70 @@ static int vm_bind_op(struct xe_eudebug *d, struct xe_vm *vm,
+ 	return 0;
+ }
+ 
++static int xe_eudebug_track_ufence(struct xe_eudebug *d,
++				   struct xe_user_fence *f,
++				   u64 seqno)
++{
++	struct xe_eudebug_ack *ack;
++	struct rb_node *old;
++
++	ack = kzalloc(sizeof(*ack), GFP_KERNEL);
++	if (!ack)
++		return -ENOMEM;
++
++	ack->seqno = seqno;
++	ack->ts_insert = ktime_get();
++
++	spin_lock(&d->acks.lock);
++	old = rb_find_add(&ack->rb_node,
++			  &d->acks.tree, ack_insert_cmp);
++	if (!old) {
++		kref_get(&f->refcount);
++		ack->ufence = f;
++	}
++	spin_unlock(&d->acks.lock);
++
++	if (old) {
++		eu_dbg(d, "ACK: seqno=%llu: already exists", seqno);
++		kfree(ack);
++		return -EEXIST;
++	}
++
++	eu_dbg(d, "ACK: seqno=%llu: tracking started", seqno);
++
++	return 0;
++}
++
++static int vm_bind_ufence_event(struct xe_eudebug *d,
++				struct xe_user_fence *ufence)
++{
++	struct xe_eudebug_event *event;
++	struct xe_eudebug_event_vm_bind_ufence *e;
++	const u32 sz = sizeof(*e);
++	const u32 flags = DRM_XE_EUDEBUG_EVENT_CREATE |
++		DRM_XE_EUDEBUG_EVENT_NEED_ACK;
++	u64 seqno;
++	int ret;
++
++	seqno = atomic_long_inc_return(&d->events.seqno);
++
++	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE,
++					seqno, flags, sz, GFP_KERNEL);
++	if (!event)
++		return -ENOMEM;
++
++	e = cast_event(e, event);
++
++	write_member(struct drm_xe_eudebug_event_vm_bind_ufence,
++		     e, vm_bind_ref_seqno, ufence->eudebug.bind_ref_seqno);
++
++	ret = xe_eudebug_track_ufence(d, ufence, seqno);
++	if (!ret)
++		ret = xe_eudebug_queue_event(d, event);
++
++	return ret;
++}
++
+ void xe_eudebug_vm_bind_start(struct xe_vm *vm)
+ {
+ 	struct xe_eudebug *d;
+@@ -2556,6 +2771,24 @@ void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int bind_err)
+ 		xe_eudebug_put(d);
+ }
+ 
++int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence)
++{
++	struct xe_eudebug *d;
++	int err;
++
++	d = ufence->eudebug.debugger;
++	if (!d || xe_eudebug_detached(d))
++		return -ENOTCONN;
++
++	err = vm_bind_ufence_event(d, ufence);
++	if (err) {
++		eu_err(d, "error %d on %s", err, __func__);
++		xe_eudebug_disconnect(d, err);
++	}
++
++	return err;
++}
++
+ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ {
+ 	struct xe_exec_queue *q;
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+index 0fd0864e74e7..58d28409c7f0 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.h
++++ b/drivers/gpu/drm/xe/xe_eudebug.h
+@@ -15,6 +15,7 @@ struct xe_vm;
+ struct xe_vma;
+ struct xe_exec_queue;
+ struct xe_hw_engine;
++struct xe_user_fence;
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
+ 
+@@ -40,6 +41,11 @@ void xe_eudebug_vm_bind_start(struct xe_vm *vm);
+ void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range);
+ void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err);
+ 
++int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence);
++
++struct xe_eudebug *xe_eudebug_get(struct xe_file *xef);
++void xe_eudebug_put(struct xe_eudebug *d);
++
+ #else
+ 
+ static inline int xe_eudebug_connect_ioctl(struct drm_device *dev,
+@@ -64,6 +70,11 @@ static inline void xe_eudebug_vm_bind_start(struct xe_vm *vm) { }
+ static inline void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range) { }
+ static inline void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err) { }
+ 
++static inline int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence) { return 0; }
++
++static inline struct xe_eudebug *xe_eudebug_get(struct xe_file *xef) { return NULL; }
++static inline void xe_eudebug_put(struct xe_eudebug *d) { }
++
+ #endif /* CONFIG_DRM_XE_EUDEBUG */
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
+index 1ffe33f15409..6cddb8acfa7d 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug_types.h
++++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
+@@ -86,6 +86,7 @@ struct xe_eudebug_eu_control_ops {
+ 	int (*stopped)(struct xe_eudebug *e, struct xe_exec_queue *q,
+ 		       struct xe_lrc *lrc, u8 *bitmap, unsigned int bitmap_size);
+ };
++
+ /**
+  * struct xe_eudebug - Top level struct for eudebug: the connection
+  */
+@@ -149,6 +150,14 @@ struct xe_eudebug {
+ 		atomic_long_t seqno;
+ 	} events;
+ 
++	/* user fences tracked by this debugger */
++	struct {
++		/** @lock: guards access to tree */
++		spinlock_t lock;
++
++		struct rb_root tree;
++	} acks;
++
+ 	/** @ops operations for eu_control */
+ 	struct xe_eudebug_eu_control_ops *ops;
+ };
+@@ -286,4 +295,9 @@ struct xe_eudebug_event_vm_bind_op {
+ 	u64 range; /* Zero for unmap all ? */
+ };
+ 
++struct xe_eudebug_event_vm_bind_ufence {
++	struct xe_eudebug_event base;
++	u64 vm_bind_ref_seqno;
++};
++
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_exec.c b/drivers/gpu/drm/xe/xe_exec.c
+index f36980aa26e6..400cb576f3b9 100644
+--- a/drivers/gpu/drm/xe/xe_exec.c
++++ b/drivers/gpu/drm/xe/xe_exec.c
+@@ -157,7 +157,7 @@ int xe_exec_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 	vm = q->vm;
+ 
+ 	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
+-		err = xe_sync_entry_parse(xe, xef, &syncs[num_syncs],
++		err = xe_sync_entry_parse(xe, xef, vm, &syncs[num_syncs],
+ 					  &syncs_user[num_syncs], SYNC_PARSE_FLAG_EXEC |
+ 					  (xe_vm_in_lr_mode(vm) ?
+ 					   SYNC_PARSE_FLAG_LR_MODE : 0));
+diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
+index 716b9d725688..fc7f4913d701 100644
+--- a/drivers/gpu/drm/xe/xe_sync.c
++++ b/drivers/gpu/drm/xe/xe_sync.c
+@@ -18,17 +18,7 @@
+ #include "xe_exec_queue.h"
+ #include "xe_macros.h"
+ #include "xe_sched_job_types.h"
+-
+-struct xe_user_fence {
+-	struct xe_device *xe;
+-	struct kref refcount;
+-	struct dma_fence_cb cb;
+-	struct work_struct worker;
+-	struct mm_struct *mm;
+-	u64 __user *addr;
+-	u64 value;
+-	int signalled;
+-};
++#include "xe_eudebug.h"
+ 
+ static void user_fence_destroy(struct kref *kref)
+ {
+@@ -36,6 +26,10 @@ static void user_fence_destroy(struct kref *kref)
+ 						 refcount);
+ 
+ 	mmdrop(ufence->mm);
++
++	if (ufence->eudebug.debugger)
++		xe_eudebug_put(ufence->eudebug.debugger);
++
+ 	kfree(ufence);
+ }
+ 
+@@ -49,16 +43,20 @@ static void user_fence_put(struct xe_user_fence *ufence)
+ 	kref_put(&ufence->refcount, user_fence_destroy);
+ }
+ 
+-static struct xe_user_fence *user_fence_create(struct xe_device *xe, u64 addr,
++static struct xe_user_fence *user_fence_create(struct xe_device *xe,
++					       struct xe_file *xef,
++					       struct xe_vm *vm,
++					       u64 addr,
+ 					       u64 value)
+ {
+ 	struct xe_user_fence *ufence;
+ 	u64 __user *ptr = u64_to_user_ptr(addr);
++	u64 bind_ref;
+ 
+ 	if (!access_ok(ptr, sizeof(ptr)))
+ 		return ERR_PTR(-EFAULT);
+ 
+-	ufence = kmalloc(sizeof(*ufence), GFP_KERNEL);
++	ufence = kzalloc(sizeof(*ufence), GFP_KERNEL);
+ 	if (!ufence)
+ 		return ERR_PTR(-ENOMEM);
+ 
+@@ -69,12 +67,23 @@ static struct xe_user_fence *user_fence_create(struct xe_device *xe, u64 addr,
+ 	ufence->mm = current->mm;
+ 	mmgrab(ufence->mm);
+ 
++	spin_lock(&vm->eudebug_bind.lock);
++	bind_ref = vm->eudebug_bind.ref;
++	spin_unlock(&vm->eudebug_bind.lock);
++
++	if (bind_ref) {
++		ufence->eudebug.debugger = xe_eudebug_get(xef);
++
++		if (ufence->eudebug.debugger)
++			ufence->eudebug.bind_ref_seqno = bind_ref;
++	}
++
+ 	return ufence;
+ }
+ 
+-static void user_fence_worker(struct work_struct *w)
++void xe_sync_ufence_signal(struct xe_user_fence *ufence)
+ {
+-	struct xe_user_fence *ufence = container_of(w, struct xe_user_fence, worker);
++	XE_WARN_ON(!ufence->signalled);
+ 
+ 	if (mmget_not_zero(ufence->mm)) {
+ 		kthread_use_mm(ufence->mm);
+@@ -85,7 +94,20 @@ static void user_fence_worker(struct work_struct *w)
+ 	}
+ 
+ 	wake_up_all(&ufence->xe->ufence_wq);
++}
++
++static void user_fence_worker(struct work_struct *w)
++{
++	struct xe_user_fence *ufence = container_of(w, struct xe_user_fence, worker);
++	int ret;
++
+ 	WRITE_ONCE(ufence->signalled, 1);
++
++	/* Lets see if debugger wants to track this */
++	ret = xe_eudebug_vm_bind_ufence(ufence);
++	if (ret)
++		xe_sync_ufence_signal(ufence);
++
+ 	user_fence_put(ufence);
+ }
+ 
+@@ -104,6 +126,7 @@ static void user_fence_cb(struct dma_fence *fence, struct dma_fence_cb *cb)
+ }
+ 
+ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
++			struct xe_vm *vm,
+ 			struct xe_sync_entry *sync,
+ 			struct drm_xe_sync __user *sync_user,
+ 			unsigned int flags)
+@@ -185,7 +208,8 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 		if (exec) {
+ 			sync->addr = sync_in.addr;
+ 		} else {
+-			sync->ufence = user_fence_create(xe, sync_in.addr,
++			sync->ufence = user_fence_create(xe, xef, vm,
++							 sync_in.addr,
+ 							 sync_in.timeline_value);
+ 			if (XE_IOCTL_DBG(xe, IS_ERR(sync->ufence)))
+ 				return PTR_ERR(sync->ufence);
+diff --git a/drivers/gpu/drm/xe/xe_sync.h b/drivers/gpu/drm/xe/xe_sync.h
+index 006dbf780793..30b508a8b5b8 100644
+--- a/drivers/gpu/drm/xe/xe_sync.h
++++ b/drivers/gpu/drm/xe/xe_sync.h
+@@ -9,8 +9,12 @@
+ #include "xe_sync_types.h"
+ 
+ struct xe_device;
+-struct xe_exec_queue;
+ struct xe_file;
++struct xe_exec_queue;
++struct drm_syncobj;
++struct dma_fence;
++struct dma_fence_chain;
++struct drm_xe_sync;
+ struct xe_sched_job;
+ struct xe_vm;
+ 
+@@ -19,6 +23,7 @@ struct xe_vm;
+ #define SYNC_PARSE_FLAG_DISALLOW_USER_FENCE	BIT(2)
+ 
+ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
++			struct xe_vm *vm,
+ 			struct xe_sync_entry *sync,
+ 			struct drm_xe_sync __user *sync_user,
+ 			unsigned int flags);
+@@ -41,5 +46,6 @@ struct xe_user_fence *__xe_sync_ufence_get(struct xe_user_fence *ufence);
+ struct xe_user_fence *xe_sync_ufence_get(struct xe_sync_entry *sync);
+ void xe_sync_ufence_put(struct xe_user_fence *ufence);
+ int xe_sync_ufence_get_status(struct xe_user_fence *ufence);
++void xe_sync_ufence_signal(struct xe_user_fence *ufence);
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_sync_types.h b/drivers/gpu/drm/xe/xe_sync_types.h
+index 30ac3f51993b..907c601a6d8c 100644
+--- a/drivers/gpu/drm/xe/xe_sync_types.h
++++ b/drivers/gpu/drm/xe/xe_sync_types.h
+@@ -7,12 +7,28 @@
+ #define _XE_SYNC_TYPES_H_
+ 
+ #include <linux/types.h>
++#include <linux/spinlock.h>
++#include <linux/kref.h>
++#include <linux/dma-fence-array.h>
+ 
+-struct drm_syncobj;
+-struct dma_fence;
+-struct dma_fence_chain;
+-struct drm_xe_sync;
+-struct user_fence;
++struct xe_eudebug;
++
++struct xe_user_fence {
++	struct xe_device *xe;
++	struct kref refcount;
++	struct dma_fence_cb cb;
++	struct work_struct worker;
++	struct mm_struct *mm;
++	u64 __user *addr;
++	u64 value;
++	int signalled;
++	struct {
++		struct xe_eudebug *debugger;
++		u64 bind_ref_seqno;
++		u64 signalled_seqno;
++		struct work_struct worker;
++	} eudebug;
++};
+ 
+ struct xe_sync_entry {
+ 	struct drm_syncobj *syncobj;
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index fc1164a34e6a..634af1c36c60 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -3052,9 +3052,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		}
+ 	}
+ 
++	xe_eudebug_vm_bind_start(vm);
++
+ 	syncs_user = u64_to_user_ptr(args->syncs);
+ 	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
+-		err = xe_sync_entry_parse(xe, xef, &syncs[num_syncs],
++		err = xe_sync_entry_parse(xe, xef, vm, &syncs[num_syncs],
+ 					  &syncs_user[num_syncs],
+ 					  (xe_vm_in_lr_mode(vm) ?
+ 					   SYNC_PARSE_FLAG_LR_MODE : 0) |
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+index 44cf1b699589..b2f6038ccc59 100644
+--- a/include/uapi/drm/xe_drm_eudebug.h
++++ b/include/uapi/drm/xe_drm_eudebug.h
+@@ -17,6 +17,7 @@ extern "C" {
+  */
+ #define DRM_XE_EUDEBUG_IOCTL_READ_EVENT		_IO('j', 0x0)
+ #define DRM_XE_EUDEBUG_IOCTL_EU_CONTROL		_IOWR('j', 0x2, struct drm_xe_eudebug_eu_control)
++#define DRM_XE_EUDEBUG_IOCTL_ACK_EVENT		_IOW('j', 0x4, struct drm_xe_eudebug_ack_event)
+ 
+ /* XXX: Document events to match their internal counterparts when moved to xe_drm.h */
+ struct drm_xe_eudebug_event {
+@@ -31,6 +32,7 @@ struct drm_xe_eudebug_event {
+ #define DRM_XE_EUDEBUG_EVENT_EU_ATTENTION	5
+ #define DRM_XE_EUDEBUG_EVENT_VM_BIND		6
+ #define DRM_XE_EUDEBUG_EVENT_VM_BIND_OP		7
++#define DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE	8
+ 
+ 	__u16 flags;
+ #define DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
+@@ -157,6 +159,17 @@ struct drm_xe_eudebug_event_vm_bind_op {
+ 	__u64 range; /* XXX: Zero for unmap all? */
+ };
+ 
++struct drm_xe_eudebug_event_vm_bind_ufence {
++	struct drm_xe_eudebug_event base;
++	__u64 vm_bind_ref_seqno; /* *_event_vm_bind.base.seqno */
++};
++
++struct drm_xe_eudebug_ack_event {
++	__u32 type;
++	__u32 flags; /* MBZ */
++	__u64 seqno;
++};
++
+ #if defined(__cplusplus)
+ }
+ #endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-debug-metadata-support-for-xe_eud.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-debug-metadata-support-for-xe_eud.patch
@@ -1,0 +1,665 @@
+From 99a802abb9416f7375460b4dc084a37200bea17d Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Thu, 19 Oct 2023 11:16:12 +0200
+Subject: drm/xe/eudebug: Add debug metadata support for xe_eudebug
+
+Reflect debug metadata resource creation/destroy as events passed to the
+debugger. Introduce ioctl allowing to read metadata content on demand.
+
+Each VMA can have multiple metadata attached and it is passed from user
+on BIND or it's copied on internal remap.
+
+Xe EU Debugger on VM BIND will inform about VMA metadata attachements
+during bind IOCTL sending proper OP event.
+
+v2: checkpatch (Maciej) v2: struct alignment (Matthew)
+v3: - squash and typos (Mika)
+    - checkpatch (Tilak)
+
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 4dcb2338c29f85c948455df8a0d4ad36e45c21ee eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_debug_metadata.c |   7 +-
+ drivers/gpu/drm/xe/xe_eudebug.c        | 331 ++++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_eudebug.h        |  13 +-
+ drivers/gpu/drm/xe/xe_eudebug_types.h  |  27 +-
+ drivers/gpu/drm/xe/xe_vm.c             |   2 +-
+ include/uapi/drm/xe_drm_eudebug.h      |  30 +++
+ 6 files changed, 399 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.c b/drivers/gpu/drm/xe/xe_debug_metadata.c
+index daffc13c58d6..31e943248cfc 100644
+--- a/drivers/gpu/drm/xe/xe_debug_metadata.c
++++ b/drivers/gpu/drm/xe/xe_debug_metadata.c
+@@ -9,6 +9,7 @@
+ #include <drm/xe_drm.h>
+ 
+ #include "xe_device.h"
++#include "xe_eudebug.h"
+ #include "xe_macros.h"
+ 
+ static void xe_debug_metadata_release(struct kref *ref)
+@@ -51,7 +52,7 @@ int xe_debug_metadata_create_ioctl(struct drm_device *dev,
+ 	if (XE_IOCTL_DBG(xe, args->extensions))
+ 		return -EINVAL;
+ 
+-	if (XE_IOCTL_DBG(xe, args->type > DRM_XE_DEBUG_METADATA_PROGRAM_MODULE))
++	if (XE_IOCTL_DBG(xe, args->type >= WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_NUM))
+ 		return -EINVAL;
+ 
+ 	if (XE_IOCTL_DBG(xe, !args->user_addr || !args->len))
+@@ -90,6 +91,8 @@ int xe_debug_metadata_create_ioctl(struct drm_device *dev,
+ 	if (err)
+ 		goto put_mdata;
+ 
++	xe_eudebug_debug_metadata_create(xef, mdata);
++
+ 	return 0;
+ 
+ put_mdata:
+@@ -115,6 +118,8 @@ int xe_debug_metadata_destroy_ioctl(struct drm_device *dev,
+ 	if (XE_IOCTL_DBG(xe, !mdata))
+ 		return -ENOENT;
+ 
++	xe_eudebug_debug_metadata_destroy(xef, mdata);
++
+ 	xe_debug_metadata_put(mdata);
+ 	return 0;
+ }
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 523ffb627539..6dce38f3f86c 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -41,6 +41,10 @@
+ #include "xe_gt_mcr.h"
+ #include "xe_sync.h"
+ #include "xe_bo.h"
++#include "xe_exec_queue_types.h"
++#include "xe_debug_metadata.h"
++#include "xe_guc_exec_queue_types.h"
++#include "xe_execlist_types.h"
+ 
+ #include "xe_eudebug_types.h"
+ #include "xe_eudebug.h"
+@@ -766,6 +770,23 @@ static struct xe_vm *find_vm(struct xe_eudebug *d, const u32 id)
+ 	return NULL;
+ }
+ 
++static struct xe_debug_metadata *find_metadata_get(struct xe_eudebug *d,
++						   u32 id)
++{
++	struct xe_debug_metadata *m = NULL;
++	struct xe_eudebug_handle *h;
++
++	mutex_lock(&d->res->lock);
++	h = __find_resource(d->res, XE_EUDEBUG_RES_TYPE_METADATA, id);
++	if (h) {
++		m = (struct xe_debug_metadata *)h->key;
++		kref_get(&m->refcount);
++	}
++	mutex_unlock(&d->res->lock);
++
++	return m;
++}
++
+ static int _xe_eudebug_add_handle(struct xe_eudebug *d,
+ 				  int type,
+ 				  void *p,
+@@ -944,7 +965,7 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 		u64_to_user_ptr(arg);
+ 	struct drm_xe_eudebug_event user_event;
+ 	struct xe_eudebug_event *event;
+-	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE;
++	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA;
+ 	long ret = 0;
+ 
+ 	if (XE_IOCTL_DBG(xe, copy_from_user(&user_event, user_orig, sizeof(user_event))))
+@@ -1221,6 +1242,73 @@ static long xe_eudebug_eu_control(struct xe_eudebug *d, const u64 arg)
+ 	return ret;
+ }
+ 
++static long xe_eudebug_read_metadata(struct xe_eudebug *d,
++				     unsigned int cmd,
++				     const u64 arg)
++{
++	struct drm_xe_eudebug_read_metadata user_arg;
++	struct xe_debug_metadata *mdata;
++	struct xe_file *xef;
++	struct xe_device *xe = d->xe;
++	long ret = 0;
++
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(cmd) & _IOC_WRITE)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(cmd) & _IOC_READ)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, _IOC_SIZE(cmd) < sizeof(user_arg)))
++		return -EINVAL;
++
++	if (copy_from_user(&user_arg, u64_to_user_ptr(arg), sizeof(user_arg)))
++		return -EFAULT;
++
++	if (XE_IOCTL_DBG(xe, user_arg.flags))
++		return -EINVAL;
++
++	if (!access_ok(u64_to_user_ptr(user_arg.ptr), user_arg.size))
++		return -EFAULT;
++
++	if (xe_eudebug_detached(d))
++		return -ENOTCONN;
++
++	eu_dbg(d,
++	       "read metadata: client_handle=%llu, metadata_handle=%llu, flags=0x%x",
++	       user_arg.client_handle, user_arg.metadata_handle, user_arg.flags);
++
++	xef = find_client(d, user_arg.client_handle);
++	if (XE_IOCTL_DBG(xe, !xef))
++		return -EINVAL;
++
++	mdata = find_metadata_get(d, (u32)user_arg.metadata_handle);
++	if (XE_IOCTL_DBG(xe, !mdata))
++		return -EINVAL;
++
++	if (user_arg.size) {
++		if (user_arg.size < mdata->len) {
++			ret = -EINVAL;
++			goto metadata_put;
++		}
++
++		/* This limits us to a maximum payload size of 2G */
++		if (copy_to_user(u64_to_user_ptr(user_arg.ptr),
++				 mdata->ptr, mdata->len)) {
++			ret = -EFAULT;
++			goto metadata_put;
++		}
++	}
++
++	user_arg.size = mdata->len;
++
++	if (copy_to_user(u64_to_user_ptr(arg), &user_arg, sizeof(user_arg)))
++		ret = -EFAULT;
++
++metadata_put:
++	xe_debug_metadata_put(mdata);
++	return ret;
++}
++
+ static long xe_eudebug_vm_open_ioctl(struct xe_eudebug *d, unsigned long arg);
+ 
+ static long xe_eudebug_ioctl(struct file *file,
+@@ -1247,7 +1335,10 @@ static long xe_eudebug_ioctl(struct file *file,
+ 		ret = xe_eudebug_vm_open_ioctl(d, arg);
+ 		eu_dbg(d, "ioctl cmd=VM_OPEN ret=%ld\n", ret);
+ 		break;
+-
++	case DRM_XE_EUDEBUG_IOCTL_READ_METADATA:
++		ret = xe_eudebug_read_metadata(d, cmd, arg);
++		eu_dbg(d, "ioctl cmd=READ_METADATA ret=%ld\n", ret);
++		break;
+ 	default:
+ 		ret = -EINVAL;
+ 	}
+@@ -2534,19 +2625,145 @@ static int vm_bind_op_event(struct xe_eudebug *d,
+ 	return xe_eudebug_queue_bind_event(d, vm, event);
+ }
+ 
++static int vm_bind_op_metadata_event(struct xe_eudebug *d,
++				     struct xe_vm *vm,
++				     u32 flags,
++				     u64 ref_seqno,
++				     u64 metadata_handle,
++				     u64 metadata_cookie)
++{
++	struct xe_eudebug_event_vm_bind_op_metadata *e;
++	struct xe_eudebug_event *event;
++	const u32 sz = sizeof(*e);
++	u64 seqno;
++
++	seqno = atomic_long_inc_return(&d->events.seqno);
++
++	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA,
++					seqno, flags, sz, GFP_KERNEL);
++	if (!event)
++		return -ENOMEM;
++
++	e = cast_event(e, event);
++
++	write_member(struct drm_xe_eudebug_event_vm_bind_op_metadata, e,
++		     vm_bind_op_ref_seqno, ref_seqno);
++	write_member(struct drm_xe_eudebug_event_vm_bind_op_metadata, e,
++		     metadata_handle, metadata_handle);
++	write_member(struct drm_xe_eudebug_event_vm_bind_op_metadata, e,
++		     metadata_cookie, metadata_cookie);
++
++	/* If in discovery, no need to collect ops */
++	if (!completion_done(&d->discovery))
++		return xe_eudebug_queue_event(d, event);
++
++	return xe_eudebug_queue_bind_event(d, vm, event);
++}
++
++static int vm_bind_op_metadata_count(struct xe_eudebug *d,
++				     struct xe_vm *vm,
++				     struct list_head *debug_metadata)
++{
++	struct xe_vma_debug_metadata *metadata;
++	struct xe_debug_metadata *mdata;
++	int h_m = 0, metadata_count = 0;
++
++	if (!debug_metadata)
++		return 0;
++
++	list_for_each_entry(metadata, debug_metadata, link) {
++		mdata = xe_debug_metadata_get(vm->xef, metadata->metadata_id);
++		if (mdata) {
++			h_m = find_handle(d->res, XE_EUDEBUG_RES_TYPE_METADATA, mdata);
++			xe_debug_metadata_put(mdata);
++		}
++
++		if (!mdata || h_m < 0) {
++			if (!mdata) {
++				eu_err(d, "Metadata::%u not found.",
++				       metadata->metadata_id);
++			} else {
++				eu_err(d, "Metadata::%u not in the xe debugger",
++				       metadata->metadata_id);
++			}
++			xe_eudebug_disconnect(d, -ENOENT);
++			return -ENOENT;
++		}
++		metadata_count++;
++	}
++	return metadata_count;
++}
++
++static int vm_bind_op_metadata(struct xe_eudebug *d, struct xe_vm *vm,
++			       const u32 flags,
++			       const u64 op_ref_seqno,
++			       struct list_head *debug_metadata)
++{
++	struct xe_vma_debug_metadata *metadata;
++	int h_m = 0; /* handle space range = <1, MAX_INT>, return 0 if metadata not attached */
++	int metadata_count = 0;
++	int ret;
++
++	if (!debug_metadata)
++		return 0;
++
++	XE_WARN_ON(flags != DRM_XE_EUDEBUG_EVENT_CREATE);
++
++	list_for_each_entry(metadata, debug_metadata, link) {
++		struct xe_debug_metadata *mdata;
++
++		mdata = xe_debug_metadata_get(vm->xef, metadata->metadata_id);
++		if (mdata) {
++			h_m = find_handle(d->res, XE_EUDEBUG_RES_TYPE_METADATA, mdata);
++			xe_debug_metadata_put(mdata);
++		}
++
++		if (!mdata || h_m < 0) {
++			eu_err(d, "Attached debug metadata::%u not found!\n",
++			       metadata->metadata_id);
++			return -ENOENT;
++		}
++
++		ret = vm_bind_op_metadata_event(d, vm, flags, op_ref_seqno,
++						h_m, metadata->cookie);
++		if (ret < 0)
++			return ret;
++
++		metadata_count++;
++	}
++
++	return metadata_count;
++}
++
+ static int vm_bind_op(struct xe_eudebug *d, struct xe_vm *vm,
+ 		      const u32 flags, const u64 bind_ref_seqno,
+-		      u64 addr, u64 range)
++		      u64 addr, u64 range,
++		      struct list_head *debug_metadata)
+ {
+ 	u64 op_seqno = 0;
+-	u64 num_extensions = 0;
++	u64 num_extensions;
+ 	int ret;
+ 
++	ret = vm_bind_op_metadata_count(d, vm, debug_metadata);
++	if (ret < 0)
++		return ret;
++
++	num_extensions = ret;
++
+ 	ret = vm_bind_op_event(d, vm, flags, bind_ref_seqno, num_extensions,
+ 			       addr, range, &op_seqno);
+ 	if (ret)
+ 		return ret;
+ 
++	ret = vm_bind_op_metadata(d, vm, flags, op_seqno, debug_metadata);
++	if (ret < 0)
++		return ret;
++
++	if (ret != num_extensions) {
++		eu_err(d, "Inconsistency in metadata detected.");
++		return -EINVAL;
++	}
++
+ 	return 0;
+ }
+ 
+@@ -2651,9 +2868,11 @@ void xe_eudebug_vm_bind_start(struct xe_vm *vm)
+ 	xe_eudebug_put(d);
+ }
+ 
+-void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range)
++void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
++			       struct drm_gpuva_ops *ops)
+ {
+ 	struct xe_eudebug *d;
++	struct list_head *debug_metadata = NULL;
+ 	u32 flags;
+ 
+ 	if (!xe_vm_in_lr_mode(vm))
+@@ -2663,7 +2882,17 @@ void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range)
+ 	case DRM_XE_VM_BIND_OP_MAP:
+ 	case DRM_XE_VM_BIND_OP_MAP_USERPTR:
+ 	{
++		struct drm_gpuva_op *__op;
++
+ 		flags = DRM_XE_EUDEBUG_EVENT_CREATE;
++
++		/* OP_MAP will be last and singleton */
++		drm_gpuva_for_each_op(__op, ops) {
++			struct xe_vma_op *op = gpuva_op_to_vma_op(__op);
++
++			if (op->base.op == DRM_GPUVA_OP_MAP)
++				debug_metadata = &op->map.vma->debug_metadata;
++		}
+ 		break;
+ 	}
+ 	case DRM_XE_VM_BIND_OP_UNMAP:
+@@ -2682,7 +2911,8 @@ void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range)
+ 	if (!d)
+ 		return;
+ 
+-	xe_eudebug_event_put(d, vm_bind_op(d, vm, flags, 0, addr, range));
++	xe_eudebug_event_put(d, vm_bind_op(d, vm, flags, 0, addr, range,
++					   debug_metadata));
+ }
+ 
+ static struct xe_eudebug_event *fetch_bind_event(struct xe_vm * const vm)
+@@ -2811,8 +3041,89 @@ int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence)
+ 	return err;
+ }
+ 
++static int send_debug_metadata_event(struct xe_eudebug *d, u32 flags,
++				     u64 client_handle, u64 metadata_handle,
++				     u64 type, u64 len, u64 seqno)
++{
++	struct xe_eudebug_event *event;
++	struct xe_eudebug_event_metadata *e;
++
++	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_METADATA, seqno,
++					flags, sizeof(*e), GFP_KERNEL);
++	if (!event)
++		return -ENOMEM;
++
++	e = cast_event(e, event);
++
++	write_member(struct drm_xe_eudebug_event_metadata, e, client_handle, client_handle);
++	write_member(struct drm_xe_eudebug_event_metadata, e, metadata_handle, metadata_handle);
++	write_member(struct drm_xe_eudebug_event_metadata, e, type, type);
++	write_member(struct drm_xe_eudebug_event_metadata, e, len, len);
++
++	return xe_eudebug_queue_event(d, event);
++}
++
++static int debug_metadata_create_event(struct xe_eudebug *d,
++				       struct xe_file *xef, struct xe_debug_metadata *m)
++{
++	int h_c, h_m;
++	u64 seqno;
++
++	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
++	if (h_c < 0)
++		return h_c;
++
++	h_m = xe_eudebug_add_handle(d, XE_EUDEBUG_RES_TYPE_METADATA, m, &seqno);
++	if (h_m <= 0)
++		return h_m;
++
++	return send_debug_metadata_event(d, DRM_XE_EUDEBUG_EVENT_CREATE,
++					 h_c, h_m, m->type, m->len, seqno);
++}
++
++static int debug_metadata_destroy_event(struct xe_eudebug *d,
++					struct xe_file *xef, struct xe_debug_metadata *m)
++{
++	int h_c, h_m;
++	u64 seqno;
++
++	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
++	if (h_c < 0)
++		return h_c;
++
++	h_m = xe_eudebug_remove_handle(d, XE_EUDEBUG_RES_TYPE_METADATA, m, &seqno);
++	if (h_m < 0)
++		return h_m;
++
++	return send_debug_metadata_event(d, DRM_XE_EUDEBUG_EVENT_DESTROY,
++					 h_c, h_m, m->type, m->len, seqno);
++}
++
++void xe_eudebug_debug_metadata_create(struct xe_file *xef, struct xe_debug_metadata *m)
++{
++	struct xe_eudebug *d;
++
++	d = xe_eudebug_get(xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, debug_metadata_create_event(d, xef, m));
++}
++
++void xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct xe_debug_metadata *m)
++{
++	struct xe_eudebug *d;
++
++	d = xe_eudebug_get(xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, debug_metadata_destroy_event(d, xef, m));
++}
++
+ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ {
++	struct xe_debug_metadata *m;
+ 	struct xe_exec_queue *q;
+ 	struct xe_vm *vm;
+ 	unsigned long i;
+@@ -2822,6 +3133,14 @@ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ 	if (err)
+ 		return err;
+ 
++	mutex_lock(&xef->debug_metadata.lock);
++	xa_for_each(&xef->debug_metadata.xa, i, m) {
++		err = debug_metadata_create_event(d, xef, m);
++		if (err)
++			break;
++	}
++	mutex_unlock(&xef->debug_metadata.lock);
++
+ 	mutex_lock(&xef->vm.lock);
+ 	xa_for_each(&xef->vm.xa, i, vm) {
+ 		err = vm_create_event(d, xef, vm);
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+index 58d28409c7f0..40ac2a6adcd8 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.h
++++ b/drivers/gpu/drm/xe/xe_eudebug.h
+@@ -16,6 +16,8 @@ struct xe_vma;
+ struct xe_exec_queue;
+ struct xe_hw_engine;
+ struct xe_user_fence;
++struct xe_debug_metadata;
++struct drm_gpuva_ops;
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
+ 
+@@ -38,7 +40,8 @@ void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q);
+ void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q);
+ 
+ void xe_eudebug_vm_bind_start(struct xe_vm *vm);
+-void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range);
++void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
++			       struct drm_gpuva_ops *ops);
+ void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err);
+ 
+ int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence);
+@@ -46,6 +49,9 @@ int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence);
+ struct xe_eudebug *xe_eudebug_get(struct xe_file *xef);
+ void xe_eudebug_put(struct xe_eudebug *d);
+ 
++void xe_eudebug_debug_metadata_create(struct xe_file *xef, struct xe_debug_metadata *m);
++void xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct xe_debug_metadata *m);
++
+ #else
+ 
+ static inline int xe_eudebug_connect_ioctl(struct drm_device *dev,
+@@ -67,7 +73,7 @@ static inline void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_e
+ static inline void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q) { }
+ 
+ static inline void xe_eudebug_vm_bind_start(struct xe_vm *vm) { }
+-static inline void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range) { }
++static inline void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range, struct drm_gpuva_ops *ops) { }
+ static inline void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err) { }
+ 
+ static inline int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence) { return 0; }
+@@ -75,6 +81,9 @@ static inline int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence) { retu
+ static inline struct xe_eudebug *xe_eudebug_get(struct xe_file *xef) { return NULL; }
+ static inline void xe_eudebug_put(struct xe_eudebug *d) { }
+ 
++static inline void xe_eudebug_debug_metadata_create(struct xe_file *xef, struct xe_debug_metadata *m) { }
++static inline void xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct xe_debug_metadata *m) { }
++
+ #endif /* CONFIG_DRM_XE_EUDEBUG */
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
+index 6cddb8acfa7d..4e319270b245 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug_types.h
++++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
+@@ -56,7 +56,8 @@ struct xe_eudebug_resource {
+ #define XE_EUDEBUG_RES_TYPE_VM		1
+ #define XE_EUDEBUG_RES_TYPE_EXEC_QUEUE	2
+ #define XE_EUDEBUG_RES_TYPE_LRC		3
+-#define XE_EUDEBUG_RES_TYPE_COUNT	(XE_EUDEBUG_RES_TYPE_LRC + 1)
++#define XE_EUDEBUG_RES_TYPE_METADATA	4
++#define XE_EUDEBUG_RES_TYPE_COUNT	(XE_EUDEBUG_RES_TYPE_METADATA + 1)
+ 
+ /**
+  * struct xe_eudebug_resources - eudebug resources for all types
+@@ -300,4 +301,28 @@ struct xe_eudebug_event_vm_bind_ufence {
+ 	u64 vm_bind_ref_seqno;
+ };
+ 
++struct xe_eudebug_event_metadata {
++	struct xe_eudebug_event base;
++
++	/** @client_handle: client for the attention */
++	u64 client_handle;
++
++	/** @metadata_handle: debug metadata handle it's created/destroyed */
++	u64 metadata_handle;
++
++	/* @type: metadata type, refer to xe_drm.h for options */
++	u64 type;
++
++	/* @len: size of metadata paylad */
++	u64 len;
++};
++
++struct xe_eudebug_event_vm_bind_op_metadata {
++	struct xe_eudebug_event base;
++	u64 vm_bind_op_ref_seqno;
++
++	u64 metadata_handle;
++	u64 metadata_cookie;
++};
++
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index fdbf395bcd03..408c3afbac62 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -3293,7 +3293,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		if (err)
+ 			goto unwind_ops;
+ 
+-		xe_eudebug_vm_bind_op_add(vm, op, addr, range);
++		xe_eudebug_vm_bind_op_add(vm, op, addr, range, ops[i]);
+ 
+ #ifdef TEST_VM_OPS_ERROR
+ 		if (flags & FORCE_OP_ERROR) {
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+index 9917280400d6..2ebf21e15f5b 100644
+--- a/include/uapi/drm/xe_drm_eudebug.h
++++ b/include/uapi/drm/xe_drm_eudebug.h
+@@ -19,6 +19,7 @@ extern "C" {
+ #define DRM_XE_EUDEBUG_IOCTL_EU_CONTROL		_IOWR('j', 0x2, struct drm_xe_eudebug_eu_control)
+ #define DRM_XE_EUDEBUG_IOCTL_ACK_EVENT		_IOW('j', 0x4, struct drm_xe_eudebug_ack_event)
+ #define DRM_XE_EUDEBUG_IOCTL_VM_OPEN		_IOW('j', 0x1, struct drm_xe_eudebug_vm_open)
++#define DRM_XE_EUDEBUG_IOCTL_READ_METADATA	_IOWR('j', 0x3, struct drm_xe_eudebug_read_metadata)
+ 
+ /* XXX: Document events to match their internal counterparts when moved to xe_drm.h */
+ struct drm_xe_eudebug_event {
+@@ -34,6 +35,8 @@ struct drm_xe_eudebug_event {
+ #define DRM_XE_EUDEBUG_EVENT_VM_BIND		6
+ #define DRM_XE_EUDEBUG_EVENT_VM_BIND_OP		7
+ #define DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE	8
++#define DRM_XE_EUDEBUG_EVENT_METADATA		9
++#define DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA 10
+ 
+ 	__u16 flags;
+ #define DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
+@@ -188,6 +191,33 @@ struct drm_xe_eudebug_vm_open {
+ 	__u64 timeout_ns;
+ };
+ 
++struct drm_xe_eudebug_read_metadata {
++	__u64 client_handle;
++	__u64 metadata_handle;
++	__u32 flags;
++	__u32 reserved;
++	__u64 ptr;
++	__u64 size;
++};
++
++struct drm_xe_eudebug_event_metadata {
++	struct drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 metadata_handle;
++	/* XXX: Refer to xe_drm.h for fields */
++	__u64 type;
++	__u64 len;
++};
++
++struct drm_xe_eudebug_event_vm_bind_op_metadata {
++	struct drm_xe_eudebug_event base;
++	__u64 vm_bind_op_ref_seqno; /* *_event_vm_bind_op.base.seqno */
++
++	__u64 metadata_handle;
++	__u64 metadata_cookie;
++};
++
+ #if defined(__cplusplus)
+ }
+ #endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-vm-bind-and-vm-bind-ops.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-vm-bind-and-vm-bind-ops.patch
@@ -1,0 +1,618 @@
+From 36a6ff7766309c26e52ee09a4061f0995c29026c Mon Sep 17 00:00:00 2001
+From: Christoph Manszewski <christoph.manszewski@intel.com>
+Date: Mon, 2 Oct 2023 13:03:05 +0200
+Subject: drm/xe/eudebug: Add vm bind and vm bind ops
+
+Add events dedicated to track vma bind and vma unbind operations. The
+events are generated for operations performed on xe_vma MAP and UNMAP
+for boss and userptrs.
+
+As one bind can result in multiple operations and fail in the middle,
+we want to store the events until full successful chain of operations
+can be relayed to debugger.
+
+Co-developed-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Signed-off-by: Christoph Manszewski <christoph.manszewski@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 87448e81c5204e38dd8aac45bd03122dea9cff6d eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_eudebug.c       | 308 +++++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_eudebug.h       |  11 +
+ drivers/gpu/drm/xe/xe_eudebug_types.h |  29 +++
+ drivers/gpu/drm/xe/xe_vm.c            |  18 +-
+ drivers/gpu/drm/xe/xe_vm_types.h      |  11 +
+ include/uapi/drm/xe_drm_eudebug.h     |  64 ++++++
+ 6 files changed, 438 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 959dba812c57..12b0d29d995a 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -822,7 +822,7 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 		u64_to_user_ptr(arg);
+ 	struct drm_xe_eudebug_event user_event;
+ 	struct xe_eudebug_event *event;
+-	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_EU_ATTENTION;
++	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_VM_BIND_OP;
+ 	long ret = 0;
+ 
+ 	if (XE_IOCTL_DBG(xe, copy_from_user(&user_event, user_orig, sizeof(user_event))))
+@@ -2250,6 +2250,312 @@ void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q)
+ 	xe_eudebug_event_put(d, exec_queue_destroy_event(d, xef, q));
+ }
+ 
++static int xe_eudebug_queue_bind_event(struct xe_eudebug *d,
++				       struct xe_vm *vm,
++				       struct xe_eudebug_event *event)
++{
++	struct xe_eudebug_event_envelope *env;
++
++	lockdep_assert_held_write(&vm->lock);
++
++	env = kmalloc(sizeof(*env), GFP_KERNEL);
++	if (!env)
++		return -ENOMEM;
++
++	INIT_LIST_HEAD(&env->link);
++	env->event = event;
++
++	spin_lock(&vm->eudebug_bind.lock);
++	list_add_tail(&env->link, &vm->eudebug_bind.events);
++
++	if (event->type == DRM_XE_EUDEBUG_EVENT_VM_BIND_OP)
++		++vm->eudebug_bind.ops;
++	spin_unlock(&vm->eudebug_bind.lock);
++
++	return 0;
++}
++
++static int queue_vm_bind_event(struct xe_eudebug *d,
++			       struct xe_vm *vm,
++			       u64 client_handle,
++			       u64 vm_handle,
++			       u32 bind_flags,
++			       u32 num_ops, u64 *seqno)
++{
++	struct xe_eudebug_event_vm_bind *e;
++	struct xe_eudebug_event *event;
++	const u32 sz = sizeof(*e);
++	const u32 base_flags = DRM_XE_EUDEBUG_EVENT_STATE_CHANGE;
++
++	*seqno = atomic_long_inc_return(&d->events.seqno);
++
++	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM_BIND,
++					*seqno, base_flags, sz, GFP_KERNEL);
++	if (!event)
++		return -ENOMEM;
++
++	e = cast_event(e, event);
++	write_member(struct drm_xe_eudebug_event_vm_bind, e, client_handle, client_handle);
++	write_member(struct drm_xe_eudebug_event_vm_bind, e, vm_handle, vm_handle);
++	write_member(struct drm_xe_eudebug_event_vm_bind, e, flags, bind_flags);
++	write_member(struct drm_xe_eudebug_event_vm_bind, e, num_binds, num_ops);
++
++	/* If in discovery, no need to collect ops */
++	if (!completion_done(&d->discovery)) {
++		XE_WARN_ON(!num_ops);
++		return xe_eudebug_queue_event(d, event);
++	}
++
++	return xe_eudebug_queue_bind_event(d, vm, event);
++}
++
++static int vm_bind_event(struct xe_eudebug *d,
++			 struct xe_vm *vm,
++			 u32 num_ops,
++			 u64 *seqno)
++{
++	int h_c, h_vm;
++
++	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, vm->xef);
++	if (h_c < 0)
++		return h_c;
++
++	h_vm = find_handle(d->res, XE_EUDEBUG_RES_TYPE_VM, vm);
++	if (h_vm < 0)
++		return h_vm;
++
++	return queue_vm_bind_event(d, vm, h_c, h_vm, 0,
++				   num_ops, seqno);
++}
++
++static int vm_bind_op_event(struct xe_eudebug *d,
++			    struct xe_vm *vm,
++			    const u32 flags,
++			    const u64 bind_ref_seqno,
++			    const u64 num_extensions,
++			    u64 addr, u64 range,
++			    u64 *op_seqno)
++{
++	struct xe_eudebug_event_vm_bind_op *e;
++	struct xe_eudebug_event *event;
++	const u32 sz = sizeof(*e);
++
++	*op_seqno = atomic_long_inc_return(&d->events.seqno);
++
++	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM_BIND_OP,
++					*op_seqno, flags, sz, GFP_KERNEL);
++	if (!event)
++		return -ENOMEM;
++
++	e = cast_event(e, event);
++
++	write_member(struct drm_xe_eudebug_event_vm_bind_op, e, vm_bind_ref_seqno, bind_ref_seqno);
++	write_member(struct drm_xe_eudebug_event_vm_bind_op, e, num_extensions, num_extensions);
++	write_member(struct drm_xe_eudebug_event_vm_bind_op, e, addr, addr);
++	write_member(struct drm_xe_eudebug_event_vm_bind_op, e, range, range);
++
++	/* If in discovery, no need to collect ops */
++	if (!completion_done(&d->discovery))
++		return xe_eudebug_queue_event(d, event);
++
++	return xe_eudebug_queue_bind_event(d, vm, event);
++}
++
++static int vm_bind_op(struct xe_eudebug *d, struct xe_vm *vm,
++		      const u32 flags, const u64 bind_ref_seqno,
++		      u64 addr, u64 range)
++{
++	u64 op_seqno = 0;
++	u64 num_extensions = 0;
++	int ret;
++
++	ret = vm_bind_op_event(d, vm, flags, bind_ref_seqno, num_extensions,
++			       addr, range, &op_seqno);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++void xe_eudebug_vm_bind_start(struct xe_vm *vm)
++{
++	struct xe_eudebug *d;
++	u64 seqno = 0;
++	int err;
++
++	if (!xe_vm_in_lr_mode(vm))
++		return;
++
++	d = xe_eudebug_get(vm->xef);
++	if (!d)
++		return;
++
++	lockdep_assert_held_write(&vm->lock);
++
++	if (XE_WARN_ON(!list_empty(&vm->eudebug_bind.events)) ||
++	    XE_WARN_ON(vm->eudebug_bind.ops) ||
++	    XE_WARN_ON(vm->eudebug_bind.ref)) {
++		eu_err(d, "bind busy on %s",  __func__);
++		xe_eudebug_disconnect(d, -EINVAL);
++	}
++
++	err = vm_bind_event(d, vm, 0, &seqno);
++	if (err) {
++		eu_err(d, "error %d on %s", err, __func__);
++		xe_eudebug_disconnect(d, err);
++	}
++
++	spin_lock(&vm->eudebug_bind.lock);
++	XE_WARN_ON(vm->eudebug_bind.ref);
++	vm->eudebug_bind.ref = seqno;
++	vm->eudebug_bind.ops = 0;
++	spin_unlock(&vm->eudebug_bind.lock);
++
++	xe_eudebug_put(d);
++}
++
++void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range)
++{
++	struct xe_eudebug *d;
++	u32 flags;
++
++	if (!xe_vm_in_lr_mode(vm))
++		return;
++
++	switch (op) {
++	case DRM_XE_VM_BIND_OP_MAP:
++	case DRM_XE_VM_BIND_OP_MAP_USERPTR:
++	{
++		flags = DRM_XE_EUDEBUG_EVENT_CREATE;
++		break;
++	}
++	case DRM_XE_VM_BIND_OP_UNMAP:
++	case DRM_XE_VM_BIND_OP_UNMAP_ALL:
++		flags = DRM_XE_EUDEBUG_EVENT_DESTROY;
++		break;
++	default:
++		flags = 0;
++		break;
++	}
++
++	if (!flags)
++		return;
++
++	d = xe_eudebug_get(vm->xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, vm_bind_op(d, vm, flags, 0, addr, range));
++}
++
++static struct xe_eudebug_event *fetch_bind_event(struct xe_vm * const vm)
++{
++	struct xe_eudebug_event_envelope *env;
++	struct xe_eudebug_event *e = NULL;
++
++	spin_lock(&vm->eudebug_bind.lock);
++	env = list_first_entry_or_null(&vm->eudebug_bind.events,
++				       struct xe_eudebug_event_envelope, link);
++	if (env) {
++		e = env->event;
++		list_del(&env->link);
++	}
++	spin_unlock(&vm->eudebug_bind.lock);
++
++	kfree(env);
++
++	return e;
++}
++
++static void fill_vm_bind_fields(struct xe_vm *vm,
++				struct xe_eudebug_event *e,
++				bool ufence,
++				u32 bind_ops)
++{
++	struct xe_eudebug_event_vm_bind *eb = cast_event(eb, e);
++
++	eb->flags = ufence ?
++		DRM_XE_EUDEBUG_EVENT_VM_BIND_FLAG_UFENCE : 0;
++	eb->num_binds = bind_ops;
++}
++
++static void fill_vm_bind_op_fields(struct xe_vm *vm,
++				   struct xe_eudebug_event *e,
++				   u64 ref_seqno)
++{
++	struct xe_eudebug_event_vm_bind_op *op;
++
++	if (e->type != DRM_XE_EUDEBUG_EVENT_VM_BIND_OP)
++		return;
++
++	op = cast_event(op, e);
++	op->vm_bind_ref_seqno = ref_seqno;
++}
++
++void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int bind_err)
++{
++	struct xe_eudebug_event *e;
++	struct xe_eudebug *d;
++	u32 bind_ops;
++	u64 ref;
++
++	if (!xe_vm_in_lr_mode(vm))
++		return;
++
++	spin_lock(&vm->eudebug_bind.lock);
++	ref = vm->eudebug_bind.ref;
++	vm->eudebug_bind.ref = 0;
++	bind_ops = vm->eudebug_bind.ops;
++	vm->eudebug_bind.ops = 0;
++	spin_unlock(&vm->eudebug_bind.lock);
++
++	e = fetch_bind_event(vm);
++	if (!e)
++		return;
++
++	d = NULL;
++	if (!bind_err && ref) {
++		d = xe_eudebug_get(vm->xef);
++		if (d) {
++			if (bind_ops) {
++				fill_vm_bind_fields(vm, e, has_ufence, bind_ops);
++			} else {
++				/*
++				 * If there was no ops we are interested in,
++				 * we can omit the whole sequence
++				 */
++				xe_eudebug_put(d);
++				d = NULL;
++			}
++		}
++	}
++
++	while (e) {
++		int err = 0;
++
++		if (d) {
++			err = xe_eudebug_queue_event(d, e);
++			if (!err)
++				e = NULL;
++		}
++
++		if (err) {
++			xe_eudebug_disconnect(d, err);
++			xe_eudebug_put(d);
++			d = NULL;
++		}
++
++		kfree(e);
++
++		e = fetch_bind_event(vm);
++		if (e && ref)
++			fill_vm_bind_op_fields(vm, e, ref);
++	}
++
++	if (d)
++		xe_eudebug_put(d);
++}
++
+ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ {
+ 	struct xe_exec_queue *q;
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+index 1fe86bec99e1..0fd0864e74e7 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.h
++++ b/drivers/gpu/drm/xe/xe_eudebug.h
+@@ -5,11 +5,14 @@
+ 
+ #ifndef _XE_EUDEBUG_H_
+ 
++#include <linux/types.h>
++
+ struct drm_device;
+ struct drm_file;
+ struct xe_device;
+ struct xe_file;
+ struct xe_vm;
++struct xe_vma;
+ struct xe_exec_queue;
+ struct xe_hw_engine;
+ 
+@@ -33,6 +36,10 @@ void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm);
+ void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q);
+ void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q);
+ 
++void xe_eudebug_vm_bind_start(struct xe_vm *vm);
++void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range);
++void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err);
++
+ #else
+ 
+ static inline int xe_eudebug_connect_ioctl(struct drm_device *dev,
+@@ -53,6 +60,10 @@ static inline void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm)
+ static inline void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q) { }
+ static inline void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q) { }
+ 
++static inline void xe_eudebug_vm_bind_start(struct xe_vm *vm) { }
++static inline void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range) { }
++static inline void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err) { }
++
+ #endif /* CONFIG_DRM_XE_EUDEBUG */
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
+index a75986180d71..1ffe33f15409 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug_types.h
++++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
+@@ -176,6 +176,11 @@ struct xe_eudebug_event {
+ 	u8 data[];
+ };
+ 
++struct xe_eudebug_event_envelope {
++	struct list_head link;
++	struct xe_eudebug_event *event;
++};
++
+ /**
+  * struct xe_eudebug_event_open - Internal event for client open/close
+  */
+@@ -257,4 +262,28 @@ struct xe_eudebug_event_eu_attention {
+ 	u8 bitmask[];
+ };
+ 
++/**
++ * struct xe_eudebug_event_vm_bind - Internal event for vm bind/unbind operation
++ */
++struct xe_eudebug_event_vm_bind {
++	/** @base: base event */
++	struct xe_eudebug_event base;
++
++	u64 client_handle;
++	u64 vm_handle;
++
++	u32 flags;
++	u32 num_binds;
++};
++
++struct xe_eudebug_event_vm_bind_op {
++	/** @base: base event */
++	struct xe_eudebug_event base;
++	u64 vm_bind_ref_seqno;
++	u64 num_extensions;
++
++	u64 addr; /* Zero for unmap all ? */
++	u64 range; /* Zero for unmap all ? */
++};
++
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 70cae0bac352..fc1164a34e6a 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -1411,6 +1411,9 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags)
+ 	for_each_tile(tile, xe, id)
+ 		xe_range_fence_tree_init(&vm->rftree[id]);
+ 
++	INIT_LIST_HEAD(&vm->eudebug_bind.events);
++	spin_lock_init(&vm->eudebug_bind.lock);
++
+ 	vm->pt_ops = &xelp_pt_ops;
+ 
+ 	/*
+@@ -1650,6 +1653,8 @@ static void vm_destroy_work_func(struct work_struct *w)
+ 	struct xe_tile *tile;
+ 	u8 id;
+ 
++	xe_eudebug_vm_bind_end(vm, 0, -ENOENT);
++
+ 	/* xe_vm_close_and_put was not called? */
+ 	xe_assert(xe, !vm->size);
+ 
+@@ -2669,7 +2674,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+ 				   struct dma_fence *fence)
+ {
+ 	struct xe_exec_queue *wait_exec_queue = to_wait_exec_queue(vm, vops->q);
+-	struct xe_user_fence *ufence;
++	struct xe_user_fence *ufence = NULL;
+ 	struct xe_vma_op *op;
+ 	int i;
+ 
+@@ -2684,6 +2689,9 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+ 			xe_vma_destroy(gpuva_to_vma(op->base.remap.unmap->va),
+ 				       fence);
+ 	}
++
++	xe_eudebug_vm_bind_end(vm, ufence, 0);
++
+ 	if (ufence)
+ 		xe_sync_ufence_put(ufence);
+ 	for (i = 0; i < vops->num_syncs; i++)
+@@ -3070,6 +3078,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 	}
+ 
+ 	xe_vma_ops_init(&vops, vm, q, syncs, num_syncs);
++
+ 	for (i = 0; i < args->num_binds; ++i) {
+ 		u64 range = bind_ops[i].range;
+ 		u64 addr = bind_ops[i].addr;
+@@ -3092,6 +3101,8 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		if (err)
+ 			goto unwind_ops;
+ 
++		xe_eudebug_vm_bind_op_add(vm, op, addr, range);
++
+ #ifdef TEST_VM_OPS_ERROR
+ 		if (flags & FORCE_OP_ERROR) {
+ 			vops.inject_error = true;
+@@ -3115,8 +3126,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 	err = vm_bind_ioctl_ops_execute(vm, &vops);
+ 
+ unwind_ops:
+-	if (err && err != -ENODATA)
++	if (err && err != -ENODATA) {
++		xe_eudebug_vm_bind_end(vm, num_ufence > 0, err);
+ 		vm_bind_ioctl_ops_unwind(vm, ops, args->num_binds);
++	}
++
+ 	xe_vma_ops_fini(&vops);
+ 	for (i = args->num_binds - 1; i >= 0; --i)
+ 		if (ops[i])
+diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
+index 7f9a303e51d8..da9d7ef6ab8f 100644
+--- a/drivers/gpu/drm/xe/xe_vm_types.h
++++ b/drivers/gpu/drm/xe/xe_vm_types.h
+@@ -282,6 +282,17 @@ struct xe_vm {
+ 	bool batch_invalidate_tlb;
+ 	/** @xef: XE file handle for tracking this VM's drm client */
+ 	struct xe_file *xef;
++
++	struct {
++		/** @lock: Lock for eudebug_bind members */
++		spinlock_t lock;
++		/** @events: List of vm bind ops gathered */
++		struct list_head events;
++		/** @ops: How many operations we have stored */
++		u32 ops;
++		/** @ref: Reference to the VM_BIND that the ops relate */
++		u64 ref;
++	} eudebug_bind;
+ };
+ 
+ /** struct xe_vma_op_map - VMA map operation */
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+index 3c43aefefedd..44cf1b699589 100644
+--- a/include/uapi/drm/xe_drm_eudebug.h
++++ b/include/uapi/drm/xe_drm_eudebug.h
+@@ -29,6 +29,8 @@ struct drm_xe_eudebug_event {
+ #define DRM_XE_EUDEBUG_EVENT_VM			3
+ #define DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE		4
+ #define DRM_XE_EUDEBUG_EVENT_EU_ATTENTION	5
++#define DRM_XE_EUDEBUG_EVENT_VM_BIND		6
++#define DRM_XE_EUDEBUG_EVENT_VM_BIND_OP		7
+ 
+ 	__u16 flags;
+ #define DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
+@@ -93,6 +95,68 @@ struct drm_xe_eudebug_eu_control {
+ 	__u64 bitmask_ptr;
+ };
+ 
++/*
++ *  When client (debuggee) does vm_bind_ioctl() following event
++ *  sequence will be created (for the debugger):
++ *
++ *  ┌───────────────────────┐
++ *  │  EVENT_VM_BIND        ├───────┬─┬─┐
++ *  └───────────────────────┘       │ │ │
++ *      ┌───────────────────────┐   │ │ │
++ *      │ EVENT_VM_BIND_OP #1   ├───┘ │ │
++ *      └───────────────────────┘     │ │
++ *                 ...                │ │
++ *      ┌───────────────────────┐     │ │
++ *      │ EVENT_VM_BIND_OP #n   ├─────┘ │
++ *      └───────────────────────┘       │
++ *                                      │
++ *      ┌───────────────────────┐       │
++ *      │ EVENT_UFENCE          ├───────┘
++ *      └───────────────────────┘
++ *
++ * All the events below VM_BIND will reference the VM_BIND
++ * they associate with, by field .vm_bind_ref_seqno.
++ * event_ufence will only be included if the client did
++ * attach sync of type UFENCE into its vm_bind_ioctl().
++ *
++ * When EVENT_UFENCE is sent by the driver, all the OPs of
++ * the original VM_BIND are completed and the [addr,range]
++ * contained in them are present and modifiable through the
++ * vm accessors. Accessing [addr, range] before related ufence
++ * event will lead to undefined results as the actual bind
++ * operations are async and the backing storage might not
++ * be there on a moment of receiving the event.
++ *
++ * Client's UFENCE sync will be held by the driver: client's
++ * drm_xe_wait_ufence will not complete and the value of the ufence
++ * won't appear until ufence is acked by the debugger process calling
++ * DRM_XE_EUDEBUG_IOCTL_ACK_EVENT with the event_ufence.base.seqno.
++ * This will signal the fence, .value will update and the wait will
++ * complete allowing the client to continue.
++ *
++ */
++
++struct drm_xe_eudebug_event_vm_bind {
++	struct drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 vm_handle;
++
++	__u32 flags;
++#define DRM_XE_EUDEBUG_EVENT_VM_BIND_FLAG_UFENCE (1 << 0)
++
++	__u32 num_binds;
++};
++
++struct drm_xe_eudebug_event_vm_bind_op {
++	struct drm_xe_eudebug_event base;
++	__u64 vm_bind_ref_seqno; /* *_event_vm_bind.base.seqno */
++	__u64 num_extensions;
++
++	__u64 addr; /* XXX: Zero for unmap all? */
++	__u64 range; /* XXX: Zero for unmap all? */
++};
++
+ #if defined(__cplusplus)
+ }
+ #endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Dynamically-toggle-debugger-functiona.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Dynamically-toggle-debugger-functiona.patch
@@ -1,0 +1,390 @@
+From ea130d3be12d4b4181240c04d0f9c3090b19416a Mon Sep 17 00:00:00 2001
+From: Christoph Manszewski <christoph.manszewski@intel.com>
+Date: Mon, 27 Nov 2023 15:26:52 +0100
+Subject: drm/xe/eudebug: Dynamically toggle debugger functionality
+
+Make it possible to dynamically enable/disable debugger funtionality,
+including the setting and unsetting of required hw register values via a
+sysfs entry located at '/sys/class/drm/card<X>/device/enable_eudebug'.
+
+This entry uses 'kstrtobool' and as such it accepts inputs as documented
+by this function, in particular '0' and '1'.
+
+1) Adjust to xe_rtp graphics ranges changes.
+2) Fix pile placement. Wa 14019869343 (aka. 16021232320) was
+added later in the pile, move disablement to appropriate commit.
+3) flush reset (Christoph)
+4) dont allow exec queue enable if feature is disabled (Dominik)
+5) bind to drm sysfs functions (Maciej)
+6) Do not use xe_rtp (Dominik)
+
+Signed-off-by: Christoph Manszewski <christoph.manszewski@intel.com>
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+(cherry picked from commit 35b41c3d0a624ff7cce718e3cd72a20e82423adf eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c       |   2 -
+ drivers/gpu/drm/xe/xe_device_types.h |   5 ++
+ drivers/gpu/drm/xe/xe_eudebug.c      | 128 +++++++++++++++++++++++----
+ drivers/gpu/drm/xe/xe_eudebug.h      |   2 -
+ drivers/gpu/drm/xe/xe_exec_queue.c   |   3 +
+ drivers/gpu/drm/xe/xe_hw_engine.c    |   1 -
+ drivers/gpu/drm/xe/xe_reg_sr.c       |  21 +++--
+ drivers/gpu/drm/xe/xe_reg_sr.h       |   4 +-
+ drivers/gpu/drm/xe/xe_rtp.c          |   2 +-
+ 9 files changed, 136 insertions(+), 32 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index c9c0f8d1df56..4ed7dd584a6d 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -779,8 +779,6 @@ int xe_device_probe(struct xe_device *xe)
+ 
+ 	xe_debugfs_register(xe);
+ 
+-	xe_eudebug_init_late(xe);
+-
+ 	xe_hwmon_register(xe);
+ 
+ 	for_each_gt(gt, xe, id)
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index c812a21ed1f5..3ab9c2b8f97d 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -517,6 +517,11 @@ struct xe_device {
+ 		/** @ordered_wq: used to discovery */
+ 		struct workqueue_struct *ordered_wq;
+ 
++		/** @enable_lock: protects the enable toggle */
++		struct mutex enable_lock;
++		/** @enable: is the debugging functionality enabled */
++		bool enable;
++
+ 		/** @attention_scan: attention scan worker */
+ 		struct delayed_work attention_scan;
+ 	} eudebug;
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 4f7e1583e02a..22e920cd2115 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -2007,9 +2007,6 @@ xe_eudebug_connect(struct xe_device *xe,
+ 
+ 	param->version = DRM_XE_EUDEBUG_VERSION;
+ 
+-	if (!xe->eudebug.available)
+-		return -EOPNOTSUPP;
+-
+ 	d = kzalloc(sizeof(*d), GFP_KERNEL);
+ 	if (!d)
+ 		return -ENOMEM;
+@@ -2071,15 +2068,24 @@ int xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 	struct drm_xe_eudebug_connect * const param = data;
+ 	int ret = 0;
+ 
++	mutex_lock(&xe->eudebug.enable_lock);
++
++	if (!xe->eudebug.enable) {
++		mutex_unlock(&xe->eudebug.enable_lock);
++		return -ENODEV;
++	}
++
+ 	ret = xe_eudebug_connect(xe, param);
+ 
++	mutex_unlock(&xe->eudebug.enable_lock);
++
+ 	return ret;
+ }
+ 
+ #undef XE_REG_MCR
+ #define XE_REG_MCR(...)     XE_REG(__VA_ARGS__, .mcr = 1)
+ 
+-void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe)
++static void xe_eudebug_reinit_hw_engine(struct xe_hw_engine *hwe, bool enable)
+ {
+ 	struct xe_gt *gt = hwe->gt;
+ 	struct xe_device *xe = gt_to_xe(gt);
+@@ -2094,22 +2100,22 @@ void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe)
+ 		struct xe_reg_sr_entry sr_entry = {
+ 			.reg = ROW_CHICKEN,
+ 			.clr_bits = STALL_DOP_GATING_DISABLE,
+-			.set_bits = STALL_DOP_GATING_DISABLE,
++			.set_bits = enable ? STALL_DOP_GATING_DISABLE : 0,
+ 			.read_mask = STALL_DOP_GATING_DISABLE,
+ 		};
+ 
+-		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt);
++		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt, true);
+ 	}
+ 
+ 	if (XE_WA(gt, 14015474168)) {
+ 		struct xe_reg_sr_entry sr_entry = {
+ 			.reg = ROW_CHICKEN2,
+ 			.clr_bits = XEHPC_DISABLE_BTB,
+-			.set_bits = XEHPC_DISABLE_BTB,
++			.set_bits = enable ? XEHPC_DISABLE_BTB : 0,
+ 			.read_mask = XEHPC_DISABLE_BTB,
+ 		};
+ 
+-		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt);
++		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt, true);
+ 	}
+ 
+ 	if (xe->info.graphics_verx100 >= 1200) {
+@@ -2119,40 +2125,124 @@ void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe)
+ 		struct xe_reg_sr_entry sr_entry = {
+ 			.reg = TD_CTL,
+ 			.clr_bits = mask,
+-			.set_bits = mask,
++			.set_bits = enable ? mask : 0,
+ 			.read_mask = mask,
+ 		};
+ 
+-		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt);
++		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt, true);
+ 	}
+ 
+ 	if (xe->info.graphics_verx100 >= 1250) {
+ 		struct xe_reg_sr_entry sr_entry = {
+ 			.reg = TD_CTL,
+ 			.clr_bits = TD_CTL_GLOBAL_DEBUG_ENABLE,
+-			.set_bits = TD_CTL_GLOBAL_DEBUG_ENABLE,
++			.set_bits = enable ? TD_CTL_GLOBAL_DEBUG_ENABLE : 0,
+ 			.read_mask = TD_CTL_GLOBAL_DEBUG_ENABLE,
+ 		};
+ 
+-		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt);
++		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt, true);
+ 	}
+ }
+ 
++static int xe_eudebug_enable(struct xe_device *xe, bool enable)
++{
++	struct xe_gt *gt;
++	int i;
++	u8 id;
++
++	if (!xe->eudebug.available)
++		return -EOPNOTSUPP;
++
++	/* XXX: TODO hold list lock? */
++	mutex_lock(&xe->eudebug.enable_lock);
++
++	if (!enable && !list_empty(&xe->eudebug.list)) {
++		mutex_unlock(&xe->eudebug.enable_lock);
++		return -EBUSY;
++	}
++
++	if (enable == xe->eudebug.enable) {
++		mutex_unlock(&xe->eudebug.enable_lock);
++		return 0;
++	}
++
++	for_each_gt(gt, xe, id) {
++		for (i = 0; i < ARRAY_SIZE(gt->hw_engines); i++) {
++			if (!(gt->info.engine_mask & BIT(i)))
++				continue;
++
++			xe_eudebug_reinit_hw_engine(&gt->hw_engines[i], enable);
++		}
++
++		xe_gt_reset_async(gt);
++		flush_work(&gt->reset.worker);
++	}
++
++	if (enable)
++		attention_scan_flush(xe);
++	else
++		attention_scan_cancel(xe);
++
++	xe->eudebug.enable = enable;
++	mutex_unlock(&xe->eudebug.enable_lock);
++
++	return 0;
++}
++
++static ssize_t enable_eudebug_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
++
++	return sysfs_emit(buf, "%u\n", xe->eudebug.enable);
++}
++
++static ssize_t enable_eudebug_store(struct device *dev, struct device_attribute *attr,
++				    const char *buf, size_t count)
++{
++	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
++	bool enable;
++	int ret;
++
++	ret = kstrtobool(buf, &enable);
++	if (ret)
++		return ret;
++
++	ret = xe_eudebug_enable(xe, enable);
++	if (ret)
++		return ret;
++
++	return count;
++}
++
++static DEVICE_ATTR_RW(enable_eudebug);
++
++static void xe_eudebug_sysfs_fini(void *arg)
++{
++	struct xe_device *xe = arg;
++
++	sysfs_remove_file(&xe->drm.dev->kobj, &dev_attr_enable_eudebug.attr);
++}
++
+ void xe_eudebug_init(struct xe_device *xe)
+ {
++	struct device *dev = xe->drm.dev;
++	int ret;
++
+ 	spin_lock_init(&xe->eudebug.lock);
+ 	INIT_LIST_HEAD(&xe->eudebug.list);
+ 	INIT_DELAYED_WORK(&xe->eudebug.attention_scan, attention_scan_fn);
+ 
+-	xe->eudebug.available = true;
+-}
++	drmm_mutex_init(&xe->drm, &xe->eudebug.enable_lock);
++	xe->eudebug.enable = false;
+ 
+-void xe_eudebug_init_late(struct xe_device *xe)
+-{
+-	if (!xe->eudebug.available)
+-		return;
+ 
+-	attention_scan_flush(xe);
++	ret = sysfs_create_file(&xe->drm.dev->kobj, &dev_attr_enable_eudebug.attr);
++	if (ret)
++		drm_warn(&xe->drm, "eudebug sysfs init failed: %d, debugger unavailable\n", ret);
++	else
++		devm_add_action_or_reset(dev, xe_eudebug_sysfs_fini, xe);
++
++	xe->eudebug.available = ret == 0;
+ }
+ 
+ void xe_eudebug_fini(struct xe_device *xe)
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+index 40ac2a6adcd8..1ebc0e48c902 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.h
++++ b/drivers/gpu/drm/xe/xe_eudebug.h
+@@ -26,9 +26,7 @@ int xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 			     struct drm_file *file);
+ 
+ void xe_eudebug_init(struct xe_device *xe);
+-void xe_eudebug_init_late(struct xe_device *xe);
+ void xe_eudebug_fini(struct xe_device *xe);
+-void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe);
+ 
+ void xe_eudebug_file_open(struct xe_file *xef);
+ void xe_eudebug_file_close(struct xe_file *xef);
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index e59017c2e158..1c4287a764fa 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -418,6 +418,9 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
+ 			 !(value & DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE)))
+ 		return -EINVAL;
+ 
++	if (XE_IOCTL_DBG(xe, !xe->eudebug.enable))
++		return -EPERM;
++
+ 	q->eudebug_flags = EXEC_QUEUE_EUDEBUG_FLAG_ENABLE;
+ 	q->sched_props.preempt_timeout_us = 0;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
+index aa75d762a658..2bf038b87a29 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine.c
+@@ -531,7 +531,6 @@ static void hw_engine_init_early(struct xe_gt *gt, struct xe_hw_engine *hwe,
+ 	xe_tuning_process_engine(hwe);
+ 	xe_wa_process_engine(hwe);
+ 	hw_engine_setup_default_state(hwe);
+-	xe_eudebug_init_hw_engine(hwe);
+ 
+ 	xe_reg_sr_init(&hwe->reg_whitelist, hwe->name, gt_to_xe(gt));
+ 	xe_reg_whitelist_process_engine(hwe);
+diff --git a/drivers/gpu/drm/xe/xe_reg_sr.c b/drivers/gpu/drm/xe/xe_reg_sr.c
+index 440ac572f6e5..a7671722a84e 100644
+--- a/drivers/gpu/drm/xe/xe_reg_sr.c
++++ b/drivers/gpu/drm/xe/xe_reg_sr.c
+@@ -92,22 +92,31 @@ static void reg_sr_inc_error(struct xe_reg_sr *sr)
+ 
+ int xe_reg_sr_add(struct xe_reg_sr *sr,
+ 		  const struct xe_reg_sr_entry *e,
+-		  struct xe_gt *gt)
++		  struct xe_gt *gt,
++		  bool overwrite)
+ {
+ 	unsigned long idx = e->reg.addr;
+ 	struct xe_reg_sr_entry *pentry = xa_load(&sr->xa, idx);
+ 	int ret;
+ 
+ 	if (pentry) {
+-		if (!compatible_entries(pentry, e)) {
++		if (overwrite && e->set_bits) {
++			pentry->clr_bits |= e->clr_bits;
++			pentry->set_bits |= e->set_bits;
++			pentry->read_mask |= e->read_mask;
++		} else if (overwrite && !e->set_bits) {
++			pentry->clr_bits |= e->clr_bits;
++			pentry->set_bits &= ~e->clr_bits;
++			pentry->read_mask |= e->read_mask;
++		} else if (!compatible_entries(pentry, e)) {
+ 			ret = -EINVAL;
+ 			goto fail;
++		} else {
++			pentry->clr_bits |= e->clr_bits;
++			pentry->set_bits |= e->set_bits;
++			pentry->read_mask |= e->read_mask;
+ 		}
+ 
+-		pentry->clr_bits |= e->clr_bits;
+-		pentry->set_bits |= e->set_bits;
+-		pentry->read_mask |= e->read_mask;
+-
+ 		return 0;
+ 	}
+ 
+diff --git a/drivers/gpu/drm/xe/xe_reg_sr.h b/drivers/gpu/drm/xe/xe_reg_sr.h
+index 51fbba423e27..d67fafdcd847 100644
+--- a/drivers/gpu/drm/xe/xe_reg_sr.h
++++ b/drivers/gpu/drm/xe/xe_reg_sr.h
+@@ -6,6 +6,8 @@
+ #ifndef _XE_REG_SR_
+ #define _XE_REG_SR_
+ 
++#include <linux/types.h>
++
+ /*
+  * Reg save/restore bookkeeping
+  */
+@@ -21,7 +23,7 @@ int xe_reg_sr_init(struct xe_reg_sr *sr, const char *name, struct xe_device *xe)
+ void xe_reg_sr_dump(struct xe_reg_sr *sr, struct drm_printer *p);
+ 
+ int xe_reg_sr_add(struct xe_reg_sr *sr, const struct xe_reg_sr_entry *e,
+-		  struct xe_gt *gt);
++		  struct xe_gt *gt, bool overwrite);
+ void xe_reg_sr_apply_mmio(struct xe_reg_sr *sr, struct xe_gt *gt);
+ void xe_reg_sr_apply_whitelist(struct xe_hw_engine *hwe);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_rtp.c b/drivers/gpu/drm/xe/xe_rtp.c
+index 5efe83cc82ab..383c7890dc11 100644
+--- a/drivers/gpu/drm/xe/xe_rtp.c
++++ b/drivers/gpu/drm/xe/xe_rtp.c
+@@ -153,7 +153,7 @@ static void rtp_add_sr_entry(const struct xe_rtp_action *action,
+ 	};
+ 
+ 	sr_entry.reg.addr += mmio_base;
+-	xe_reg_sr_add(sr, &sr_entry, gt);
++	xe_reg_sr_add(sr, &sr_entry, gt, false);
+ }
+ 
+ static bool rtp_process_one_sr(const struct xe_rtp_entry_sr *entry,
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Implement-vm_bind_op-discovery.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Implement-vm_bind_op-discovery.patch
@@ -1,0 +1,79 @@
+From be5dfd714298760be1312178ba1846c54b76fb18 Mon Sep 17 00:00:00 2001
+From: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Date: Mon, 5 Feb 2024 13:28:46 +0200
+Subject: drm/xe/eudebug: Implement vm_bind_op discovery
+
+Follow the vm bind, vm_bind op sequence for
+discovery process of a vm with the vmas it has.
+Send events for ops and attach metadata if available.
+
+v2: Fix bad op ref seqno (Christoph)
+
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 35c1730a9bccc9bafe755052ba964d95435b6202 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_eudebug.c | 40 +++++++++++++++++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 6dce38f3f86c..4f7e1583e02a 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -3121,6 +3121,42 @@ void xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct xe_debug_meta
+ 	xe_eudebug_event_put(d, debug_metadata_destroy_event(d, xef, m));
+ }
+ 
++static int vm_discover_binds(struct xe_eudebug *d, struct xe_vm *vm)
++{
++	struct drm_gpuva *va;
++	unsigned int num_ops = 0, send_ops = 0;
++	u64 ref_seqno = 0;
++	int err;
++
++	/* Currently only vm_bind_ioctl inserts vma's */
++	drm_gpuvm_for_each_va(va, &vm->gpuvm)
++		num_ops++;
++
++	if (!num_ops)
++		return 0;
++
++	err = vm_bind_event(d, vm, num_ops, &ref_seqno);
++	if (err)
++		return err;
++
++	drm_gpuvm_for_each_va(va, &vm->gpuvm) {
++		struct xe_vma *vma = container_of(va, struct xe_vma, gpuva);
++
++		if (send_ops >= num_ops)
++			break;
++
++		err = vm_bind_op(d, vm, DRM_XE_EUDEBUG_EVENT_CREATE, ref_seqno,
++				 xe_vma_start(vma), xe_vma_size(vma),
++				 &vma->debug_metadata);
++		if (err)
++			return err;
++
++		send_ops++;
++	}
++
++	return num_ops == send_ops ? 0 : -EINVAL;
++}
++
+ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ {
+ 	struct xe_debug_metadata *m;
+@@ -3146,6 +3182,10 @@ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ 		err = vm_create_event(d, xef, vm);
+ 		if (err)
+ 			break;
++
++		err = vm_discover_binds(d, vm);
++		if (err)
++			break;
+ 	}
+ 	mutex_unlock(&xef->vm.lock);
+ 
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-EU-control-interface.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-EU-control-interface.patch
@@ -1,0 +1,779 @@
+From da565f52052f9d69d28fc32ec00641b3b201f83b Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Wed, 2 Aug 2023 12:27:19 +0200
+Subject: drm/xe/eudebug: Introduce EU control interface
+
+Introduce EU control functionality, which allows EU debugger
+to interrupt, resume, and inform about the current state of
+EU threads during execution. Provide an abstraction layer,
+so in the future guc will only need to provide appropriate callbacks.
+
+Based on implementation created by authors and other folks within
+i915 driver.
+
+v2: checkpatch (Maciej)
+v3: - lrc index off by one fix (Mika)
+    - checkpatch (Tilak)
+
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 27fa7b27e8ebde99cacad8e51b1cf8dfcce63f48 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h  |   2 +
+ drivers/gpu/drm/xe/xe_eudebug.c       | 515 +++++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_eudebug_types.h |  23 ++
+ drivers/gpu/drm/xe/xe_gt_debug.c      |  12 +-
+ drivers/gpu/drm/xe/xe_gt_debug.h      |   6 +
+ include/uapi/drm/xe_drm_eudebug.h     |  21 +-
+ 6 files changed, 559 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index 313ca00f3a0d..41ff01abea1b 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -450,6 +450,8 @@
+ #define   THREAD_EX_ARB_MODE			REG_GENMASK(3, 2)
+ #define   THREAD_EX_ARB_MODE_RR_AFTER_DEP	REG_FIELD_PREP(THREAD_EX_ARB_MODE, 0x2)
+ 
++#define TD_CLR(i)				XE_REG_MCR(0xe490 + (i) * 4)
++
+ #define ROW_CHICKEN3				XE_REG_MCR(0xe49c, XE_REG_OPTION_MASKED)
+ #define   XE2_EUPEND_CHK_FLUSH_DIS		REG_BIT(14)
+ #define   DIS_FIX_EOT1_FLUSH			REG_BIT(9)
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 3cc476bb7279..959dba812c57 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -35,6 +35,7 @@
+ #include "xe_reg_sr.h"
+ #include "xe_pm.h"
+ #include "xe_rtp.h"
++#include "xe_gt_mcr.h"
+ 
+ #include "xe_eudebug_types.h"
+ #include "xe_eudebug.h"
+@@ -579,6 +580,70 @@ static int find_handle(struct xe_eudebug_resources *res,
+ 	return id;
+ }
+ 
++static struct xe_eudebug_handle *__find_resource(struct xe_eudebug_resources *res,
++						 const int type,
++						 const u32 id)
++{
++	struct xe_eudebug_resource *r;
++
++	r = resource_from_type(res, type);
++
++	return xa_load(&r->xa, id);
++}
++
++static struct xe_eudebug_handle *find_resource(struct xe_eudebug_resources *res,
++					       const int type,
++					       const u32 id)
++{
++	struct xe_eudebug_handle *h;
++
++	mutex_lock(&res->lock);
++	h = __find_resource(res, type, id);
++	mutex_unlock(&res->lock);
++
++	return h;
++}
++
++static struct xe_file *find_client(struct xe_eudebug *d, const u32 id)
++{
++	struct xe_eudebug_handle *h;
++
++	h = find_resource(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, id);
++	if (h)
++		return (void *)h->key;
++
++	return NULL;
++}
++
++static struct xe_exec_queue *find_exec_queue_get(struct xe_eudebug *d,
++						 u32 id)
++{
++	struct xe_exec_queue *q = NULL;
++	struct xe_eudebug_handle *h;
++
++	mutex_lock(&d->res->lock);
++	h = __find_resource(d->res, XE_EUDEBUG_RES_TYPE_EXEC_QUEUE, id);
++	if (h) {
++		q = (struct xe_exec_queue *)h->key;
++		xe_exec_queue_get(q);
++	}
++	mutex_unlock(&d->res->lock);
++
++	return q;
++}
++
++static struct xe_lrc *find_lrc(struct xe_eudebug *d, const u32 id)
++{
++	struct xe_lrc *l = NULL;
++	struct xe_eudebug_handle *h;
++
++	h = find_resource(d->res, XE_EUDEBUG_RES_TYPE_LRC, id);
++	if (h)
++		return (void *)h->key;
++
++	return l;
++}
++
+ static int _xe_eudebug_add_handle(struct xe_eudebug *d,
+ 				  int type,
+ 				  void *p,
+@@ -832,6 +897,170 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 	return ret;
+ }
+ 
++static int do_eu_control(struct xe_eudebug *d,
++			 const struct drm_xe_eudebug_eu_control * const arg,
++			 struct drm_xe_eudebug_eu_control __user * const user_ptr)
++{
++	void __user * const bitmask_ptr = u64_to_user_ptr(arg->bitmask_ptr);
++	struct xe_device *xe = d->xe;
++	u8 *bits = NULL;
++	unsigned int hw_attn_size, attn_size;
++	struct xe_exec_queue *q;
++	struct xe_file *xef;
++	struct xe_lrc *lrc;
++	u64 seqno;
++	int ret;
++
++	if (xe_eudebug_detached(d))
++		return -ENOTCONN;
++
++	/* Accept only hardware reg granularity mask */
++	if (XE_IOCTL_DBG(xe, !IS_ALIGNED(arg->bitmask_size, sizeof(u32))))
++		return -EINVAL;
++
++	xef = find_client(d, arg->client_handle);
++	if (XE_IOCTL_DBG(xe, !xef))
++		return -EINVAL;
++
++	q = find_exec_queue_get(d, arg->exec_queue_handle);
++	if (XE_IOCTL_DBG(xe, !q))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, !xe_exec_queue_is_debuggable(q))) {
++		ret = -EINVAL;
++		goto queue_put;
++	}
++
++	if (XE_IOCTL_DBG(xe, xef != q->vm->xef)) {
++		ret = -EINVAL;
++		goto queue_put;
++	}
++
++	lrc = find_lrc(d, arg->lrc_handle);
++	if (XE_IOCTL_DBG(xe, !lrc)) {
++		ret = -EINVAL;
++		goto queue_put;
++	}
++
++	hw_attn_size = xe_gt_eu_attention_bitmap_size(q->gt);
++	attn_size = arg->bitmask_size;
++
++	if (attn_size > hw_attn_size)
++		attn_size = hw_attn_size;
++
++	if (attn_size > 0) {
++		bits = kmalloc(attn_size, GFP_KERNEL);
++		if (!bits) {
++			ret =  -ENOMEM;
++			goto queue_put;
++		}
++
++		if (copy_from_user(bits, bitmask_ptr, attn_size)) {
++			ret = -EFAULT;
++			goto out_free;
++		}
++	}
++
++	if (!pm_runtime_active(xe->drm.dev)) {
++		ret = -EIO;
++		goto out_free;
++	}
++
++	ret = -EINVAL;
++	mutex_lock(&d->eu_lock);
++
++	switch (arg->cmd) {
++	case DRM_XE_EUDEBUG_EU_CONTROL_CMD_INTERRUPT_ALL:
++		/* Make sure we dont promise anything but interrupting all */
++		if (!attn_size)
++			ret = d->ops->interrupt_all(d, q, lrc);
++		break;
++	case DRM_XE_EUDEBUG_EU_CONTROL_CMD_STOPPED:
++		ret = d->ops->stopped(d, q, lrc, bits, attn_size);
++		break;
++	case DRM_XE_EUDEBUG_EU_CONTROL_CMD_RESUME:
++		ret = d->ops->resume(d, q, lrc, bits, attn_size);
++		break;
++	default:
++		break;
++	}
++
++	if (ret == 0)
++		seqno = atomic_long_inc_return(&d->events.seqno);
++
++	mutex_unlock(&d->eu_lock);
++
++	if (ret)
++		goto out_free;
++
++	if (put_user(seqno, &user_ptr->seqno)) {
++		ret = -EFAULT;
++		goto out_free;
++	}
++
++	if (copy_to_user(bitmask_ptr, bits, attn_size)) {
++		ret = -EFAULT;
++		goto out_free;
++	}
++
++	if (hw_attn_size != arg->bitmask_size)
++		if (put_user(hw_attn_size, &user_ptr->bitmask_size))
++			ret = -EFAULT;
++
++out_free:
++	kfree(bits);
++queue_put:
++	xe_exec_queue_put(q);
++
++	return ret;
++}
++
++static long xe_eudebug_eu_control(struct xe_eudebug *d, const u64 arg)
++{
++	struct drm_xe_eudebug_eu_control __user * const user_ptr =
++		u64_to_user_ptr(arg);
++	struct drm_xe_eudebug_eu_control user_arg;
++	struct xe_device *xe = d->xe;
++	int ret;
++
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) & _IOC_WRITE)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) & _IOC_READ)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, _IOC_SIZE(DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) != sizeof(user_arg)))
++		return -EINVAL;
++
++	if (copy_from_user(&user_arg,
++			   user_ptr,
++			   sizeof(user_arg)))
++		return -EFAULT;
++
++	if (XE_IOCTL_DBG(xe, user_arg.flags))
++		return -EINVAL;
++
++	if (!access_ok(u64_to_user_ptr(user_arg.bitmask_ptr), user_arg.bitmask_size))
++		return -EFAULT;
++
++	eu_dbg(d,
++	       "eu_control: client_handle=%llu, cmd=%u, flags=0x%x, exec_queue_handle=%llu, bitmask_size=%u\n",
++	       user_arg.client_handle, user_arg.cmd, user_arg.flags, user_arg.exec_queue_handle,
++	       user_arg.bitmask_size);
++
++	if (XE_IOCTL_DBG(xe, IS_ERR(find_client(d, user_arg.client_handle))))
++		return -EINVAL; /* As this is user input */
++
++	ret = do_eu_control(d, &user_arg, user_ptr);
++
++	eu_dbg(d,
++	       "eu_control: client_handle=%llu, cmd=%u, flags=0x%x, exec_queue_handle=%llu, bitmask_size=%u ret=%d\n",
++	       user_arg.client_handle, user_arg.cmd, user_arg.flags, user_arg.exec_queue_handle,
++	       user_arg.bitmask_size, ret);
++
++	return ret;
++}
++
+ static long xe_eudebug_ioctl(struct file *file,
+ 			     unsigned int cmd,
+ 			     unsigned long arg)
+@@ -844,6 +1073,10 @@ static long xe_eudebug_ioctl(struct file *file,
+ 		ret = xe_eudebug_read_event(d, arg,
+ 					    !(file->f_flags & O_NONBLOCK));
+ 		break;
++	case DRM_XE_EUDEBUG_IOCTL_EU_CONTROL:
++		ret = xe_eudebug_eu_control(d, arg);
++		eu_dbg(d, "ioctl cmd=EU_CONTROL ret=%ld\n", ret);
++		break;
+ 
+ 	default:
+ 		ret = -EINVAL;
+@@ -1002,23 +1235,17 @@ static struct xe_hw_engine *get_runalone_active_hw_engine(struct xe_gt *gt)
+ 	return first;
+ }
+ 
+-static struct xe_exec_queue *runalone_active_queue_get(struct xe_gt *gt, int *lrc_idx)
++static struct xe_exec_queue *active_hwe_to_exec_queue(struct xe_hw_engine *hwe, int *lrc_idx)
+ {
+-	struct xe_device *xe = gt_to_xe(gt);
++	struct xe_device *xe = gt_to_xe(hwe->gt);
++	struct xe_gt *gt = hwe->gt;
+ 	struct xe_exec_queue *q, *found = NULL;
+-	struct xe_hw_engine *active;
+ 	struct xe_file *xef;
+ 	unsigned long i, j;
+ 	int idx, err;
+ 	u32 lrc_hw;
+ 
+-	active = get_runalone_active_hw_engine(gt);
+-	if (!active) {
+-		drm_dbg(&gt_to_xe(gt)->drm, "Runalone engine not found!");
+-		return ERR_PTR(-ENOENT);
+-	}
+-
+-	err = current_lrca(active, &lrc_hw);
++	err = current_lrca(hwe, &lrc_hw);
+ 	if (err)
+ 		return ERR_PTR(err);
+ 
+@@ -1035,7 +1262,7 @@ static struct xe_exec_queue *runalone_active_queue_get(struct xe_gt *gt, int *lr
+ 			if (q->gt != gt)
+ 				goto cont_search;
+ 
+-			if (q->class != active->class)
++			if (q->class != hwe->class)
+ 				goto cont_search;
+ 
+ 			if (xe_exec_queue_is_idle(q))
+@@ -1068,7 +1295,7 @@ static struct xe_exec_queue *runalone_active_queue_get(struct xe_gt *gt, int *lr
+ 		return ERR_PTR(-ENOENT);
+ 	}
+ 
+-	if (XE_WARN_ON(current_lrca(active, &lrc_hw)) &&
++	if (XE_WARN_ON(current_lrca(hwe, &lrc_hw)) &&
+ 	    XE_WARN_ON(match_exec_queue_lrca(found, lrc_hw) < 0)) {
+ 		xe_exec_queue_put(found);
+ 		return ERR_PTR(-ENOENT);
+@@ -1077,6 +1304,19 @@ static struct xe_exec_queue *runalone_active_queue_get(struct xe_gt *gt, int *lr
+ 	return found;
+ }
+ 
++static struct xe_exec_queue *runalone_active_queue_get(struct xe_gt *gt, int *lrc_idx)
++{
++	struct xe_hw_engine *active;
++
++	active = get_runalone_active_hw_engine(gt);
++	if (!active) {
++		drm_dbg(&gt_to_xe(gt)->drm, "Runalone engine not found!");
++		return ERR_PTR(-ENOENT);
++	}
++
++	return active_hwe_to_exec_queue(active, lrc_idx);
++}
++
+ static int send_attention_event(struct xe_eudebug *d, struct xe_exec_queue *q, int lrc_idx)
+ {
+ 	struct xe_eudebug_event_eu_attention *ea;
+@@ -1125,7 +1365,6 @@ static int send_attention_event(struct xe_eudebug *d, struct xe_exec_queue *q, i
+ 	return xe_eudebug_queue_event(d, event);
+ }
+ 
+-
+ static int xe_send_gt_attention(struct xe_gt *gt)
+ {
+ 	struct xe_eudebug *d;
+@@ -1233,6 +1472,255 @@ static void attention_scan_flush(struct xe_device *xe)
+ 	mod_delayed_work(system_wq, &xe->eudebug.attention_scan, 0);
+ }
+ 
++static int xe_eu_control_interrupt_all(struct xe_eudebug *d,
++				       struct xe_exec_queue *q,
++				       struct xe_lrc *lrc)
++{
++	struct xe_gt *gt = q->hwe->gt;
++	struct xe_device *xe = d->xe;
++	struct xe_exec_queue *active;
++	struct xe_hw_engine *hwe;
++	int lrc_idx, ret;
++	u32 lrc_hw;
++	u32 td_ctl;
++
++	hwe = get_runalone_active_hw_engine(gt);
++	if (XE_IOCTL_DBG(xe, !hwe)) {
++		drm_dbg(&gt_to_xe(gt)->drm, "Runalone engine not found!");
++		return -EINVAL;
++	}
++
++	active = active_hwe_to_exec_queue(hwe, &lrc_idx);
++	if (XE_IOCTL_DBG(xe, IS_ERR(active)))
++		return PTR_ERR(active);
++
++	if (XE_IOCTL_DBG(xe, q != active)) {
++		xe_exec_queue_put(active);
++		return -EINVAL;
++	}
++	xe_exec_queue_put(active);
++
++	if (XE_IOCTL_DBG(xe, lrc_idx >= q->width || q->lrc[lrc_idx] != lrc)) {
++		ret = -EINVAL;
++		goto put_fw;
++	}
++
++	ret = xe_force_wake_get(gt_to_fw(gt), hwe->domain);
++	if (ret)
++		goto put_fw;
++
++	/* Additional check just before issuing MMIO writes */
++	ret = __current_lrca(hwe, &lrc_hw);
++	if (ret)
++		goto put_fw;
++
++	if (!lrca_equals(lower_32_bits(xe_lrc_descriptor(lrc)), lrc_hw)) {
++		ret = -EBUSY;
++		goto put_fw;
++	}
++
++	td_ctl = xe_gt_mcr_unicast_read_any(gt, TD_CTL);
++
++	/* Halt on next thread dispatch */
++	if (!(td_ctl & TD_CTL_FORCE_EXTERNAL_HALT))
++		xe_gt_mcr_multicast_write(gt, TD_CTL,
++					  td_ctl | TD_CTL_FORCE_EXTERNAL_HALT);
++	else
++		eu_warn(d, "TD_CTL force external halt bit already set!\n");
++
++	/*
++	 * The sleep is needed because some interrupts are ignored
++	 * by the HW, hence we allow the HW some time to acknowledge
++	 * that.
++	 */
++	usleep_range(100, 110);
++
++	/* Halt regardless of thread dependencies */
++	if (!(td_ctl & TD_CTL_FORCE_EXCEPTION))
++		xe_gt_mcr_multicast_write(gt, TD_CTL,
++					  td_ctl | TD_CTL_FORCE_EXCEPTION);
++	else
++		eu_warn(d, "TD_CTL force exception bit already set!\n");
++
++	usleep_range(100, 110);
++
++	xe_gt_mcr_multicast_write(gt, TD_CTL, td_ctl &
++				  ~(TD_CTL_FORCE_EXTERNAL_HALT | TD_CTL_FORCE_EXCEPTION));
++
++	/*
++	 * In case of stopping wrong ctx emit warning.
++	 * Nothing else we can do for now.
++	 */
++	ret = __current_lrca(hwe, &lrc_hw);
++	if (ret || !lrca_equals(lower_32_bits(xe_lrc_descriptor(lrc)), lrc_hw))
++		eu_warn(d, "xe_eudebug: interrupted wrong context.");
++
++put_fw:
++	xe_force_wake_put(gt_to_fw(gt), q->hwe->domain);
++
++	return ret;
++}
++
++struct ss_iter {
++	struct xe_eudebug *debugger;
++	unsigned int i;
++
++	unsigned int size;
++	u8 *bits;
++};
++
++static int check_attn_mcr(struct xe_gt *gt, void *data,
++			  u16 group, u16 instance)
++{
++	struct ss_iter *iter = data;
++	struct xe_eudebug *d = iter->debugger;
++	unsigned int row;
++
++	for (row = 0; row < TD_EU_ATTENTION_MAX_ROWS; row++) {
++		u32 val, cur = 0;
++
++		if (iter->i >= iter->size)
++			return 0;
++
++		if (XE_WARN_ON((iter->i + sizeof(val)) >
++				(xe_gt_eu_attention_bitmap_size(gt))))
++			return -EIO;
++
++		memcpy(&val, &iter->bits[iter->i], sizeof(val));
++		iter->i += sizeof(val);
++
++		cur = xe_gt_mcr_unicast_read(gt, TD_ATT(row), group, instance);
++
++		if ((val | cur) != cur) {
++			eu_dbg(d,
++			       "WRONG CLEAR (%u:%u:%u) TD_CRL: 0x%08x; TD_ATT: 0x%08x\n",
++			       group, instance, row, val, cur);
++			return -EINVAL;
++		}
++	}
++
++	return 0;
++}
++
++static int clear_attn_mcr(struct xe_gt *gt, void *data,
++			  u16 group, u16 instance)
++{
++	struct ss_iter *iter = data;
++	struct xe_eudebug *d = iter->debugger;
++	unsigned int row;
++
++	for (row = 0; row < TD_EU_ATTENTION_MAX_ROWS; row++) {
++		u32 val;
++
++		if (iter->i >= iter->size)
++			return 0;
++
++		if (XE_WARN_ON((iter->i + sizeof(val)) >
++				(xe_gt_eu_attention_bitmap_size(gt))))
++			return -EIO;
++
++		memcpy(&val, &iter->bits[iter->i], sizeof(val));
++		iter->i += sizeof(val);
++
++		if (!val)
++			continue;
++
++		xe_gt_mcr_unicast_write(gt, TD_CLR(row), val,
++					group, instance);
++
++		eu_dbg(d,
++		       "TD_CLR: (%u:%u:%u): 0x%08x\n",
++		       group, instance, row, val);
++	}
++
++	return 0;
++}
++
++static int xe_eu_control_resume(struct xe_eudebug *d,
++				struct xe_exec_queue *q,
++				struct xe_lrc *lrc,
++				u8 *bits, unsigned int bitmask_size)
++{
++	struct xe_device *xe = d->xe;
++	struct ss_iter iter = {
++		.debugger = d,
++		.i = 0,
++		.size = bitmask_size,
++		.bits = bits
++	};
++	int ret = 0;
++	struct xe_exec_queue *active;
++	int lrc_idx;
++
++	active = runalone_active_queue_get(q->gt, &lrc_idx);
++	if (IS_ERR(active))
++		return PTR_ERR(active);
++
++	if (XE_IOCTL_DBG(xe, q != active)) {
++		xe_exec_queue_put(active);
++		return -EBUSY;
++	}
++	xe_exec_queue_put(active);
++
++	if (XE_IOCTL_DBG(xe, lrc_idx >= q->width || q->lrc[lrc_idx] != lrc))
++		return -EBUSY;
++
++	/*
++	 * hsdes: 18021122357
++	 * We need to avoid clearing attention bits that are not set
++	 * in order to avoid the EOT hang on PVC.
++	 */
++	if (GRAPHICS_VERx100(d->xe) == 1260) {
++		ret = xe_gt_foreach_dss_group_instance(q->gt, check_attn_mcr, &iter);
++		if (ret)
++			return ret;
++
++		iter.i = 0;
++	}
++
++	xe_gt_foreach_dss_group_instance(q->gt, clear_attn_mcr, &iter);
++	return 0;
++}
++
++static int xe_eu_control_stopped(struct xe_eudebug *d,
++				 struct xe_exec_queue *q,
++				 struct xe_lrc *lrc,
++				 u8 *bits, unsigned int bitmask_size)
++{
++	struct xe_device *xe = d->xe;
++	struct xe_exec_queue *active;
++	int lrc_idx;
++
++	if (XE_WARN_ON(!q) || XE_WARN_ON(!q->gt))
++		return -EINVAL;
++
++	active = runalone_active_queue_get(q->gt, &lrc_idx);
++	if (IS_ERR(active))
++		return PTR_ERR(active);
++
++	if (active) {
++		if (XE_IOCTL_DBG(xe, q != active)) {
++			xe_exec_queue_put(active);
++			return -EBUSY;
++		}
++
++		if (XE_IOCTL_DBG(xe, lrc_idx >= q->width || q->lrc[lrc_idx] != lrc)) {
++			xe_exec_queue_put(active);
++			return -EBUSY;
++		}
++	}
++
++	xe_exec_queue_put(active);
++
++	return xe_gt_eu_attention_bitmap(q->gt, bits, bitmask_size);
++}
++
++static struct xe_eudebug_eu_control_ops eu_control = {
++	.interrupt_all = xe_eu_control_interrupt_all,
++	.stopped = xe_eu_control_stopped,
++	.resume = xe_eu_control_resume,
++};
++
+ static void discovery_work_fn(struct work_struct *work);
+ 
+ static int
+@@ -1295,6 +1783,7 @@ xe_eudebug_connect(struct xe_device *xe,
+ 	kref_get(&d->ref);
+ 	queue_work(xe->eudebug.ordered_wq, &d->discovery_work);
+ 	attention_scan_flush(xe);
++	d->ops = &eu_control;
+ 
+ 	eu_dbg(d, "connected session %lld", d->session);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
+index 16667b4dfe45..a75986180d71 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug_types.h
++++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
+@@ -18,8 +18,12 @@
+ 
+ struct xe_device;
+ struct task_struct;
++struct xe_eudebug;
+ struct xe_eudebug_event;
++struct xe_hw_engine;
+ struct workqueue_struct;
++struct xe_exec_queue;
++struct xe_lrc;
+ 
+ #define CONFIG_DRM_XE_DEBUGGER_EVENT_QUEUE_SIZE 64
+ 
+@@ -65,6 +69,23 @@ struct xe_eudebug_resources {
+ 	struct xe_eudebug_resource rt[XE_EUDEBUG_RES_TYPE_COUNT];
+ };
+ 
++/**
++ * struct xe_eudebug_eu_control_ops - interface for eu thread
++ * state control backend
++ */
++struct xe_eudebug_eu_control_ops {
++	/** @interrupt_all: interrupts workload active on given hwe */
++	int (*interrupt_all)(struct xe_eudebug *e, struct xe_exec_queue *q,
++			     struct xe_lrc *lrc);
++
++	/** @resume: resumes threads reflected by bitmask active on given hwe */
++	int (*resume)(struct xe_eudebug *e, struct xe_exec_queue *q,
++		      struct xe_lrc *lrc, u8 *bitmap, unsigned int bitmap_size);
++
++	/** @stopped: returns bitmap reflecting threads which signal attention */
++	int (*stopped)(struct xe_eudebug *e, struct xe_exec_queue *q,
++		       struct xe_lrc *lrc, u8 *bitmap, unsigned int bitmap_size);
++};
+ /**
+  * struct xe_eudebug - Top level struct for eudebug: the connection
+  */
+@@ -128,6 +149,8 @@ struct xe_eudebug {
+ 		atomic_long_t seqno;
+ 	} events;
+ 
++	/** @ops operations for eu_control */
++	struct xe_eudebug_eu_control_ops *ops;
+ };
+ 
+ /**
+diff --git a/drivers/gpu/drm/xe/xe_gt_debug.c b/drivers/gpu/drm/xe/xe_gt_debug.c
+index d36684c7514d..fcf32c7c77d8 100644
+--- a/drivers/gpu/drm/xe/xe_gt_debug.c
++++ b/drivers/gpu/drm/xe/xe_gt_debug.c
+@@ -13,12 +13,12 @@
+ #include "xe_pm.h"
+ #include "xe_macros.h"
+ 
+-static int xe_gt_foreach_dss_group_instance(struct xe_gt *gt,
+-					    int (*fn)(struct xe_gt *gt,
+-						      void *data,
+-						      u16 group,
+-						      u16 instance),
+-					    void *data)
++int xe_gt_foreach_dss_group_instance(struct xe_gt *gt,
++				     int (*fn)(struct xe_gt *gt,
++					       void *data,
++					       u16 group,
++					       u16 instance),
++				     void *data)
+ {
+ 	const enum xe_force_wake_domains fw_domains = XE_FW_GT | XE_FW_RENDER;
+ 	unsigned int dss;
+diff --git a/drivers/gpu/drm/xe/xe_gt_debug.h b/drivers/gpu/drm/xe/xe_gt_debug.h
+index 3f13dbb17a5f..342082699ff6 100644
+--- a/drivers/gpu/drm/xe/xe_gt_debug.h
++++ b/drivers/gpu/drm/xe/xe_gt_debug.h
+@@ -13,6 +13,12 @@
+ #define XE_GT_ATTENTION_TIMEOUT_MS 100
+ 
+ int xe_gt_eu_threads_needing_attention(struct xe_gt *gt);
++int xe_gt_foreach_dss_group_instance(struct xe_gt *gt,
++				     int (*fn)(struct xe_gt *gt,
++					       void *data,
++					       u16 group,
++					       u16 instance),
++				     void *data);
+ 
+ int xe_gt_eu_attention_bitmap_size(struct xe_gt *gt);
+ int xe_gt_eu_attention_bitmap(struct xe_gt *gt, u8 *bits,
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+index 1e63bdede5f2..3c43aefefedd 100644
+--- a/include/uapi/drm/xe_drm_eudebug.h
++++ b/include/uapi/drm/xe_drm_eudebug.h
+@@ -15,7 +15,8 @@ extern "C" {
+  *
+  * This ioctl is available in debug version 1.
+  */
+-#define DRM_XE_EUDEBUG_IOCTL_READ_EVENT _IO('j', 0x0)
++#define DRM_XE_EUDEBUG_IOCTL_READ_EVENT		_IO('j', 0x0)
++#define DRM_XE_EUDEBUG_IOCTL_EU_CONTROL		_IOWR('j', 0x2, struct drm_xe_eudebug_eu_control)
+ 
+ /* XXX: Document events to match their internal counterparts when moved to xe_drm.h */
+ struct drm_xe_eudebug_event {
+@@ -74,6 +75,24 @@ struct drm_xe_eudebug_event_eu_attention {
+ 	__u8 bitmask[];
+ };
+ 
++struct drm_xe_eudebug_eu_control {
++	__u64 client_handle;
++
++#define DRM_XE_EUDEBUG_EU_CONTROL_CMD_INTERRUPT_ALL	0
++#define DRM_XE_EUDEBUG_EU_CONTROL_CMD_STOPPED		1
++#define DRM_XE_EUDEBUG_EU_CONTROL_CMD_RESUME		2
++	__u32 cmd;
++	__u32 flags;
++
++	__u64 seqno;
++
++	__u64 exec_queue_handle;
++	__u64 lrc_handle;
++	__u32 reserved;
++	__u32 bitmask_size;
++	__u64 bitmask_ptr;
++};
++
+ #if defined(__cplusplus)
+ }
+ #endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-discovery-for-resources.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-discovery-for-resources.patch
@@ -1,0 +1,225 @@
+From 4379edff907aa286f4dd2b196e926ea6950ee675 Mon Sep 17 00:00:00 2001
+From: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Date: Tue, 31 Jan 2023 11:40:42 +0200
+Subject: drm/xe/eudebug: Introduce discovery for resources
+
+Debugger connection can happen way after the client has
+created and destroyed arbitrary number of resources.
+
+We need to playback all currently existing resources for the
+debugger. The client is held until this so called discovery
+process, executed by workqueue, is complete.
+
+This patch is based on discovery work by Maciej Patelczyk
+for i915 driver.
+
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Co-developed-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+(cherry picked from commit acf0700d860a7b27fa2021f7f967bab44e06f623 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c        |  6 +-
+ drivers/gpu/drm/xe/xe_device_types.h  |  3 +
+ drivers/gpu/drm/xe/xe_eudebug.c       | 92 +++++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_eudebug_types.h |  7 ++
+ 4 files changed, 107 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 8ceb0d4684b1..06e612899191 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -306,6 +306,9 @@ static void xe_device_destroy(struct drm_device *dev, void *dummy)
+ 	if (xe->unordered_wq)
+ 		destroy_workqueue(xe->unordered_wq);
+ 
++	if (xe->eudebug.ordered_wq)
++		destroy_workqueue(xe->eudebug.ordered_wq);
++
+ 	ttm_device_fini(&xe->ttm);
+ }
+ 
+@@ -376,8 +379,9 @@ struct xe_device *xe_device_create(struct pci_dev *pdev,
+ 	xe->preempt_fence_wq = alloc_ordered_workqueue("xe-preempt-fence-wq", 0);
+ 
+ 	xe->ordered_wq = alloc_ordered_workqueue("xe-ordered-wq", 0);
++	xe->eudebug.ordered_wq = alloc_ordered_workqueue("xe-eudebug-ordered-wq", 0);
+ 	xe->unordered_wq = alloc_workqueue("xe-unordered-wq", 0, 0);
+-	if (!xe->ordered_wq || !xe->unordered_wq ||
++	if (!xe->ordered_wq || !xe->unordered_wq || !xe->eudebug.ordered_wq ||
+ 	    !xe->preempt_fence_wq) {
+ 		/*
+ 		 * Cleanup done in xe_device_destroy via
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index 3ee74d006171..a677e141da7f 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -513,6 +513,9 @@ struct xe_device {
+ 
+ 		/** @available: is the debugging functionality available */
+ 		bool available;
++
++		/** @ordered_wq: used to discovery */
++		struct workqueue_struct *ordered_wq;
+ 	} eudebug;
+ 
+ 	/* private: */
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 38e01e9f0b4d..e2e67739c299 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -428,6 +428,12 @@ xe_eudebug_get(struct xe_file *xef)
+ 	if (!d)
+ 		return NULL;
+ 
++	if (!xe_eudebug_detached(d) &&
++	    !completion_done(&d->discovery) &&
++	    wait_for_completion_killable_timeout(&d->discovery,
++						 HZ * 40) <= 0)
++		xe_eudebug_disconnect(d, -ETIMEDOUT);
++
+ 	if (xe_eudebug_detached(d)) {
+ 		xe_eudebug_put(d);
+ 		return NULL;
+@@ -835,6 +841,8 @@ static const struct file_operations fops = {
+ 	.unlocked_ioctl	= xe_eudebug_ioctl,
+ };
+ 
++static void discovery_work_fn(struct work_struct *work);
++
+ static int
+ xe_eudebug_connect(struct xe_device *xe,
+ 		   struct drm_xe_eudebug_connect *param)
+@@ -869,9 +877,11 @@ xe_eudebug_connect(struct xe_device *xe,
+ 	spin_lock_init(&d->connection.lock);
+ 	init_waitqueue_head(&d->events.write_done);
+ 	init_waitqueue_head(&d->events.read_done);
++	init_completion(&d->discovery);
+ 
+ 	spin_lock_init(&d->events.lock);
+ 	INIT_KFIFO(d->events.fifo);
++	INIT_WORK(&d->discovery_work, discovery_work_fn);
+ 
+ 	d->res = xe_eudebug_resources_alloc();
+ 	if (IS_ERR(d->res)) {
+@@ -889,6 +899,9 @@ xe_eudebug_connect(struct xe_device *xe,
+ 		goto err_detach;
+ 	}
+ 
++	kref_get(&d->ref);
++	queue_work(xe->eudebug.ordered_wq, &d->discovery_work);
++
+ 	eu_dbg(d, "connected session %lld", d->session);
+ 
+ 	return fd;
+@@ -1107,3 +1120,82 @@ void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm)
+ 
+ 	xe_eudebug_event_put(d, vm_destroy_event(d, xef, vm));
+ }
++
++static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
++{
++	struct xe_vm *vm;
++	unsigned long i;
++	int err;
++
++	err = client_create_event(d, xef);
++	if (err)
++		return err;
++
++	mutex_lock(&xef->vm.lock);
++	xa_for_each(&xef->vm.xa, i, vm) {
++		err = vm_create_event(d, xef, vm);
++		if (err)
++			break;
++	}
++	mutex_unlock(&xef->vm.lock);
++
++	return err;
++}
++
++static bool xe_eudebug_task_match(struct xe_eudebug *d, struct xe_file *xef)
++{
++	struct task_struct *task;
++	bool match;
++
++	task = find_task_get(xef);
++	if (!task)
++		return false;
++
++	match = same_thread_group(d->target_task, task);
++
++	put_task_struct(task);
++
++	return match;
++}
++
++static void discover_clients(struct xe_device *xe, struct xe_eudebug *d)
++{
++	struct xe_file *xef;
++	unsigned long i;
++	int err;
++
++	mutex_lock(&xe->files.lock);
++	xa_for_each(&xe->files.xa, i, xef) {
++		if (xe_eudebug_detached(d))
++			break;
++
++		if (xe_eudebug_task_match(d, xef))
++			err = discover_client(d, xef);
++		else
++			err = 0;
++
++		if (err) {
++			eu_dbg(d, "discover client %p: %d\n", xef, err);
++			xe_eudebug_disconnect(d, err);
++			break;
++		}
++	}
++	mutex_unlock(&xe->files.lock);
++}
++
++static void discovery_work_fn(struct work_struct *work)
++{
++	struct xe_eudebug *d = container_of(work, typeof(*d),
++					    discovery_work);
++	struct xe_device *xe = d->xe;
++
++	eu_dbg(d, "Discovery start for %lld\n", d->session);
++
++	discover_clients(xe, d);
++
++	eu_dbg(d, "Discovery end for %lld\n", d->session);
++
++	complete_all(&d->discovery);
++
++	xe_eudebug_put(d);
++}
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
+index 093221a707df..202ddf41a325 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug_types.h
++++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
+@@ -19,6 +19,7 @@
+ struct xe_device;
+ struct task_struct;
+ struct xe_eudebug_event;
++struct workqueue_struct;
+ 
+ #define CONFIG_DRM_XE_DEBUGGER_EVENT_QUEUE_SIZE 64
+ 
+@@ -96,6 +97,12 @@ struct xe_eudebug {
+ 	/** @session: session number for this connection (for logs) */
+ 	u64 session;
+ 
++	/** @discovery: completion to wait for discovery */
++	struct completion discovery;
++
++	/** @discovery_work: worker to discover resources for target_task */
++	struct work_struct discovery_work;
++
+ 	/** @events: kfifo queue of to-be-delivered events */
+ 	struct {
+ 		/** @lock: guards access to fifo */
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch
@@ -1,0 +1,1726 @@
+From 60ac26b63c74f5c625dbac6f178e5581b36f33e4 Mon Sep 17 00:00:00 2001
+From: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Date: Thu, 5 Jan 2023 11:06:00 +0200
+Subject: drm/xe/eudebug: Introduce eudebug support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With eudebug event interface, user space debugger process (like gdb)
+is able to keep track of resources created by another process
+(debuggee using drm/xe) and act upon these resources.
+
+For example, debugger can find a client vm which contains isa/elf
+for a particular shader/eu-kernel and then inspect and modify it
+(for example installing a breakpoint).
+
+Debugger first opens a connection to xe with a drm ioctl specifying
+target pid to connect. This returns an anon fd handle that can then be
+used to listen for events with dedicated ioctl.
+
+This patch introduces eudebug connection and event queuing, adding
+client create/destroy and vm create/destroy events as a baseline.
+More events for full debugger operation are needed and
+those will be introduced in follow up patches.
+
+The resource tracking parts are inspired by the work of
+Maciej Patelczyk on resource handling for i915. Chris Wilson
+suggested improvement of two ways mapping which makes it easy to
+use resource map as a definitive bookkeep of what resources
+are played to debugger in the discovery phase (on follow up patch).
+
+v2: - Kconfig support (Matthew)
+    - ptraced access control (Lucas)
+    - pass expected event length to user (Zbigniew)
+    - only track long running VMs
+    - checkpatch (Tilak)
+
+Cc: Maarten Lankhorst <maarten.lankhorst@linux.intel.com>
+Cc: Lucas De Marchi <lucas.demarchi@intel.com>
+Cc: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Cc: Andi Shyti <andi.shyti@linux.intel.com>
+Cc: Matt Roper <matthew.d.roper@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Zbigniew Kempczyński <zbigniew.kempczynski@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+(cherry picked from commit c023ae0974b82a1f8add54cbf1b54dbd41a0a279 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/Kconfig            |   10 +
+ drivers/gpu/drm/xe/Makefile           |    2 +
+ drivers/gpu/drm/xe/xe_device.c        |   27 +
+ drivers/gpu/drm/xe/xe_device_types.h  |   26 +
+ drivers/gpu/drm/xe/xe_eudebug.c       | 1109 +++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_eudebug.h       |   46 +
+ drivers/gpu/drm/xe/xe_eudebug_types.h |  169 ++++
+ drivers/gpu/drm/xe/xe_vm.c            |    7 +-
+ include/uapi/drm/xe_drm.h             |   21 +
+ include/uapi/drm/xe_drm_eudebug.h     |   56 ++
+ 10 files changed, 1472 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/gpu/drm/xe/xe_eudebug.c
+ create mode 100644 drivers/gpu/drm/xe/xe_eudebug.h
+ create mode 100644 drivers/gpu/drm/xe/xe_eudebug_types.h
+ create mode 100644 include/uapi/drm/xe_drm_eudebug.h
+
+diff --git a/drivers/gpu/drm/xe/Kconfig b/drivers/gpu/drm/xe/Kconfig
+index 7bbe46a98ff1..23f34e8e3151 100644
+--- a/drivers/gpu/drm/xe/Kconfig
++++ b/drivers/gpu/drm/xe/Kconfig
+@@ -85,6 +85,16 @@ config DRM_XE_FORCE_PROBE
+ 
+ 	  Use "!*" to block the probe of the driver for all known devices.
+ 
++config DRM_XE_EUDEBUG
++	bool "Enable gdb debugger support (eudebug)"
++	depends on DRM_XE
++	default y
++	help
++	  Choose this option if you want to add support for debugger (gdb) to
++	  attach into process using Xe and debug the gpu/gpgpu programs.
++	  With debugger support, Xe will provide interface for a debugger to
++	  process to track, inspect and modify resources.
++
+ menu "drm/Xe Debugging"
+ depends on DRM_XE
+ depends on EXPERT
+diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
+index 1ff9602a52f6..8d0fc9caacc6 100644
+--- a/drivers/gpu/drm/xe/Makefile
++++ b/drivers/gpu/drm/xe/Makefile
+@@ -143,6 +143,8 @@ xe-$(CONFIG_PCI_IOV) += \
+ 	xe_pci_sriov.o \
+ 	xe_sriov_pf.o
+ 
++xe-$(CONFIG_DRM_XE_EUDEBUG) += xe_eudebug.o
++
+ # include helpers for tests even when XE is built-in
+ ifdef CONFIG_DRM_XE_KUNIT_TEST
+ xe-y += tests/xe_kunit_helpers.o
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index c89deffffb6d..8ceb0d4684b1 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -55,6 +55,7 @@
+ #include "xe_vram.h"
+ #include "xe_wait_user_fence.h"
+ #include "xe_wa.h"
++#include "xe_eudebug.h"
+ 
+ #include <generated/xe_wa_oob.h>
+ 
+@@ -79,6 +80,15 @@ static int xe_file_open(struct drm_device *dev, struct drm_file *file)
+ 	xef->client = client;
+ 	xef->xe = xe;
+ 
++	mutex_lock(&xe->files.lock);
++	ret = xa_alloc(&xe->files.xa, &xef->id, xef, xa_limit_32b, GFP_KERNEL);
++	mutex_unlock(&xe->files.lock);
++	if (ret) {
++		xe_drm_client_put(client);
++		kfree(xef);
++		return -ENOMEM;
++	}
++
+ 	mutex_init(&xef->vm.lock);
+ 	xa_init_flags(&xef->vm.xa, XA_FLAGS_ALLOC1);
+ 
+@@ -92,6 +102,8 @@ static int xe_file_open(struct drm_device *dev, struct drm_file *file)
+ 	file->driver_priv = xef;
+ 	kref_init(&xef->refcount);
+ 
++	xe_eudebug_file_open(xef);
++
+ 	return 0;
+ }
+ 
+@@ -149,6 +161,12 @@ static void xe_file_close(struct drm_device *dev, struct drm_file *file)
+ 
+ 	xe_pm_runtime_get(xe);
+ 
++	xe_eudebug_file_close(xef);
++
++	mutex_lock(&xef->xe->files.lock);
++	xa_erase(&xef->xe->files.xa, xef->id);
++	mutex_unlock(&xef->xe->files.lock);
++
+ 	/*
+ 	 * No need for exec_queue.lock here as there is no contention for it
+ 	 * when FD is closing as IOCTLs presumably can't be modifying the
+@@ -187,6 +205,7 @@ static const struct drm_ioctl_desc xe_ioctls[] = {
+ 	DRM_IOCTL_DEF_DRV(XE_WAIT_USER_FENCE, xe_wait_user_fence_ioctl,
+ 			  DRM_RENDER_ALLOW),
+ 	DRM_IOCTL_DEF_DRV(XE_OBSERVATION, xe_observation_ioctl, DRM_RENDER_ALLOW),
++	DRM_IOCTL_DEF_DRV(XE_EUDEBUG_CONNECT, xe_eudebug_connect_ioctl, DRM_RENDER_ALLOW),
+ };
+ 
+ static long xe_drm_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
+@@ -276,6 +295,8 @@ static void xe_device_destroy(struct drm_device *dev, void *dummy)
+ {
+ 	struct xe_device *xe = to_xe_device(dev);
+ 
++	xe_eudebug_fini(xe);
++
+ 	if (xe->preempt_fence_wq)
+ 		destroy_workqueue(xe->preempt_fence_wq);
+ 
+@@ -321,6 +342,9 @@ struct xe_device *xe_device_create(struct pci_dev *pdev,
+ 	spin_lock_init(&xe->irq.lock);
+ 	spin_lock_init(&xe->clients.lock);
+ 
++	drmm_mutex_init(&xe->drm, &xe->files.lock);
++	xa_init_flags(&xe->files.xa, XA_FLAGS_ALLOC);
++
+ 	init_waitqueue_head(&xe->ufence_wq);
+ 
+ 	err = drmm_mutex_init(&xe->drm, &xe->usm.lock);
+@@ -347,7 +371,10 @@ struct xe_device *xe_device_create(struct pci_dev *pdev,
+ 	INIT_LIST_HEAD(&xe->pinned.external_vram);
+ 	INIT_LIST_HEAD(&xe->pinned.evicted);
+ 
++	xe_eudebug_init(xe);
++
+ 	xe->preempt_fence_wq = alloc_ordered_workqueue("xe-preempt-fence-wq", 0);
++
+ 	xe->ordered_wq = alloc_ordered_workqueue("xe-ordered-wq", 0);
+ 	xe->unordered_wq = alloc_workqueue("xe-unordered-wq", 0, 0);
+ 	if (!xe->ordered_wq || !xe->unordered_wq ||
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index 4219d82a60a2..3ee74d006171 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -355,6 +355,15 @@ struct xe_device {
+ 		u64 count;
+ 	} clients;
+ 
++	/** @files: xe_file array (opens) */
++	struct {
++		/** @xa: xe files xarray */
++		struct xarray xa;
++
++		/** @lock: Protects xe_file list */
++		struct mutex lock;
++	} files;
++
+ 	/** @usm: unified memory state */
+ 	struct {
+ 		/** @usm.asid: convert a ASID to VM */
+@@ -492,6 +501,20 @@ struct xe_device {
+ 	u8 vm_inject_error_position;
+ #endif
+ 
++	/** @debugger connection list and globals for device */
++	struct {
++		/** @lock: protects the list of connections */
++		spinlock_t lock;
++		/** @list: list of connections, aka debuggers */
++		struct list_head list;
++
++		/** @session_count: session counter to track connections */
++		u64 session_count;
++
++		/** @available: is the debugging functionality available */
++		bool available;
++	} eudebug;
++
+ 	/* private: */
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_DISPLAY)
+@@ -584,6 +607,9 @@ struct xe_file {
+ 
+ 	/** @refcount: ref count of this xe file */
+ 	struct kref refcount;
++
++	/** @id: id into xe_device.files.xa */
++	u32 id;
+ };
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+new file mode 100644
+index 000000000000..38e01e9f0b4d
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -0,0 +1,1109 @@
++// SPDX-License-Identifier: MIT
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#include <linux/uaccess.h>
++
++#include <linux/anon_inodes.h>
++#include <linux/poll.h>
++#include <linux/delay.h>
++
++#include <drm/drm_managed.h>
++
++#include "xe_device.h"
++#include "xe_assert.h"
++#include "xe_macros.h"
++#include "xe_vm.h"
++
++#include "xe_eudebug_types.h"
++#include "xe_eudebug.h"
++
++/*
++ * If there is no detected event read by userspace, during this period, assume
++ * userspace problem and disconnect debugger to allow forward progress.
++ */
++#define XE_EUDEBUG_NO_READ_DETECTED_TIMEOUT_MS (25 * 1000)
++
++#define for_each_debugger_rcu(debugger, head) \
++	list_for_each_entry_rcu((debugger), (head), connection_link)
++#define for_each_debugger(debugger, head) \
++	list_for_each_entry((debugger), (head), connection_link)
++
++#define cast_event(T, event) container_of((event), typeof(*(T)), base)
++
++#define XE_EUDEBUG_DBG_STR "eudbg: %lld:%lu:%s (%d/%d) -> (%d/%d): "
++#define XE_EUDEBUG_DBG_ARGS(d) (d)->session, \
++		atomic_long_read(&(d)->events.seqno), \
++		READ_ONCE(d->connection.status) <= 0 ? "disconnected" : "", \
++		current->pid, \
++		task_tgid_nr(current), \
++		(d)->target_task->pid, \
++		task_tgid_nr((d)->target_task)
++
++#define eu_err(d, fmt, ...) drm_err(&(d)->xe->drm, XE_EUDEBUG_DBG_STR # fmt, \
++				    XE_EUDEBUG_DBG_ARGS(d), ##__VA_ARGS__)
++#define eu_warn(d, fmt, ...) drm_warn(&(d)->xe->drm, XE_EUDEBUG_DBG_STR # fmt, \
++				      XE_EUDEBUG_DBG_ARGS(d), ##__VA_ARGS__)
++#define eu_dbg(d, fmt, ...) drm_dbg(&(d)->xe->drm, XE_EUDEBUG_DBG_STR # fmt, \
++				    XE_EUDEBUG_DBG_ARGS(d), ##__VA_ARGS__)
++
++#define xe_eudebug_assert(d, ...) xe_assert((d)->xe, ##__VA_ARGS__)
++
++#define struct_member(T, member) (((T *)0)->member)
++
++/* Keep 1:1 parity with uapi events */
++#define write_member(T_out, ptr, member, value) { \
++	BUILD_BUG_ON(sizeof(*ptr) != sizeof(T_out)); \
++	BUILD_BUG_ON(offsetof(typeof(*ptr), member) != \
++		     offsetof(typeof(T_out), member)); \
++	BUILD_BUG_ON(sizeof(ptr->member) != sizeof(value)); \
++	BUILD_BUG_ON(sizeof(struct_member(T_out, member)) != sizeof(value)); \
++	BUILD_BUG_ON(!typecheck(typeof((ptr)->member), value));	\
++	(ptr)->member = (value); \
++	}
++
++static struct xe_eudebug_event *
++event_fifo_pending(struct xe_eudebug *d)
++{
++	struct xe_eudebug_event *event;
++
++	if (kfifo_peek(&d->events.fifo, &event))
++		return event;
++
++	return NULL;
++}
++
++/*
++ * This is racy as we dont take the lock for read but all the
++ * callsites can handle the race so we can live without lock.
++ */
++__no_kcsan
++static unsigned int
++event_fifo_num_events_peek(const struct xe_eudebug * const d)
++{
++	return kfifo_len(&d->events.fifo);
++}
++
++static bool
++xe_eudebug_detached(struct xe_eudebug *d)
++{
++	int status;
++
++	spin_lock(&d->connection.lock);
++	status = d->connection.status;
++	spin_unlock(&d->connection.lock);
++
++	return status <= 0;
++}
++
++static int
++xe_eudebug_error(const struct xe_eudebug * const d)
++{
++	const int status = READ_ONCE(d->connection.status);
++
++	return status <= 0 ? status : 0;
++}
++
++static unsigned int
++event_fifo_has_events(struct xe_eudebug *d)
++{
++	if (xe_eudebug_detached(d))
++		return 1;
++
++	return event_fifo_num_events_peek(d);
++}
++
++static const struct rhashtable_params rhash_res = {
++	.head_offset = offsetof(struct xe_eudebug_handle, rh_head),
++	.key_len = sizeof_field(struct xe_eudebug_handle, key),
++	.key_offset = offsetof(struct xe_eudebug_handle, key),
++	.automatic_shrinking = true,
++};
++
++static struct xe_eudebug_resource *
++resource_from_type(struct xe_eudebug_resources * const res, const int t)
++{
++	return &res->rt[t];
++}
++
++static struct xe_eudebug_resources *
++xe_eudebug_resources_alloc(void)
++{
++	struct xe_eudebug_resources *res;
++	int err;
++	int i;
++
++	res = kzalloc(sizeof(*res), GFP_ATOMIC);
++	if (!res)
++		return ERR_PTR(-ENOMEM);
++
++	mutex_init(&res->lock);
++
++	for (i = 0; i < XE_EUDEBUG_RES_TYPE_COUNT; i++) {
++		xa_init_flags(&res->rt[i].xa, XA_FLAGS_ALLOC1);
++		err = rhashtable_init(&res->rt[i].rh, &rhash_res);
++
++		if (err)
++			break;
++	}
++
++	if (err) {
++		while (i--) {
++			xa_destroy(&res->rt[i].xa);
++			rhashtable_destroy(&res->rt[i].rh);
++		}
++
++		kfree(res);
++		return ERR_PTR(err);
++	}
++
++	return res;
++}
++
++static void res_free_fn(void *ptr, void *arg)
++{
++	XE_WARN_ON(ptr);
++	kfree(ptr);
++}
++
++static void
++xe_eudebug_destroy_resources(struct xe_eudebug *d)
++{
++	struct xe_eudebug_resources *res = d->res;
++	struct xe_eudebug_handle *h;
++	unsigned long j;
++	int i;
++	int err;
++
++	mutex_lock(&res->lock);
++	for (i = 0; i < XE_EUDEBUG_RES_TYPE_COUNT; i++) {
++		struct xe_eudebug_resource *r = &res->rt[i];
++
++		xa_for_each(&r->xa, j, h) {
++			struct xe_eudebug_handle *t;
++
++			err = rhashtable_remove_fast(&r->rh,
++						     &h->rh_head,
++						     rhash_res);
++			xe_eudebug_assert(d, !err);
++			t = xa_erase(&r->xa, h->id);
++			xe_eudebug_assert(d, t == h);
++			kfree(t);
++		}
++	}
++	mutex_unlock(&res->lock);
++
++	for (i = 0; i < XE_EUDEBUG_RES_TYPE_COUNT; i++) {
++		struct xe_eudebug_resource *r = &res->rt[i];
++
++		rhashtable_free_and_destroy(&r->rh, res_free_fn, NULL);
++		xe_eudebug_assert(d, xa_empty(&r->xa));
++		xa_destroy(&r->xa);
++	}
++
++	mutex_destroy(&res->lock);
++
++	kfree(res);
++}
++
++static void xe_eudebug_free(struct kref *ref)
++{
++	struct xe_eudebug *d = container_of(ref, typeof(*d), ref);
++	struct xe_eudebug_event *event;
++
++	while (kfifo_get(&d->events.fifo, &event))
++		kfree(event);
++
++	xe_eudebug_destroy_resources(d);
++	put_task_struct(d->target_task);
++
++	xe_eudebug_assert(d, !kfifo_len(&d->events.fifo));
++
++	kfree_rcu(d, rcu);
++}
++
++static void xe_eudebug_put(struct xe_eudebug *d)
++{
++	kref_put(&d->ref, xe_eudebug_free);
++}
++
++static struct task_struct *find_get_target(const pid_t nr)
++{
++	struct task_struct *task;
++
++	rcu_read_lock();
++	task = pid_task(find_pid_ns(nr, task_active_pid_ns(current)), PIDTYPE_PID);
++	if (task)
++		get_task_struct(task);
++	rcu_read_unlock();
++
++	return task;
++}
++
++static int
++xe_eudebug_attach(struct xe_device *xe, struct xe_eudebug *d,
++		  const pid_t pid_nr)
++{
++	struct task_struct *target;
++	struct xe_eudebug *iter;
++	int ret = 0;
++
++	target = find_get_target(pid_nr);
++	if (!target)
++		return -ENOENT;
++
++	if (!ptrace_may_access(target, PTRACE_MODE_READ_REALCREDS)) {
++		put_task_struct(target);
++		return -EACCES;
++	}
++
++	XE_WARN_ON(d->connection.status != 0);
++
++	spin_lock(&xe->eudebug.lock);
++	for_each_debugger(iter, &xe->eudebug.list) {
++		if (!same_thread_group(iter->target_task, target))
++			continue;
++
++		ret = -EBUSY;
++	}
++
++	if (!ret && xe->eudebug.session_count + 1 == 0)
++		ret = -ENOSPC;
++
++	if (!ret) {
++		d->connection.status = XE_EUDEBUG_STATUS_CONNECTED;
++		d->xe = xe;
++		d->target_task = target;
++		d->session = ++xe->eudebug.session_count;
++		kref_get(&d->ref);
++		list_add_tail_rcu(&d->connection_link, &xe->eudebug.list);
++	}
++	spin_unlock(&xe->eudebug.lock);
++
++	if (ret)
++		put_task_struct(target);
++
++	return ret;
++}
++
++static bool xe_eudebug_detach(struct xe_device *xe,
++			      struct xe_eudebug *d,
++			      const int err)
++{
++	bool detached = false;
++
++	XE_WARN_ON(err > 0);
++
++	spin_lock(&d->connection.lock);
++	if (d->connection.status == XE_EUDEBUG_STATUS_CONNECTED) {
++		d->connection.status = err;
++		detached = true;
++	}
++	spin_unlock(&d->connection.lock);
++
++	if (!detached)
++		return false;
++
++	spin_lock(&xe->eudebug.lock);
++	list_del_rcu(&d->connection_link);
++	spin_unlock(&xe->eudebug.lock);
++
++	eu_dbg(d, "session %lld detached with %d", d->session, err);
++
++	/* Our ref with the connection_link */
++	xe_eudebug_put(d);
++
++	return true;
++}
++
++static int _xe_eudebug_disconnect(struct xe_eudebug *d,
++				  const int err)
++{
++	wake_up_all(&d->events.write_done);
++	wake_up_all(&d->events.read_done);
++
++	return xe_eudebug_detach(d->xe, d, err);
++}
++
++#define xe_eudebug_disconnect(_d, _err) ({ \
++	if (_xe_eudebug_disconnect((_d), (_err))) { \
++		if ((_err) == 0 || (_err) == -ETIMEDOUT) \
++			eu_dbg(d, "Session closed (%d)", (_err)); \
++		else \
++			eu_err(d, "Session disconnected, err = %d (%s:%d)", \
++			       (_err), __func__, __LINE__); \
++	} \
++})
++
++static int xe_eudebug_release(struct inode *inode, struct file *file)
++{
++	struct xe_eudebug *d = file->private_data;
++
++	xe_eudebug_disconnect(d, 0);
++	xe_eudebug_put(d);
++
++	return 0;
++}
++
++static __poll_t xe_eudebug_poll(struct file *file, poll_table *wait)
++{
++	struct xe_eudebug * const d = file->private_data;
++	__poll_t ret = 0;
++
++	poll_wait(file, &d->events.write_done, wait);
++
++	if (xe_eudebug_detached(d)) {
++		ret |= EPOLLHUP;
++		if (xe_eudebug_error(d))
++			ret |= EPOLLERR;
++	}
++
++	if (event_fifo_num_events_peek(d))
++		ret |= EPOLLIN;
++
++	return ret;
++}
++
++static ssize_t xe_eudebug_read(struct file *file,
++			       char __user *buf,
++			       size_t count,
++			       loff_t *ppos)
++{
++	return -EINVAL;
++}
++
++static struct xe_eudebug *
++xe_eudebug_for_task_get(struct xe_device *xe,
++			struct task_struct *task)
++{
++	struct xe_eudebug *d, *iter;
++
++	d = NULL;
++
++	rcu_read_lock();
++	for_each_debugger_rcu(iter, &xe->eudebug.list) {
++		if (!same_thread_group(iter->target_task, task))
++			continue;
++
++		if (kref_get_unless_zero(&iter->ref))
++			d = iter;
++
++		break;
++	}
++	rcu_read_unlock();
++
++	return d;
++}
++
++static struct task_struct *find_task_get(struct xe_file *xef)
++{
++	struct task_struct *task;
++	struct pid *pid;
++
++	rcu_read_lock();
++	pid = rcu_dereference(xef->drm->pid);
++	task = pid_task(pid, PIDTYPE_PID);
++	if (task)
++		get_task_struct(task);
++	rcu_read_unlock();
++
++	return task;
++}
++
++static struct xe_eudebug *
++xe_eudebug_get(struct xe_file *xef)
++{
++	struct task_struct *task;
++	struct xe_eudebug *d;
++
++	d = NULL;
++	task = find_task_get(xef);
++	if (task) {
++		d = xe_eudebug_for_task_get(to_xe_device(xef->drm->minor->dev),
++					    task);
++		put_task_struct(task);
++	}
++
++	if (!d)
++		return NULL;
++
++	if (xe_eudebug_detached(d)) {
++		xe_eudebug_put(d);
++		return NULL;
++	}
++
++	return d;
++}
++
++static int xe_eudebug_queue_event(struct xe_eudebug *d,
++				  struct xe_eudebug_event *event)
++{
++	const u64 wait_jiffies = msecs_to_jiffies(1000);
++	u64 last_read_detected_ts, last_head_seqno, start_ts;
++
++	xe_eudebug_assert(d, event->len > sizeof(struct xe_eudebug_event));
++	xe_eudebug_assert(d, event->type);
++	xe_eudebug_assert(d, event->type != DRM_XE_EUDEBUG_EVENT_READ);
++
++	start_ts = ktime_get();
++	last_read_detected_ts = start_ts;
++	last_head_seqno = 0;
++
++	do  {
++		struct xe_eudebug_event *head;
++		u64 head_seqno;
++		bool was_queued;
++
++		if (xe_eudebug_detached(d))
++			break;
++
++		spin_lock(&d->events.lock);
++		head = event_fifo_pending(d);
++		if (head)
++			head_seqno = event->seqno;
++		else
++			head_seqno = 0;
++
++		was_queued = kfifo_in(&d->events.fifo, &event, 1);
++		spin_unlock(&d->events.lock);
++
++		wake_up_all(&d->events.write_done);
++
++		if (was_queued) {
++			event = NULL;
++			break;
++		}
++
++		XE_WARN_ON(!head_seqno);
++
++		/* If we detect progress, restart timeout */
++		if (last_head_seqno != head_seqno)
++			last_read_detected_ts = ktime_get();
++
++		last_head_seqno = head_seqno;
++
++		wait_event_interruptible_timeout(d->events.read_done,
++						 !kfifo_is_full(&d->events.fifo),
++						 wait_jiffies);
++
++	} while (ktime_ms_delta(ktime_get(), last_read_detected_ts) <
++		 XE_EUDEBUG_NO_READ_DETECTED_TIMEOUT_MS);
++
++	if (event) {
++		eu_dbg(d,
++		       "event %llu queue failed (blocked %lld ms, avail %d)",
++		       event ? event->seqno : 0,
++		       ktime_ms_delta(ktime_get(), start_ts),
++		       kfifo_avail(&d->events.fifo));
++
++		kfree(event);
++
++		return -ETIMEDOUT;
++	}
++
++	return 0;
++}
++
++static struct xe_eudebug_handle *
++alloc_handle(const int type, const u64 key)
++{
++	struct xe_eudebug_handle *h;
++
++	h = kzalloc(sizeof(*h), GFP_ATOMIC);
++	if (!h)
++		return NULL;
++
++	h->key = key;
++
++	return h;
++}
++
++static struct xe_eudebug_handle *
++__find_handle(struct xe_eudebug_resource *r,
++	      const u64 key)
++{
++	struct xe_eudebug_handle *h;
++
++	h = rhashtable_lookup_fast(&r->rh,
++				   &key,
++				   rhash_res);
++	return h;
++}
++
++static int find_handle(struct xe_eudebug_resources *res,
++		       const int type,
++		       const void *p)
++{
++	const u64 key = (u64)p;
++	struct xe_eudebug_resource *r;
++	struct xe_eudebug_handle *h;
++	int id;
++
++	if (XE_WARN_ON(!key))
++		return -EINVAL;
++
++	r = resource_from_type(res, type);
++
++	mutex_lock(&res->lock);
++	h = __find_handle(r, key);
++	id = h ? h->id : -ENOENT;
++	mutex_unlock(&res->lock);
++
++	return id;
++}
++
++static int _xe_eudebug_add_handle(struct xe_eudebug *d,
++				  int type,
++				  void *p,
++				  u64 *seqno,
++				  int *handle)
++{
++	const u64 key = (u64)p;
++	struct xe_eudebug_resource *r;
++	struct xe_eudebug_handle *h, *o;
++	int err;
++
++	if (XE_WARN_ON(!p))
++		return -EINVAL;
++
++	if (xe_eudebug_detached(d))
++		return -ENOTCONN;
++
++	h = alloc_handle(type, key);
++	if (!h)
++		return -ENOMEM;
++
++	r = resource_from_type(d->res, type);
++
++	mutex_lock(&d->res->lock);
++	o = __find_handle(r, key);
++	if (!o) {
++		err = xa_alloc(&r->xa, &h->id, h, xa_limit_31b, GFP_KERNEL);
++
++		if (h->id >= INT_MAX) {
++			xa_erase(&r->xa, h->id);
++			err = -ENOSPC;
++		}
++
++		if (!err)
++			err = rhashtable_insert_fast(&r->rh,
++						     &h->rh_head,
++						     rhash_res);
++
++		if (err) {
++			xa_erase(&r->xa, h->id);
++		} else {
++			if (seqno)
++				*seqno = atomic_long_inc_return(&d->events.seqno);
++		}
++	} else {
++		xe_eudebug_assert(d, o->id);
++		err = -EEXIST;
++	}
++	mutex_unlock(&d->res->lock);
++
++	if (handle)
++		*handle = o ? o->id : h->id;
++
++	if (err) {
++		kfree(h);
++		XE_WARN_ON(err > 0);
++		return err;
++	}
++
++	xe_eudebug_assert(d, h->id);
++
++	return h->id;
++}
++
++static int xe_eudebug_add_handle(struct xe_eudebug *d,
++				 int type,
++				 void *p,
++				 u64 *seqno)
++{
++	int ret;
++
++	ret = _xe_eudebug_add_handle(d, type, p, seqno, NULL);
++	if (ret == -EEXIST || ret == -ENOTCONN) {
++		eu_dbg(d, "%d on adding %d", ret, type);
++		return 0;
++	}
++
++	if (ret < 0)
++		xe_eudebug_disconnect(d, ret);
++
++	return ret;
++}
++
++static int _xe_eudebug_remove_handle(struct xe_eudebug *d, int type, void *p,
++				     u64 *seqno)
++{
++	const u64 key = (u64)p;
++	struct xe_eudebug_resource *r;
++	struct xe_eudebug_handle *h, *xa_h;
++	int ret;
++
++	if (XE_WARN_ON(!key))
++		return -EINVAL;
++
++	if (xe_eudebug_detached(d))
++		return -ENOTCONN;
++
++	r = resource_from_type(d->res, type);
++
++	mutex_lock(&d->res->lock);
++	h = __find_handle(r, key);
++	if (h) {
++		ret = rhashtable_remove_fast(&r->rh,
++					     &h->rh_head,
++					     rhash_res);
++		xe_eudebug_assert(d, !ret);
++		xa_h = xa_erase(&r->xa, h->id);
++		xe_eudebug_assert(d, xa_h == h);
++		if (!ret) {
++			ret = h->id;
++			if (seqno)
++				*seqno = atomic_long_inc_return(&d->events.seqno);
++		}
++	} else {
++		ret = -ENOENT;
++	}
++	mutex_unlock(&d->res->lock);
++
++	kfree(h);
++
++	xe_eudebug_assert(d, ret);
++
++	return ret;
++}
++
++static int xe_eudebug_remove_handle(struct xe_eudebug *d, int type, void *p,
++				    u64 *seqno)
++{
++	int ret;
++
++	ret = _xe_eudebug_remove_handle(d, type, p, seqno);
++	if (ret == -ENOENT || ret == -ENOTCONN) {
++		eu_dbg(d, "%d on removing %d", ret, type);
++		return 0;
++	}
++
++	if (ret < 0)
++		xe_eudebug_disconnect(d, ret);
++
++	return ret;
++}
++
++static struct xe_eudebug_event *
++__xe_eudebug_create_event(struct xe_eudebug *d,
++			  u64 seqno, u16 type, u16 flags, u32 len, gfp_t gfp)
++{
++	struct xe_eudebug_event *event;
++
++	xe_eudebug_assert(d, len > sizeof(*event));
++
++	event = kzalloc(len, gfp);
++	if (!event)
++		return NULL;
++
++	event->type = type;
++	event->flags = flags;
++	event->len = len;
++	event->seqno = seqno;
++
++	return event;
++}
++
++static struct xe_eudebug_event *
++xe_eudebug_create_event(struct xe_eudebug *d, u16 type, u64 seqno, u16 flags,
++			u32 len, gfp_t gfp)
++{
++	return __xe_eudebug_create_event(d, seqno, type, flags, len, gfp);
++}
++
++static long xe_eudebug_read_event(struct xe_eudebug *d,
++				  const u64 arg,
++				  const bool wait)
++{
++	struct xe_device *xe = d->xe;
++	struct drm_xe_eudebug_event __user * const user_orig =
++		u64_to_user_ptr(arg);
++	struct drm_xe_eudebug_event user_event;
++	struct xe_eudebug_event *event;
++	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_VM;
++	long ret = 0;
++
++	if (XE_IOCTL_DBG(xe, copy_from_user(&user_event, user_orig, sizeof(user_event))))
++		return -EFAULT;
++
++	if (XE_IOCTL_DBG(xe, !user_event.type))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, user_event.type > max_event))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, user_event.type != DRM_XE_EUDEBUG_EVENT_READ))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, user_event.len < sizeof(*user_orig)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, user_event.flags))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, user_event.reserved))
++		return -EINVAL;
++
++	/* XXX: define wait time in connect arguments ? */
++	if (wait) {
++		ret = wait_event_interruptible_timeout(d->events.write_done,
++						       event_fifo_has_events(d),
++						       msecs_to_jiffies(5 * 1000));
++
++		if (XE_IOCTL_DBG(xe, ret < 0))
++			return ret;
++	}
++
++	ret = 0;
++	spin_lock(&d->events.lock);
++	event = event_fifo_pending(d);
++	if (event) {
++		if (user_event.len < event->len) {
++			ret = -EMSGSIZE;
++		} else if (!kfifo_out(&d->events.fifo, &event, 1)) {
++			eu_warn(d, "internal fifo corruption");
++			ret = -ENOTCONN;
++		}
++	}
++	spin_unlock(&d->events.lock);
++
++	wake_up_all(&d->events.read_done);
++
++	if (ret == -EMSGSIZE && put_user(event->len, &user_orig->len))
++		ret = -EFAULT;
++
++	if (XE_IOCTL_DBG(xe, ret))
++		return ret;
++
++	if (!event) {
++		if (xe_eudebug_detached(d))
++			return -ENOTCONN;
++		if (!wait)
++			return -EAGAIN;
++
++		return -ENOENT;
++	}
++
++	if (copy_to_user(user_orig, event, event->len))
++		ret = -EFAULT;
++	else
++		eu_dbg(d, "event read: type=%u, flags=0x%x, seqno=%llu", event->type,
++		       event->flags, event->seqno);
++
++	kfree(event);
++
++	return ret;
++}
++
++static long xe_eudebug_ioctl(struct file *file,
++			     unsigned int cmd,
++			     unsigned long arg)
++{
++	struct xe_eudebug * const d = file->private_data;
++	long ret;
++
++	switch (cmd) {
++	case DRM_XE_EUDEBUG_IOCTL_READ_EVENT:
++		ret = xe_eudebug_read_event(d, arg,
++					    !(file->f_flags & O_NONBLOCK));
++		break;
++
++	default:
++		ret = -EINVAL;
++	}
++
++	return ret;
++}
++
++static const struct file_operations fops = {
++	.owner		= THIS_MODULE,
++	.llseek		= no_llseek,
++	.release	= xe_eudebug_release,
++	.poll		= xe_eudebug_poll,
++	.read		= xe_eudebug_read,
++	.unlocked_ioctl	= xe_eudebug_ioctl,
++};
++
++static int
++xe_eudebug_connect(struct xe_device *xe,
++		   struct drm_xe_eudebug_connect *param)
++{
++	const u64 known_open_flags = 0;
++	unsigned long f_flags = 0;
++	struct xe_eudebug *d;
++	int fd, err;
++
++	if (param->extensions)
++		return -EINVAL;
++
++	if (!param->pid)
++		return -EINVAL;
++
++	if (param->flags & ~known_open_flags)
++		return -EINVAL;
++
++	if (param->version && param->version != DRM_XE_EUDEBUG_VERSION)
++		return -EINVAL;
++
++	param->version = DRM_XE_EUDEBUG_VERSION;
++
++	if (!xe->eudebug.available)
++		return -EOPNOTSUPP;
++
++	d = kzalloc(sizeof(*d), GFP_KERNEL);
++	if (!d)
++		return -ENOMEM;
++
++	kref_init(&d->ref);
++	spin_lock_init(&d->connection.lock);
++	init_waitqueue_head(&d->events.write_done);
++	init_waitqueue_head(&d->events.read_done);
++
++	spin_lock_init(&d->events.lock);
++	INIT_KFIFO(d->events.fifo);
++
++	d->res = xe_eudebug_resources_alloc();
++	if (IS_ERR(d->res)) {
++		err = PTR_ERR(d->res);
++		goto err_free;
++	}
++
++	err = xe_eudebug_attach(xe, d, param->pid);
++	if (err)
++		goto err_free_res;
++
++	fd = anon_inode_getfd("[xe_eudebug]", &fops, d, f_flags);
++	if (fd < 0) {
++		err = fd;
++		goto err_detach;
++	}
++
++	eu_dbg(d, "connected session %lld", d->session);
++
++	return fd;
++
++err_detach:
++	xe_eudebug_detach(xe, d, err);
++err_free_res:
++	xe_eudebug_destroy_resources(d);
++err_free:
++	kfree(d);
++
++	return err;
++}
++
++int xe_eudebug_connect_ioctl(struct drm_device *dev,
++			     void *data,
++			     struct drm_file *file)
++{
++	struct xe_device *xe = to_xe_device(dev);
++	struct drm_xe_eudebug_connect * const param = data;
++	int ret = 0;
++
++	ret = xe_eudebug_connect(xe, param);
++
++	return ret;
++}
++
++void xe_eudebug_init(struct xe_device *xe)
++{
++	spin_lock_init(&xe->eudebug.lock);
++	INIT_LIST_HEAD(&xe->eudebug.list);
++
++	xe->eudebug.available = true;
++}
++
++void xe_eudebug_fini(struct xe_device *xe)
++{
++	xe_assert(xe, list_empty_careful(&xe->eudebug.list));
++}
++
++static int send_open_event(struct xe_eudebug *d, u32 flags, const u64 handle,
++			   const u64 seqno)
++{
++	struct xe_eudebug_event *event;
++	struct xe_eudebug_event_open *eo;
++
++	if (!handle)
++		return -EINVAL;
++
++	if (XE_WARN_ON((long)handle >= INT_MAX))
++		return -EINVAL;
++
++	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_OPEN, seqno,
++					flags, sizeof(*eo), GFP_KERNEL);
++	if (!event)
++		return -ENOMEM;
++
++	eo = cast_event(eo, event);
++
++	write_member(struct drm_xe_eudebug_event_client, eo,
++		     client_handle, handle);
++
++	return xe_eudebug_queue_event(d, event);
++}
++
++static int client_create_event(struct xe_eudebug *d, struct xe_file *xef)
++{
++	u64 seqno;
++	int ret;
++
++	ret = xe_eudebug_add_handle(d, XE_EUDEBUG_RES_TYPE_CLIENT, xef, &seqno);
++	if (ret > 0)
++		ret = send_open_event(d, DRM_XE_EUDEBUG_EVENT_CREATE,
++				      ret, seqno);
++
++	return ret;
++}
++
++static int client_destroy_event(struct xe_eudebug *d, struct xe_file *xef)
++{
++	u64 seqno;
++	int ret;
++
++	ret = xe_eudebug_remove_handle(d, XE_EUDEBUG_RES_TYPE_CLIENT,
++				       xef, &seqno);
++	if (ret > 0)
++		ret = send_open_event(d, DRM_XE_EUDEBUG_EVENT_DESTROY,
++				      ret, seqno);
++
++	return ret;
++}
++
++#define xe_eudebug_event_put(_d, _err) ({ \
++	if ((_err)) \
++		xe_eudebug_disconnect((_d), (_err)); \
++	xe_eudebug_put((_d)); \
++	})
++
++void xe_eudebug_file_open(struct xe_file *xef)
++{
++	struct xe_eudebug *d;
++
++	d = xe_eudebug_get(xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, client_create_event(d, xef));
++}
++
++void xe_eudebug_file_close(struct xe_file *xef)
++{
++	struct xe_eudebug *d;
++
++	d = xe_eudebug_get(xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, client_destroy_event(d, xef));
++}
++
++static int send_vm_event(struct xe_eudebug *d, u32 flags,
++			 const u64 client_handle,
++			 const u64 vm_handle,
++			 const u64 seqno)
++{
++	struct xe_eudebug_event *event;
++	struct xe_eudebug_event_vm *e;
++
++	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM,
++					seqno, flags, sizeof(*e), GFP_KERNEL);
++	if (!event)
++		return -ENOMEM;
++
++	e = cast_event(e, event);
++
++	write_member(struct drm_xe_eudebug_event_vm, e, client_handle, client_handle);
++	write_member(struct drm_xe_eudebug_event_vm, e, vm_handle, vm_handle);
++
++	return xe_eudebug_queue_event(d, event);
++}
++
++static int vm_create_event(struct xe_eudebug *d,
++			   struct xe_file *xef, struct xe_vm *vm)
++{
++	int h_c, h_vm;
++	u64 seqno;
++	int ret;
++
++	if (!xe_vm_in_lr_mode(vm))
++		return 0;
++
++	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
++	if (h_c < 0)
++		return h_c;
++
++	xe_eudebug_assert(d, h_c);
++
++	h_vm = xe_eudebug_add_handle(d, XE_EUDEBUG_RES_TYPE_VM, vm, &seqno);
++	if (h_vm <= 0)
++		return h_vm;
++
++	ret = send_vm_event(d, DRM_XE_EUDEBUG_EVENT_CREATE, h_c, h_vm, seqno);
++
++	return ret;
++}
++
++static int vm_destroy_event(struct xe_eudebug *d,
++			    struct xe_file *xef, struct xe_vm *vm)
++{
++	int h_c, h_vm;
++	u64 seqno;
++
++	if (!xe_vm_in_lr_mode(vm))
++		return 0;
++
++	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
++	if (h_c < 0) {
++		XE_WARN_ON("no client found for vm");
++		eu_warn(d, "no client found for vm");
++		return h_c;
++	}
++
++	xe_eudebug_assert(d, h_c);
++
++	h_vm = xe_eudebug_remove_handle(d, XE_EUDEBUG_RES_TYPE_VM, vm, &seqno);
++	if (h_vm <= 0)
++		return h_vm;
++
++	return send_vm_event(d, DRM_XE_EUDEBUG_EVENT_DESTROY, h_c, h_vm, seqno);
++}
++
++void xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm)
++{
++	struct xe_eudebug *d;
++
++	if (!xe_vm_in_lr_mode(vm))
++		return;
++
++	d = xe_eudebug_get(xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, vm_create_event(d, xef, vm));
++}
++
++void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm)
++{
++	struct xe_eudebug *d;
++
++	if (!xe_vm_in_lr_mode(vm))
++		return;
++
++	d = xe_eudebug_get(xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, vm_destroy_event(d, xef, vm));
++}
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+new file mode 100644
+index 000000000000..e3247365f72f
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_eudebug.h
+@@ -0,0 +1,46 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef _XE_EUDEBUG_H_
++
++struct drm_device;
++struct drm_file;
++struct xe_device;
++struct xe_file;
++struct xe_vm;
++
++#if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
++
++int xe_eudebug_connect_ioctl(struct drm_device *dev,
++			     void *data,
++			     struct drm_file *file);
++
++void xe_eudebug_init(struct xe_device *xe);
++void xe_eudebug_fini(struct xe_device *xe);
++
++void xe_eudebug_file_open(struct xe_file *xef);
++void xe_eudebug_file_close(struct xe_file *xef);
++
++void xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm);
++void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm);
++
++#else
++
++static inline int xe_eudebug_connect_ioctl(struct drm_device *dev,
++					   void *data,
++					   struct drm_file *file) { return 0; }
++
++static inline void xe_eudebug_init(struct xe_device *xe) { }
++static inline void xe_eudebug_fini(struct xe_device *xe) { }
++
++static inline void xe_eudebug_file_open(struct xe_file *xef) { }
++static inline void xe_eudebug_file_close(struct xe_file *xef) { }
++
++static inline void xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm) { }
++static inline void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm) { }
++
++#endif /* CONFIG_DRM_XE_EUDEBUG */
++
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
+new file mode 100644
+index 000000000000..093221a707df
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
+@@ -0,0 +1,169 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef __XE_EUDEBUG_TYPES_H_
++
++#include <linux/mutex.h>
++#include <linux/kref.h>
++#include <linux/kfifo.h>
++#include <linux/completion.h>
++#include <linux/wait.h>
++#include <linux/xarray.h>
++#include <linux/rbtree.h>
++#include <linux/rhashtable.h>
++
++#include <uapi/drm/xe_drm.h>
++
++struct xe_device;
++struct task_struct;
++struct xe_eudebug_event;
++
++#define CONFIG_DRM_XE_DEBUGGER_EVENT_QUEUE_SIZE 64
++
++/**
++ * struct xe_eudebug_handle - eudebug resource handle
++ */
++struct xe_eudebug_handle {
++	/** @key: key value in rhashtable <key:id> */
++	u64 key;
++
++	/** @id: opaque handle id for xarray <id:key> */
++	int id;
++
++	/** @rh_head: rhashtable head */
++	struct rhash_head rh_head;
++};
++
++/**
++ * struct xe_eudebug_resource - Resource map for one resource
++ */
++struct xe_eudebug_resource {
++	/** @xa: xarrays for <id->key> */
++	struct xarray xa;
++
++	/** @rh rhashtable for <key->id> */
++	struct rhashtable rh;
++};
++
++#define XE_EUDEBUG_RES_TYPE_CLIENT	0
++#define XE_EUDEBUG_RES_TYPE_VM		1
++#define XE_EUDEBUG_RES_TYPE_COUNT	(XE_EUDEBUG_RES_TYPE_VM + 1)
++
++/**
++ * struct xe_eudebug_resources - eudebug resources for all types
++ */
++struct xe_eudebug_resources {
++	/** @lock: guards access into rt */
++	struct mutex lock;
++
++	/** @rt: resource maps for all types */
++	struct xe_eudebug_resource rt[XE_EUDEBUG_RES_TYPE_COUNT];
++};
++
++/**
++ * struct xe_eudebug - Top level struct for eudebug: the connection
++ */
++struct xe_eudebug {
++	/** @ref: kref counter for this struct */
++	struct kref ref;
++
++	/** @rcu: rcu_head for rcu destruction */
++	struct rcu_head rcu;
++
++	/** @connection_link: our link into the xe_device:eudebug.list */
++	struct list_head connection_link;
++
++	struct {
++		/** @status: connected = 1, disconnected = error */
++#define XE_EUDEBUG_STATUS_CONNECTED 1
++		int status;
++
++		/** @lock: guards access to status */
++		spinlock_t lock;
++	} connection;
++
++	/** @xe: the parent device we are serving */
++	struct xe_device *xe;
++
++	/** @target_task: the task that we are debugging */
++	struct task_struct *target_task;
++
++	/** @res: the resource maps we track for target_task */
++	struct xe_eudebug_resources *res;
++
++	/** @session: session number for this connection (for logs) */
++	u64 session;
++
++	/** @events: kfifo queue of to-be-delivered events */
++	struct {
++		/** @lock: guards access to fifo */
++		spinlock_t lock;
++
++		/** @fifo: queue of events pending */
++		DECLARE_KFIFO(fifo,
++			      struct xe_eudebug_event *,
++			      CONFIG_DRM_XE_DEBUGGER_EVENT_QUEUE_SIZE);
++
++		/** @write_done: waitqueue for signalling write to fifo */
++		wait_queue_head_t write_done;
++
++		/** @read_done: waitqueue for signalling read from fifo */
++		wait_queue_head_t read_done;
++
++		/** @event_seqno: seqno counter to stamp events for fifo */
++		atomic_long_t seqno;
++	} events;
++
++};
++
++/**
++ * struct xe_eudebug_event - Internal base event struct for eudebug
++ */
++struct xe_eudebug_event {
++	/** @len: length of this event, including payload */
++	u32 len;
++
++	/** @type: message type */
++	u16 type;
++
++	/** @flags: message flags */
++	u16 flags;
++
++	/** @seqno: sequence number for ordering */
++	u64 seqno;
++
++	/** @reserved: reserved field MBZ */
++	u64 reserved;
++
++	/** @data: payload bytes */
++	u8 data[];
++};
++
++/**
++ * struct xe_eudebug_event_open - Internal event for client open/close
++ */
++struct xe_eudebug_event_open {
++	/** @base: base event */
++	struct xe_eudebug_event base;
++
++	/** @client_handle: opaque handle for client */
++	u64 client_handle;
++};
++
++/**
++ * struct xe_eudebug_event_vm - Internal event for vm open/close
++ */
++struct xe_eudebug_event_vm {
++	/** @base: base event */
++	struct xe_eudebug_event base;
++
++	/** @client_handle: client containing the vm open/close */
++	u64 client_handle;
++
++	/** @vm_handle: vm handle it's open/close */
++	u64 vm_handle;
++};
++
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 3e77eba14cfa..70cae0bac352 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -39,6 +39,7 @@
+ #include "xe_trace_bo.h"
+ #include "xe_wa.h"
+ #include "xe_hmm.h"
++#include "xe_eudebug.h"
+ 
+ static struct drm_gem_object *xe_vm_obj(struct xe_vm *vm)
+ {
+@@ -1812,6 +1813,8 @@ int xe_vm_create_ioctl(struct drm_device *dev, void *data,
+ 	args->reserved[0] = xe_bo_main_addr(vm->pt_root[0]->bo, XE_PAGE_SIZE);
+ #endif
+ 
++	xe_eudebug_vm_create(xef, vm);
++
+ 	return 0;
+ 
+ err_free_id:
+@@ -1847,8 +1850,10 @@ int xe_vm_destroy_ioctl(struct drm_device *dev, void *data,
+ 		xa_erase(&xef->vm.xa, args->vm_id);
+ 	mutex_unlock(&xef->vm.lock);
+ 
+-	if (!err)
++	if (!err) {
++		xe_eudebug_vm_destroy(xef, vm);
+ 		xe_vm_close_and_put(vm);
++	}
+ 
+ 	return err;
+ }
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index b6fbe4988f2e..7e66e9117f49 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -102,6 +102,7 @@ extern "C" {
+ #define DRM_XE_EXEC			0x09
+ #define DRM_XE_WAIT_USER_FENCE		0x0a
+ #define DRM_XE_OBSERVATION		0x0b
++#define DRM_XE_EUDEBUG_CONNECT		0x0c
+ 
+ /* Must be kept compact -- no holes */
+ 
+@@ -117,6 +118,7 @@ extern "C" {
+ #define DRM_IOCTL_XE_EXEC			DRM_IOW(DRM_COMMAND_BASE + DRM_XE_EXEC, struct drm_xe_exec)
+ #define DRM_IOCTL_XE_WAIT_USER_FENCE		DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_WAIT_USER_FENCE, struct drm_xe_wait_user_fence)
+ #define DRM_IOCTL_XE_OBSERVATION		DRM_IOW(DRM_COMMAND_BASE + DRM_XE_OBSERVATION, struct drm_xe_observation_param)
++#define DRM_IOCTL_XE_EUDEBUG_CONNECT		DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_EUDEBUG_CONNECT, struct drm_xe_eudebug_connect)
+ 
+ /**
+  * DOC: Xe IOCTL Extensions
+@@ -1694,6 +1696,25 @@ struct drm_xe_oa_stream_info {
+ 	__u64 reserved[3];
+ };
+ 
++/*
++ * Debugger ABI (ioctl and events) Version History:
++ * 0 - No debugger available
++ * 1 - Initial version
++ */
++#define DRM_XE_EUDEBUG_VERSION 1
++
++struct drm_xe_eudebug_connect {
++	/** @extensions: Pointer to the first extension struct, if any */
++	__u64 extensions;
++
++	__u64 pid; /* input: Target process ID */
++	__u32 flags; /* MBZ */
++
++	__u32 version; /* output: current ABI (ioctl / events) version */
++};
++
++#include "xe_drm_eudebug.h"
++
+ #if defined(__cplusplus)
+ }
+ #endif
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+new file mode 100644
+index 000000000000..acf6071c82bf
+--- /dev/null
++++ b/include/uapi/drm/xe_drm_eudebug.h
+@@ -0,0 +1,56 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef _UAPI_XE_DRM_EUDEBUG_H_
++#define _UAPI_XE_DRM_EUDEBUG_H_
++
++#if defined(__cplusplus)
++extern "C" {
++#endif
++
++/**
++ * Do a eudebug event read for a debugger connection.
++ *
++ * This ioctl is available in debug version 1.
++ */
++#define DRM_XE_EUDEBUG_IOCTL_READ_EVENT _IO('j', 0x0)
++
++/* XXX: Document events to match their internal counterparts when moved to xe_drm.h */
++struct drm_xe_eudebug_event {
++	__u32 len;
++
++	__u16 type;
++#define DRM_XE_EUDEBUG_EVENT_NONE		0
++#define DRM_XE_EUDEBUG_EVENT_READ		1
++#define DRM_XE_EUDEBUG_EVENT_OPEN		2
++#define DRM_XE_EUDEBUG_EVENT_VM			3
++
++	__u16 flags;
++#define DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
++#define DRM_XE_EUDEBUG_EVENT_DESTROY		(1 << 1)
++#define DRM_XE_EUDEBUG_EVENT_STATE_CHANGE	(1 << 2)
++#define DRM_XE_EUDEBUG_EVENT_NEED_ACK		(1 << 3)
++	__u64 seqno;
++	__u64 reserved;
++};
++
++struct drm_xe_eudebug_event_client {
++	struct drm_xe_eudebug_event base;
++
++	__u64 client_handle; /* This is unique per debug connection */
++};
++
++struct drm_xe_eudebug_event_vm {
++	struct drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 vm_handle;
++};
++
++#if defined(__cplusplus)
++}
++#endif
++
++#endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-exec_queue-events.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-exec_queue-events.patch
@@ -1,0 +1,394 @@
+From c60f763bd60575434e7ce72e3c918e07b9f94b9d Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Fri, 27 Jan 2023 00:15:09 +0100
+Subject: drm/xe/eudebug: Introduce exec_queue events
+
+Inform debugger about creation and destruction of exec_queues.
+
+1) Use user engine class types instead of internal xe_engine_class enum
+   in exec_queue event.
+
+2) During discovery do not advertise every execqueue created, only ones
+   with class render or compute.
+
+v2: - Only track long running queues
+    - Checkpatch (Tilak)
+
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit cce2901f7a100c0bc27e088e886fa06f9105921b eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_eudebug.c       | 189 +++++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_eudebug.h       |   7 +
+ drivers/gpu/drm/xe/xe_eudebug_types.h |  31 ++++-
+ drivers/gpu/drm/xe/xe_exec_queue.c    |   5 +
+ include/uapi/drm/xe_drm_eudebug.h     |  12 ++
+ 5 files changed, 242 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index e2e67739c299..27ad278ab569 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -15,6 +15,7 @@
+ #include "xe_assert.h"
+ #include "xe_macros.h"
+ #include "xe_vm.h"
++#include "xe_exec_queue.h"
+ 
+ #include "xe_eudebug_types.h"
+ #include "xe_eudebug.h"
+@@ -737,7 +738,7 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 		u64_to_user_ptr(arg);
+ 	struct drm_xe_eudebug_event user_event;
+ 	struct xe_eudebug_event *event;
+-	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_VM;
++	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE;
+ 	long ret = 0;
+ 
+ 	if (XE_IOCTL_DBG(xe, copy_from_user(&user_event, user_orig, sizeof(user_event))))
+@@ -1121,8 +1122,183 @@ void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm)
+ 	xe_eudebug_event_put(d, vm_destroy_event(d, xef, vm));
+ }
+ 
++static bool exec_queue_class_is_tracked(enum xe_engine_class class)
++{
++	return class == XE_ENGINE_CLASS_COMPUTE ||
++		class == XE_ENGINE_CLASS_RENDER;
++}
++
++static const u16 xe_to_user_engine_class[] = {
++	[XE_ENGINE_CLASS_RENDER] = DRM_XE_ENGINE_CLASS_RENDER,
++	[XE_ENGINE_CLASS_COPY] = DRM_XE_ENGINE_CLASS_COPY,
++	[XE_ENGINE_CLASS_VIDEO_DECODE] = DRM_XE_ENGINE_CLASS_VIDEO_DECODE,
++	[XE_ENGINE_CLASS_VIDEO_ENHANCE] = DRM_XE_ENGINE_CLASS_VIDEO_ENHANCE,
++	[XE_ENGINE_CLASS_COMPUTE] = DRM_XE_ENGINE_CLASS_COMPUTE,
++};
++
++static int send_exec_queue_event(struct xe_eudebug *d, u32 flags,
++				 u64 client_handle, u64 vm_handle,
++				 u64 exec_queue_handle, enum xe_engine_class class,
++				 u32 width, u64 *lrc_handles, u64 seqno)
++{
++	struct xe_eudebug_event *event;
++	struct xe_eudebug_event_exec_queue *e;
++	const u32 sz = struct_size(e, lrc_handle, width);
++	const u32 xe_engine_class = xe_to_user_engine_class[class];
++
++	if (!exec_queue_class_is_tracked(class))
++		return -EINVAL;
++
++	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE,
++					seqno, flags, sz, GFP_KERNEL);
++	if (!event)
++		return -ENOMEM;
++
++	e = cast_event(e, event);
++
++	write_member(struct drm_xe_eudebug_event_exec_queue, e, client_handle, client_handle);
++	write_member(struct drm_xe_eudebug_event_exec_queue, e, vm_handle, vm_handle);
++	write_member(struct drm_xe_eudebug_event_exec_queue, e, exec_queue_handle,
++		     exec_queue_handle);
++	write_member(struct drm_xe_eudebug_event_exec_queue, e, engine_class, xe_engine_class);
++	write_member(struct drm_xe_eudebug_event_exec_queue, e, width, width);
++
++	memcpy(e->lrc_handle, lrc_handles, width);
++
++	return xe_eudebug_queue_event(d, event);
++}
++
++static int exec_queue_create_event(struct xe_eudebug *d,
++				   struct xe_file *xef, struct xe_exec_queue *q)
++{
++	int h_c, h_vm, h_queue;
++	u64 h_lrc[XE_HW_ENGINE_MAX_INSTANCE], seqno;
++	int i;
++
++	if (!xe_exec_queue_is_lr(q))
++		return 0;
++
++	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
++	if (h_c < 0)
++		return h_c;
++
++	h_vm = find_handle(d->res, XE_EUDEBUG_RES_TYPE_VM, q->vm);
++	if (h_vm < 0)
++		return h_vm;
++
++	if (XE_WARN_ON(q->width >= XE_HW_ENGINE_MAX_INSTANCE))
++		return -EINVAL;
++
++	for (i = 0; i < q->width; i++) {
++		int h, ret;
++
++		ret = _xe_eudebug_add_handle(d,
++					     XE_EUDEBUG_RES_TYPE_LRC,
++					     q->lrc[i],
++					     NULL,
++					     &h);
++
++		if (ret < 0 && ret != -EEXIST)
++			return ret;
++
++		XE_WARN_ON(!h);
++
++		h_lrc[i] = h;
++	}
++
++	h_queue = xe_eudebug_add_handle(d, XE_EUDEBUG_RES_TYPE_EXEC_QUEUE, q, &seqno);
++	if (h_queue <= 0)
++		return h_queue;
++
++	/* No need to cleanup for added handles on error as if we fail
++	 * we disconnect
++	 */
++
++	return send_exec_queue_event(d, DRM_XE_EUDEBUG_EVENT_CREATE,
++				     h_c, h_vm, h_queue, q->class,
++				     q->width, h_lrc, seqno);
++}
++
++static int exec_queue_destroy_event(struct xe_eudebug *d,
++				    struct xe_file *xef,
++				    struct xe_exec_queue *q)
++{
++	int h_c, h_vm, h_queue;
++	u64 h_lrc[XE_HW_ENGINE_MAX_INSTANCE], seqno;
++	int i;
++
++	if (!xe_exec_queue_is_lr(q))
++		return 0;
++
++	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
++	if (h_c < 0)
++		return h_c;
++
++	h_vm = find_handle(d->res, XE_EUDEBUG_RES_TYPE_VM, q->vm);
++	if (h_vm < 0)
++		return h_vm;
++
++	if (XE_WARN_ON(q->width >= XE_HW_ENGINE_MAX_INSTANCE))
++		return -EINVAL;
++
++	h_queue = xe_eudebug_remove_handle(d,
++					   XE_EUDEBUG_RES_TYPE_EXEC_QUEUE,
++					   q,
++					   &seqno);
++	if (h_queue <= 0)
++		return h_queue;
++
++	for (i = 0; i < q->width; i++) {
++		int ret;
++
++		ret = _xe_eudebug_remove_handle(d,
++						XE_EUDEBUG_RES_TYPE_LRC,
++						q->lrc[i],
++						NULL);
++		if (ret < 0 && ret != -ENOENT)
++			return ret;
++
++		XE_WARN_ON(!ret);
++
++		h_lrc[i] = ret;
++	}
++
++	return send_exec_queue_event(d, DRM_XE_EUDEBUG_EVENT_DESTROY,
++				     h_c, h_vm, h_queue, q->class,
++				     q->width, h_lrc, seqno);
++}
++
++void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q)
++{
++	struct xe_eudebug *d;
++
++	if (!exec_queue_class_is_tracked(q->class))
++		return;
++
++	d = xe_eudebug_get(xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, exec_queue_create_event(d, xef, q));
++}
++
++void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q)
++{
++	struct xe_eudebug *d;
++
++	if (!exec_queue_class_is_tracked(q->class))
++		return;
++
++	d = xe_eudebug_get(xef);
++	if (!d)
++		return;
++
++	xe_eudebug_event_put(d, exec_queue_destroy_event(d, xef, q));
++}
++
+ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ {
++	struct xe_exec_queue *q;
+ 	struct xe_vm *vm;
+ 	unsigned long i;
+ 	int err;
+@@ -1139,6 +1315,17 @@ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ 	}
+ 	mutex_unlock(&xef->vm.lock);
+ 
++	mutex_lock(&xef->exec_queue.lock);
++	xa_for_each(&xef->exec_queue.xa, i, q) {
++		if (!exec_queue_class_is_tracked(q->class))
++			continue;
++
++		err = exec_queue_create_event(d, xef, q);
++		if (err)
++			break;
++	}
++	mutex_unlock(&xef->exec_queue.lock);
++
+ 	return err;
+ }
+ 
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+index e3247365f72f..326ddbd50651 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.h
++++ b/drivers/gpu/drm/xe/xe_eudebug.h
+@@ -10,6 +10,7 @@ struct drm_file;
+ struct xe_device;
+ struct xe_file;
+ struct xe_vm;
++struct xe_exec_queue;
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
+ 
+@@ -26,6 +27,9 @@ void xe_eudebug_file_close(struct xe_file *xef);
+ void xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm);
+ void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm);
+ 
++void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q);
++void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q);
++
+ #else
+ 
+ static inline int xe_eudebug_connect_ioctl(struct drm_device *dev,
+@@ -41,6 +45,9 @@ static inline void xe_eudebug_file_close(struct xe_file *xef) { }
+ static inline void xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm) { }
+ static inline void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm) { }
+ 
++static inline void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q) { }
++static inline void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q) { }
++
+ #endif /* CONFIG_DRM_XE_EUDEBUG */
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
+index 202ddf41a325..6e3c23023933 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug_types.h
++++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
+@@ -50,7 +50,9 @@ struct xe_eudebug_resource {
+ 
+ #define XE_EUDEBUG_RES_TYPE_CLIENT	0
+ #define XE_EUDEBUG_RES_TYPE_VM		1
+-#define XE_EUDEBUG_RES_TYPE_COUNT	(XE_EUDEBUG_RES_TYPE_VM + 1)
++#define XE_EUDEBUG_RES_TYPE_EXEC_QUEUE	2
++#define XE_EUDEBUG_RES_TYPE_LRC		3
++#define XE_EUDEBUG_RES_TYPE_COUNT	(XE_EUDEBUG_RES_TYPE_LRC + 1)
+ 
+ /**
+  * struct xe_eudebug_resources - eudebug resources for all types
+@@ -173,4 +175,31 @@ struct xe_eudebug_event_vm {
+ 	u64 vm_handle;
+ };
+ 
++/**
++ * struct xe_eudebug_event_exec_queue - Internal event for
++ * exec_queue create/destroy
++ */
++struct xe_eudebug_event_exec_queue {
++	/** @base: base event */
++	struct xe_eudebug_event base;
++
++	/** @client_handle: client for the engine create/destroy */
++	u64 client_handle;
++
++	/** @vm_handle: vm handle for the engine create/destroy */
++	u64 vm_handle;
++
++	/** @exec_queue_handle: engine handle */
++	u64 exec_queue_handle;
++
++	/** @engine_handle: engine class */
++	u32 engine_class;
++
++	/** @width: submission width (number BB per exec) for this exec queue */
++	u32 width;
++
++	/** @lrc_handles: handles for each logical ring context created with this exec queue */
++	u64 lrc_handle[];
++};
++
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index 3597dd788c7a..e9e32af1a8b4 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -22,6 +22,7 @@
+ #include "xe_ring_ops_types.h"
+ #include "xe_trace.h"
+ #include "xe_vm.h"
++#include "xe_eudebug.h"
+ 
+ enum xe_exec_queue_sched_prop {
+ 	XE_EXEC_QUEUE_JOB_TIMEOUT = 0,
+@@ -634,6 +635,8 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
+ 	args->exec_queue_id = id;
+ 	q->xef = xe_file_get(xef);
+ 
++	xe_eudebug_exec_queue_create(xef, q);
++
+ 	return 0;
+ 
+ kill_exec_queue:
+@@ -805,6 +808,8 @@ int xe_exec_queue_destroy_ioctl(struct drm_device *dev, void *data,
+ 	if (XE_IOCTL_DBG(xe, !q))
+ 		return -ENOENT;
+ 
++	xe_eudebug_exec_queue_destroy(xef, q);
++
+ 	xe_exec_queue_kill(q);
+ 
+ 	trace_xe_exec_queue_close(q);
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+index acf6071c82bf..ac44e890152a 100644
+--- a/include/uapi/drm/xe_drm_eudebug.h
++++ b/include/uapi/drm/xe_drm_eudebug.h
+@@ -26,6 +26,7 @@ struct drm_xe_eudebug_event {
+ #define DRM_XE_EUDEBUG_EVENT_READ		1
+ #define DRM_XE_EUDEBUG_EVENT_OPEN		2
+ #define DRM_XE_EUDEBUG_EVENT_VM			3
++#define DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE		4
+ 
+ 	__u16 flags;
+ #define DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
+@@ -49,6 +50,17 @@ struct drm_xe_eudebug_event_vm {
+ 	__u64 vm_handle;
+ };
+ 
++struct drm_xe_eudebug_event_exec_queue {
++	struct drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 vm_handle;
++	__u64 exec_queue_handle;
++	__u32 engine_class;
++	__u32 width;
++	__u64 lrc_handle[];
++};
++
+ #if defined(__cplusplus)
+ }
+ #endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-per-device-attention-scan-w.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-per-device-attention-scan-w.patch
@@ -1,0 +1,857 @@
+From abb7f1641b19b4fa65f710d1a4308eb67cca5fb7 Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Sat, 17 Jun 2023 14:40:31 +0200
+Subject: drm/xe/eudebug: Introduce per device attention scan worker
+
+Scan for EU debugging attention bits periodically to detect if some EU
+thread has entered the system routine (SIP) due to EU thread exception.
+
+Make the scanning interval 10 times slower when there is no debugger
+connection open. Send attention event whenever we see attention with
+debugger presence. If there is no debugger connection active - reset.
+
+Based on work by authors and other folks who were part of attentions in
+i915.
+
+v2: - use xa_array for files
+    - null ptr deref fix for non-debugged context (Dominik)
+    - checkpatch (Tilak)
+
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Christoph Manszewski <christoph.manszewski@intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit b0aba7eb4bc5d98b667b8ba50fb6d5c2763c3cee eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/Makefile              |   1 +
+ drivers/gpu/drm/xe/regs/xe_engine_regs.h |   3 +
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h     |   7 +
+ drivers/gpu/drm/xe/xe_device.c           |   2 +
+ drivers/gpu/drm/xe/xe_device_types.h     |   3 +
+ drivers/gpu/drm/xe/xe_eudebug.c          | 397 ++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_eudebug.h          |   2 +
+ drivers/gpu/drm/xe/xe_eudebug_types.h    |  32 ++
+ drivers/gpu/drm/xe/xe_gt_debug.c         | 148 +++++++++
+ drivers/gpu/drm/xe/xe_gt_debug.h         |  21 ++
+ include/uapi/drm/xe_drm_eudebug.h        |  13 +
+ 11 files changed, 628 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/gpu/drm/xe/xe_gt_debug.c
+ create mode 100644 drivers/gpu/drm/xe/xe_gt_debug.h
+
+diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
+index 8d0fc9caacc6..b655c0e43834 100644
+--- a/drivers/gpu/drm/xe/Makefile
++++ b/drivers/gpu/drm/xe/Makefile
+@@ -49,6 +49,7 @@ xe-y += xe_bb.o \
+ 	xe_gt_debugfs.o \
+ 	xe_gt_freq.o \
+ 	xe_gt_idle.o \
++	xe_gt_debug.o \
+ 	xe_gt_mcr.o \
+ 	xe_gt_pagefault.o \
+ 	xe_gt_sysfs.o \
+diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
+index e004423a66bf..f2f136b1b0fa 100644
+--- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
+@@ -133,6 +133,9 @@
+ #define RING_EXECLIST_STATUS_LO(base)		XE_REG((base) + 0x234)
+ #define RING_EXECLIST_STATUS_HI(base)		XE_REG((base) + 0x234 + 4)
+ 
++#define RING_CURRENT_LRCA(base)			XE_REG((base) + 0x240)
++#define   CURRENT_LRCA_VALID			REG_BIT(0)
++
+ #define RING_CONTEXT_CONTROL(base)		XE_REG((base) + 0x244, XE_REG_OPTION_MASKED)
+ #define	  CTX_CTRL_OAC_CONTEXT_ENABLE		REG_BIT(8)
+ #define	  CTX_CTRL_RUN_ALONE			REG_BIT(7)
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index f7f6e52173af..313ca00f3a0d 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -439,6 +439,8 @@
+ #define   DISABLE_ECC				REG_BIT(5)
+ #define   ENABLE_PREFETCH_INTO_IC		REG_BIT(3)
+ 
++#define TD_ATT(x)				XE_REG_MCR(0xe470 + (x) * 4)
++
+ #define ROW_CHICKEN4				XE_REG_MCR(0xe48c, XE_REG_OPTION_MASKED)
+ #define   DISABLE_GRF_CLEAR			REG_BIT(13)
+ #define   XEHP_DIS_BBL_SYSPIPE			REG_BIT(11)
+@@ -519,6 +521,11 @@
+ #define   CCS_MODE_CSLICE(cslice, ccs) \
+ 	((ccs) << ((cslice) * CCS_MODE_CSLICE_WIDTH))
+ 
++#define RCU_DEBUG_1				XE_REG(0x14a00)
++#define   RCU_DEBUG_1_ENGINE_STATUS		REG_GENMASK(2, 0)
++#define   RCU_DEBUG_1_RUNALONE_ACTIVE		REG_BIT(2)
++#define   RCU_DEBUG_1_CONTEXT_ACTIVE		REG_BIT(0)
++
+ #define FORCEWAKE_ACK_GT			XE_REG(0x130044)
+ 
+ /* Applicable for all FORCEWAKE_DOMAIN and FORCEWAKE_ACK_DOMAIN regs */
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 06e612899191..22c87999f92d 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -762,6 +762,8 @@ int xe_device_probe(struct xe_device *xe)
+ 
+ 	xe_debugfs_register(xe);
+ 
++	xe_eudebug_init_late(xe);
++
+ 	xe_hwmon_register(xe);
+ 
+ 	for_each_gt(gt, xe, id)
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index a677e141da7f..fdc9ee0ad1c8 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -516,6 +516,9 @@ struct xe_device {
+ 
+ 		/** @ordered_wq: used to discovery */
+ 		struct workqueue_struct *ordered_wq;
++
++		/** @attention_scan: attention scan worker */
++		struct delayed_work attention_scan;
+ 	} eudebug;
+ 
+ 	/* private: */
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 2c380622f586..3cc476bb7279 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -24,6 +24,17 @@
+ #include "xe_reg_sr.h"
+ #include "xe_rtp.h"
+ #include "xe_wa.h"
++#include "xe_gt.h"
++#include "xe_gt_debug.h"
++#include "xe_lrc.h"
++#include "xe_hw_engine.h"
++#include "xe_exec_queue.h"
++#include "xe_sched_job.h"
++#include "xe_force_wake.h"
++#include "xe_mmio.h"
++#include "xe_reg_sr.h"
++#include "xe_pm.h"
++#include "xe_rtp.h"
+ 
+ #include "xe_eudebug_types.h"
+ #include "xe_eudebug.h"
+@@ -746,7 +757,7 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 		u64_to_user_ptr(arg);
+ 	struct drm_xe_eudebug_event user_event;
+ 	struct xe_eudebug_event *event;
+-	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE;
++	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_EU_ATTENTION;
+ 	long ret = 0;
+ 
+ 	if (XE_IOCTL_DBG(xe, copy_from_user(&user_event, user_orig, sizeof(user_event))))
+@@ -850,6 +861,378 @@ static const struct file_operations fops = {
+ 	.unlocked_ioctl	= xe_eudebug_ioctl,
+ };
+ 
++static int __current_lrca(struct xe_hw_engine *hwe, u32 *lrc_hw)
++{
++	u32 lrc_reg;
++
++	lrc_reg = xe_hw_engine_mmio_read32(hwe, RING_CURRENT_LRCA(0));
++
++	if (!(lrc_reg & CURRENT_LRCA_VALID))
++		return -ENOENT;
++
++	*lrc_hw = lrc_reg & GENMASK(31, 12);
++
++	return 0;
++}
++
++static int current_lrca(struct xe_hw_engine *hwe, u32 *lrc_hw)
++{
++	int ret;
++
++	ret = xe_force_wake_get(gt_to_fw(hwe->gt), hwe->domain);
++	if (ret)
++		return ret;
++
++	ret = __current_lrca(hwe, lrc_hw);
++
++	xe_force_wake_put(gt_to_fw(hwe->gt), hwe->domain);
++
++	return ret;
++}
++
++static bool lrca_equals(u32 a, u32 b)
++{
++	return (a & GENMASK(31, 12)) == (b & GENMASK(31, 12));
++}
++
++static int match_exec_queue_lrca(struct xe_exec_queue *q, u32 lrc_hw)
++{
++	int i;
++
++	for (i = 0; i < q->width; i++)
++		if (lrca_equals(lower_32_bits(xe_lrc_descriptor(q->lrc[i])), lrc_hw))
++			return i;
++
++	return -1;
++}
++
++static u32 engine_status(const struct xe_hw_engine * const hwe,
++			 u32 rcu_debug1)
++{
++	const bool xe1 = GRAPHICS_VER(gt_to_xe(hwe->gt)) < 20;
++	unsigned int shift;
++
++	if (hwe->class == XE_ENGINE_CLASS_RENDER) {
++		shift = 7;
++		XE_WARN_ON(hwe->instance != 0);
++	} else if (hwe->class == XE_ENGINE_CLASS_COMPUTE) {
++		XE_WARN_ON(hwe->instance > 3);
++
++		if (xe1)
++			shift = 10 + (hwe->instance * 3);
++		else
++			shift = 11 + (hwe->instance * 4);
++	} else {
++		XE_WARN_ON(hwe->class);
++		return 0;
++	}
++
++	return (rcu_debug1 >> shift) & RCU_DEBUG_1_ENGINE_STATUS;
++}
++
++static bool engine_runalone_set(const struct xe_hw_engine * const hwe,
++				u32 rcu_debug1)
++{
++	return engine_status(hwe, rcu_debug1) & RCU_DEBUG_1_RUNALONE_ACTIVE;
++}
++
++static bool engine_context_set(const struct xe_hw_engine * const hwe,
++			       u32 rcu_debug1)
++{
++	return engine_status(hwe, rcu_debug1) & RCU_DEBUG_1_CONTEXT_ACTIVE;
++}
++
++static bool engine_has_runalone(const struct xe_hw_engine * const hwe)
++{
++	return hwe->class == XE_ENGINE_CLASS_RENDER ||
++		hwe->class == XE_ENGINE_CLASS_COMPUTE;
++}
++
++static struct xe_hw_engine *get_runalone_active_hw_engine(struct xe_gt *gt)
++{
++	struct xe_hw_engine *hwe, *first = NULL;
++	unsigned int num_active, id;
++	u32 val;
++
++	if (xe_force_wake_get(gt_to_fw(gt), XE_FW_GT)) {
++		drm_dbg(&gt_to_xe(gt)->drm, "eudbg: runalone failed to get force wake\n");
++		return NULL;
++	}
++
++	val = xe_mmio_read32(gt, RCU_DEBUG_1);
++	xe_force_wake_put(gt_to_fw(gt), XE_FW_GT);
++
++	drm_dbg(&gt_to_xe(gt)->drm, "eudbg: runalone RCU_DEBUG_1 = 0x%08x\n", val);
++
++	num_active = 0;
++	for_each_hw_engine(hwe, gt, id) {
++		bool runalone, ctx;
++
++		if (!engine_has_runalone(hwe))
++			continue;
++
++		runalone = engine_runalone_set(hwe, val);
++		ctx = engine_context_set(hwe, val);
++
++		drm_dbg(&gt_to_xe(gt)->drm, "eudbg: engine %s: runalone=%s, context=%s",
++			hwe->name, runalone ? "active" : "inactive",
++			ctx ? "active" : "inactive");
++
++		/*
++		 * On earlier gen12 the context status seems to be idle when
++		 * it has raised attention. We have to omit the active bit.
++		 */
++		if (IS_DGFX(gt_to_xe(gt)))
++			ctx = true;
++
++		if (runalone && ctx) {
++			num_active++;
++
++			drm_dbg(&gt_to_xe(gt)->drm, "eudbg: runalone engine %s %s",
++				hwe->name, first ? "selected" : "found");
++			if (!first)
++				first = hwe;
++		}
++	}
++
++	if (num_active > 1)
++		drm_err(&gt_to_xe(gt)->drm, "eudbg: %d runalone engines active!",
++			num_active);
++
++	return first;
++}
++
++static struct xe_exec_queue *runalone_active_queue_get(struct xe_gt *gt, int *lrc_idx)
++{
++	struct xe_device *xe = gt_to_xe(gt);
++	struct xe_exec_queue *q, *found = NULL;
++	struct xe_hw_engine *active;
++	struct xe_file *xef;
++	unsigned long i, j;
++	int idx, err;
++	u32 lrc_hw;
++
++	active = get_runalone_active_hw_engine(gt);
++	if (!active) {
++		drm_dbg(&gt_to_xe(gt)->drm, "Runalone engine not found!");
++		return ERR_PTR(-ENOENT);
++	}
++
++	err = current_lrca(active, &lrc_hw);
++	if (err)
++		return ERR_PTR(err);
++
++	mutex_lock(&xe->files.lock);
++	xa_for_each(&xe->files.xa, i, xef) {
++		xe_file_get(xef);
++		mutex_unlock(&xe->files.lock);
++
++		mutex_lock(&xef->exec_queue.lock);
++		xa_for_each(&xef->exec_queue.xa, j, q) {
++			xe_exec_queue_get(q);
++			mutex_unlock(&xef->exec_queue.lock);
++
++			if (q->gt != gt)
++				goto cont_search;
++
++			if (q->class != active->class)
++				goto cont_search;
++
++			if (xe_exec_queue_is_idle(q))
++				goto cont_search;
++
++			idx = match_exec_queue_lrca(q, lrc_hw);
++			if (idx < 0)
++				goto cont_search;
++
++			found = q;
++
++			if (lrc_idx)
++				*lrc_idx = idx;
++
++			break;
++cont_search:
++			xe_exec_queue_put(q);
++			mutex_lock(&xef->exec_queue.lock);
++		}
++
++		if (found)
++			break;
++
++		mutex_unlock(&xef->exec_queue.lock);
++		mutex_lock(&xe->files.lock);
++	}
++
++	if (!found) {
++		mutex_unlock(&xe->files.lock);
++		return ERR_PTR(-ENOENT);
++	}
++
++	if (XE_WARN_ON(current_lrca(active, &lrc_hw)) &&
++	    XE_WARN_ON(match_exec_queue_lrca(found, lrc_hw) < 0)) {
++		xe_exec_queue_put(found);
++		return ERR_PTR(-ENOENT);
++	}
++
++	return found;
++}
++
++static int send_attention_event(struct xe_eudebug *d, struct xe_exec_queue *q, int lrc_idx)
++{
++	struct xe_eudebug_event_eu_attention *ea;
++	struct xe_eudebug_event *event;
++	int h_c, h_queue, h_lrc;
++	u32 size = xe_gt_eu_attention_bitmap_size(q->gt);
++	u32 sz = struct_size(ea, bitmask, size);
++	int ret;
++
++	XE_WARN_ON(lrc_idx < 0 || lrc_idx >= q->width);
++
++	XE_WARN_ON(!xe_exec_queue_is_debuggable(q));
++
++	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, q->vm->xef);
++	if (h_c < 0)
++		return h_c;
++
++	h_queue = find_handle(d->res, XE_EUDEBUG_RES_TYPE_EXEC_QUEUE, q);
++	if (h_queue < 0)
++		return h_queue;
++
++	h_lrc = find_handle(d->res, XE_EUDEBUG_RES_TYPE_LRC, q->lrc[lrc_idx]);
++	if (h_lrc < 0)
++		return h_lrc;
++
++	event = __xe_eudebug_create_event(d, 0, DRM_XE_EUDEBUG_EVENT_EU_ATTENTION,
++					  DRM_XE_EUDEBUG_EVENT_STATE_CHANGE, sz, GFP_KERNEL);
++
++	if (!event)
++		return -ENOSPC;
++
++	ea = cast_event(ea, event);
++	write_member(struct drm_xe_eudebug_event_eu_attention, ea, client_handle, (u64)h_c);
++	write_member(struct drm_xe_eudebug_event_eu_attention, ea, exec_queue_handle, (u64)h_queue);
++	write_member(struct drm_xe_eudebug_event_eu_attention, ea, lrc_handle, (u64)h_lrc);
++	write_member(struct drm_xe_eudebug_event_eu_attention, ea, bitmask_size, size);
++
++	mutex_lock(&d->eu_lock);
++	event->seqno = atomic_long_inc_return(&d->events.seqno);
++	ret = xe_gt_eu_attention_bitmap(q->gt, &ea->bitmask[0], ea->bitmask_size);
++	mutex_unlock(&d->eu_lock);
++
++	if (ret)
++		return ret;
++
++	return xe_eudebug_queue_event(d, event);
++}
++
++
++static int xe_send_gt_attention(struct xe_gt *gt)
++{
++	struct xe_eudebug *d;
++	struct xe_exec_queue *q;
++	int ret, lrc_idx;
++
++	if (list_empty_careful(&gt_to_xe(gt)->eudebug.list))
++		return -ENOTCONN;
++
++	q = runalone_active_queue_get(gt, &lrc_idx);
++	if (IS_ERR(q))
++		return PTR_ERR(q);
++
++	if (!xe_exec_queue_is_debuggable(q)) {
++		ret = -EPERM;
++		goto err_exec_queue_put;
++	}
++
++	d = xe_eudebug_get(q->vm->xef);
++	if (!d) {
++		ret = -ENOTCONN;
++		goto err_exec_queue_put;
++	}
++
++	if (!completion_done(&d->discovery)) {
++		eu_dbg(d, "discovery not yet done\n");
++		ret = -EBUSY;
++		goto err_eudebug_put;
++	}
++
++	ret = send_attention_event(d, q, lrc_idx);
++	if (ret)
++		xe_eudebug_disconnect(d, ret);
++
++err_eudebug_put:
++	xe_eudebug_put(d);
++err_exec_queue_put:
++	xe_exec_queue_put(q);
++
++	return ret;
++}
++
++static int xe_eudebug_handle_gt_attention(struct xe_gt *gt)
++{
++	int ret;
++
++	ret = xe_gt_eu_threads_needing_attention(gt);
++	if (ret <= 0)
++		return ret;
++
++	ret = xe_send_gt_attention(gt);
++
++	/* Discovery in progress, fake it */
++	if (ret == -EBUSY)
++		return 0;
++
++	return ret;
++}
++
++#define XE_EUDEBUG_ATTENTION_INTERVAL 100
++static void attention_scan_fn(struct work_struct *work)
++{
++	struct xe_device *xe = container_of(work, typeof(*xe), eudebug.attention_scan.work);
++	long delay = msecs_to_jiffies(XE_EUDEBUG_ATTENTION_INTERVAL);
++	struct xe_gt *gt;
++	u8 gt_id;
++
++	if (list_empty_careful(&xe->eudebug.list))
++		delay *= 10;
++
++	if (delay >= HZ)
++		delay = round_jiffies_up_relative(delay);
++
++	if (xe_pm_runtime_get_if_active(xe)) {
++		for_each_gt(gt, xe, gt_id) {
++			int ret;
++
++			if (gt->info.type != XE_GT_TYPE_MAIN)
++				continue;
++
++			ret = xe_eudebug_handle_gt_attention(gt);
++			if (ret) {
++				// TODO: error capture
++				drm_info(&gt_to_xe(gt)->drm,
++					 "gt:%d unable to handle eu attention ret=%d\n",
++					 gt_id, ret);
++
++				xe_gt_reset_async(gt);
++			}
++		}
++
++		xe_pm_runtime_put(xe);
++	}
++
++	schedule_delayed_work(&xe->eudebug.attention_scan, delay);
++}
++
++static void attention_scan_cancel(struct xe_device *xe)
++{
++	cancel_delayed_work_sync(&xe->eudebug.attention_scan);
++}
++
++static void attention_scan_flush(struct xe_device *xe)
++{
++	mod_delayed_work(system_wq, &xe->eudebug.attention_scan, 0);
++}
++
+ static void discovery_work_fn(struct work_struct *work);
+ 
+ static int
+@@ -884,6 +1267,7 @@ xe_eudebug_connect(struct xe_device *xe,
+ 
+ 	kref_init(&d->ref);
+ 	spin_lock_init(&d->connection.lock);
++	mutex_init(&d->eu_lock);
+ 	init_waitqueue_head(&d->events.write_done);
+ 	init_waitqueue_head(&d->events.read_done);
+ 	init_completion(&d->discovery);
+@@ -910,6 +1294,7 @@ xe_eudebug_connect(struct xe_device *xe,
+ 
+ 	kref_get(&d->ref);
+ 	queue_work(xe->eudebug.ordered_wq, &d->discovery_work);
++	attention_scan_flush(xe);
+ 
+ 	eu_dbg(d, "connected session %lld", d->session);
+ 
+@@ -1004,12 +1389,22 @@ void xe_eudebug_init(struct xe_device *xe)
+ {
+ 	spin_lock_init(&xe->eudebug.lock);
+ 	INIT_LIST_HEAD(&xe->eudebug.list);
++	INIT_DELAYED_WORK(&xe->eudebug.attention_scan, attention_scan_fn);
+ 
+ 	xe->eudebug.available = true;
+ }
+ 
++void xe_eudebug_init_late(struct xe_device *xe)
++{
++	if (!xe->eudebug.available)
++		return;
++
++	attention_scan_flush(xe);
++}
++
+ void xe_eudebug_fini(struct xe_device *xe)
+ {
++	attention_scan_cancel(xe);
+ 	xe_assert(xe, list_empty_careful(&xe->eudebug.list));
+ }
+ 
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+index 3cd6bc7bb682..1fe86bec99e1 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.h
++++ b/drivers/gpu/drm/xe/xe_eudebug.h
+@@ -20,6 +20,7 @@ int xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 			     struct drm_file *file);
+ 
+ void xe_eudebug_init(struct xe_device *xe);
++void xe_eudebug_init_late(struct xe_device *xe);
+ void xe_eudebug_fini(struct xe_device *xe);
+ void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe);
+ 
+@@ -39,6 +40,7 @@ static inline int xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 					   struct drm_file *file) { return 0; }
+ 
+ static inline void xe_eudebug_init(struct xe_device *xe) { }
++static inline void xe_eudebug_init_late(struct xe_device *xe) { }
+ static inline void xe_eudebug_fini(struct xe_device *xe) { }
+ static inline void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe) { }
+ 
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
+index 6e3c23023933..16667b4dfe45 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug_types.h
++++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
+@@ -105,6 +105,9 @@ struct xe_eudebug {
+ 	/** @discovery_work: worker to discover resources for target_task */
+ 	struct work_struct discovery_work;
+ 
++	/** eu_lock: guards operations on eus (eu thread control and attention) */
++	struct mutex eu_lock;
++
+ 	/** @events: kfifo queue of to-be-delivered events */
+ 	struct {
+ 		/** @lock: guards access to fifo */
+@@ -202,4 +205,33 @@ struct xe_eudebug_event_exec_queue {
+ 	u64 lrc_handle[];
+ };
+ 
++/**
++ * struct xe_eudebug_event_eu_attention - Internal event for EU attention
++ */
++struct xe_eudebug_event_eu_attention {
++	/** @base: base event */
++	struct xe_eudebug_event base;
++
++	/** @client_handle: client for the attention */
++	u64 client_handle;
++
++	/** @exec_queue_handle: handle of exec_queue which raised attention */
++	u64 exec_queue_handle;
++
++	/** @lrc_handle: lrc handle of the workload which raised attention */
++	u64 lrc_handle;
++
++	/** @flags: eu attention event flags, currently MBZ */
++	u32 flags;
++
++	/** @bitmask_size: size of the bitmask, specific to device */
++	u32 bitmask_size;
++
++	/**
++	 * @bitmask: reflects threads currently signalling attention,
++	 * starting from natural hardware order of DSS=0, eu=0
++	 */
++	u8 bitmask[];
++};
++
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_gt_debug.c b/drivers/gpu/drm/xe/xe_gt_debug.c
+new file mode 100644
+index 000000000000..d36684c7514d
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_gt_debug.c
+@@ -0,0 +1,148 @@
++// SPDX-License-Identifier: MIT
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#include "regs/xe_gt_regs.h"
++#include "xe_device.h"
++#include "xe_force_wake.h"
++#include "xe_gt.h"
++#include "xe_gt_topology.h"
++#include "xe_gt_debug.h"
++#include "xe_gt_mcr.h"
++#include "xe_pm.h"
++#include "xe_macros.h"
++
++static int xe_gt_foreach_dss_group_instance(struct xe_gt *gt,
++					    int (*fn)(struct xe_gt *gt,
++						      void *data,
++						      u16 group,
++						      u16 instance),
++					    void *data)
++{
++	const enum xe_force_wake_domains fw_domains = XE_FW_GT | XE_FW_RENDER;
++	unsigned int dss;
++	u16 group, instance;
++	int ret;
++
++	ret = xe_force_wake_get(gt_to_fw(gt), fw_domains);
++	if (ret)
++		return ret;
++
++	for_each_dss_steering(dss, gt, group, instance) {
++		ret = fn(gt, data, group, instance);
++		if (ret)
++			break;
++	}
++
++	xe_force_wake_put(gt_to_fw(gt), fw_domains);
++
++	return ret;
++}
++
++static int read_first_attention_mcr(struct xe_gt *gt, void *data,
++				    u16 group, u16 instance)
++{
++	unsigned int row;
++
++	for (row = 0; row < 2; row++) {
++		u32 val;
++
++		val = xe_gt_mcr_unicast_read(gt, TD_ATT(row), group, instance);
++
++		if (val)
++			return 1;
++	}
++
++	return 0;
++}
++
++#define MAX_EUS_PER_ROW 4u
++#define MAX_THREADS 8u
++
++/**
++ * xe_gt_eu_attention_bitmap_size - query size of the attention bitmask
++ *
++ * @gt: pointer to struct xe_gt
++ *
++ * Return: size in bytes.
++ */
++int xe_gt_eu_attention_bitmap_size(struct xe_gt *gt)
++{
++	xe_dss_mask_t dss_mask;
++
++	bitmap_or(dss_mask, gt->fuse_topo.c_dss_mask,
++		  gt->fuse_topo.g_dss_mask, XE_MAX_DSS_FUSE_BITS);
++
++	return  bitmap_weight(dss_mask, XE_MAX_DSS_FUSE_BITS) *
++		TD_EU_ATTENTION_MAX_ROWS * MAX_THREADS *
++		MAX_EUS_PER_ROW / 8;
++}
++
++struct attn_read_iter {
++	struct xe_gt *gt;
++	unsigned int i;
++	unsigned int size;
++	u8 *bits;
++};
++
++static int read_eu_attentions_mcr(struct xe_gt *gt, void *data,
++				  u16 group, u16 instance)
++{
++	struct attn_read_iter * const iter = data;
++	unsigned int row;
++
++	for (row = 0; row < TD_EU_ATTENTION_MAX_ROWS; row++) {
++		u32 val;
++
++		if (iter->i >= iter->size)
++			return 0;
++
++		XE_WARN_ON(iter->i + sizeof(val) > xe_gt_eu_attention_bitmap_size(gt));
++
++		val = xe_gt_mcr_unicast_read(gt, TD_ATT(row), group, instance);
++
++		memcpy(&iter->bits[iter->i], &val, sizeof(val));
++		iter->i += sizeof(val);
++	}
++
++	return 0;
++}
++
++/**
++ * xe_gt_eu_attention_bitmap - query host attention
++ *
++ * @gt: pointer to struct xe_gt
++ *
++ * Return: 0 on success, negative otherwise.
++ */
++int xe_gt_eu_attention_bitmap(struct xe_gt *gt, u8 *bits,
++			      unsigned int bitmap_size)
++{
++	struct attn_read_iter iter = {
++		.gt = gt,
++		.i = 0,
++		.size = bitmap_size,
++		.bits = bits
++	};
++
++	return xe_gt_foreach_dss_group_instance(gt, read_eu_attentions_mcr, &iter);
++}
++
++/**
++ * xe_gt_eu_threads_needing_attention - Query host attention
++ *
++ * @gt: pointer to struct xe_gt
++ *
++ * Return: 1 if threads waiting host attention, 0 otherwise.
++ */
++int xe_gt_eu_threads_needing_attention(struct xe_gt *gt)
++{
++	int err;
++
++	err = xe_gt_foreach_dss_group_instance(gt, read_first_attention_mcr, NULL);
++
++	XE_WARN_ON(err < 0);
++
++	return err < 0 ? 0 : err;
++}
+diff --git a/drivers/gpu/drm/xe/xe_gt_debug.h b/drivers/gpu/drm/xe/xe_gt_debug.h
+new file mode 100644
+index 000000000000..3f13dbb17a5f
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_gt_debug.h
+@@ -0,0 +1,21 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef __XE_GT_DEBUG_
++#define __XE_GT_DEBUG_
++
++#define TD_EU_ATTENTION_MAX_ROWS 2u
++
++#include "xe_gt_types.h"
++
++#define XE_GT_ATTENTION_TIMEOUT_MS 100
++
++int xe_gt_eu_threads_needing_attention(struct xe_gt *gt);
++
++int xe_gt_eu_attention_bitmap_size(struct xe_gt *gt);
++int xe_gt_eu_attention_bitmap(struct xe_gt *gt, u8 *bits,
++			      unsigned int bitmap_size);
++
++#endif
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+index ac44e890152a..1e63bdede5f2 100644
+--- a/include/uapi/drm/xe_drm_eudebug.h
++++ b/include/uapi/drm/xe_drm_eudebug.h
+@@ -27,12 +27,14 @@ struct drm_xe_eudebug_event {
+ #define DRM_XE_EUDEBUG_EVENT_OPEN		2
+ #define DRM_XE_EUDEBUG_EVENT_VM			3
+ #define DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE		4
++#define DRM_XE_EUDEBUG_EVENT_EU_ATTENTION	5
+ 
+ 	__u16 flags;
+ #define DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
+ #define DRM_XE_EUDEBUG_EVENT_DESTROY		(1 << 1)
+ #define DRM_XE_EUDEBUG_EVENT_STATE_CHANGE	(1 << 2)
+ #define DRM_XE_EUDEBUG_EVENT_NEED_ACK		(1 << 3)
++
+ 	__u64 seqno;
+ 	__u64 reserved;
+ };
+@@ -61,6 +63,17 @@ struct drm_xe_eudebug_event_exec_queue {
+ 	__u64 lrc_handle[];
+ };
+ 
++struct drm_xe_eudebug_event_eu_attention {
++	struct drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 exec_queue_handle;
++	__u64 lrc_handle;
++	__u32 flags;
++	__u32 bitmask_size;
++	__u8 bitmask[];
++};
++
+ #if defined(__cplusplus)
+ }
+ #endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
@@ -1,0 +1,2808 @@
+From 8878f492c59ac46316fb900f3a0fac2d0b2bd327 Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Wed, 20 Mar 2024 12:20:35 +0100
+Subject: drm/xe/eudebug: Prelim rework for Xe EU debug
+
+Moved all xe_eudebug declarations and definitions to xe_drm_prelim.h
+Removed xe_drm_eudebug.h Moved eudebug related files into prelim/ directory
+Added prelim_ prefix where necessary.
+
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+(cherry picked from commit 33dfbae234c790ab724747233e2d40182e53b09c eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/Kconfig                    |   2 +-
+ drivers/gpu/drm/xe/Makefile                   |   6 +-
+ .../drm/xe/{ => prelim}/xe_debug_metadata.c   |  34 +-
+ drivers/gpu/drm/xe/prelim/xe_debug_metadata.h |  25 ++
+ .../xe/{ => prelim}/xe_debug_metadata_types.h |   2 +-
+ drivers/gpu/drm/xe/{ => prelim}/xe_eudebug.c  | 326 +++++++++---------
+ drivers/gpu/drm/xe/prelim/xe_eudebug.h        |  87 +++++
+ .../drm/xe/{ => prelim}/xe_eudebug_types.h    |   0
+ drivers/gpu/drm/xe/{ => prelim}/xe_gt_debug.c |  26 +-
+ drivers/gpu/drm/xe/prelim/xe_gt_debug.h       |  27 ++
+ .../drm/xe/tests/{ => prelim}/xe_eudebug.c    |   0
+ drivers/gpu/drm/xe/tests/xe_live_test_mod.c   |   2 +-
+ drivers/gpu/drm/xe/xe_debug_metadata.h        |  25 --
+ drivers/gpu/drm/xe/xe_device.c                |  22 +-
+ drivers/gpu/drm/xe/xe_eudebug.h               |  87 -----
+ drivers/gpu/drm/xe/xe_exec_queue.c            |  16 +-
+ drivers/gpu/drm/xe/xe_exec_queue_types.h      |   2 +-
+ drivers/gpu/drm/xe/xe_gt_debug.h              |  27 --
+ drivers/gpu/drm/xe/xe_hw_engine.c             |   2 +-
+ drivers/gpu/drm/xe/xe_sync.c                  |   8 +-
+ drivers/gpu/drm/xe/xe_vm.c                    |  28 +-
+ include/uapi/drm/xe_drm.h                     |  95 +----
+ include/uapi/drm/xe_drm_eudebug.h             | 225 ------------
+ include/uapi/drm/xe_drm_prelim.h              | 302 ++++++++++++++++
+ 24 files changed, 681 insertions(+), 695 deletions(-)
+ rename drivers/gpu/drm/xe/{ => prelim}/xe_debug_metadata.c (67%)
+ create mode 100644 drivers/gpu/drm/xe/prelim/xe_debug_metadata.h
+ rename drivers/gpu/drm/xe/{ => prelim}/xe_debug_metadata_types.h (92%)
+ rename drivers/gpu/drm/xe/{ => prelim}/xe_eudebug.c (88%)
+ create mode 100644 drivers/gpu/drm/xe/prelim/xe_eudebug.h
+ rename drivers/gpu/drm/xe/{ => prelim}/xe_eudebug_types.h (100%)
+ rename drivers/gpu/drm/xe/{ => prelim}/xe_gt_debug.c (72%)
+ create mode 100644 drivers/gpu/drm/xe/prelim/xe_gt_debug.h
+ rename drivers/gpu/drm/xe/tests/{ => prelim}/xe_eudebug.c (100%)
+ delete mode 100644 drivers/gpu/drm/xe/xe_debug_metadata.h
+ delete mode 100644 drivers/gpu/drm/xe/xe_eudebug.h
+ delete mode 100644 drivers/gpu/drm/xe/xe_gt_debug.h
+ delete mode 100644 include/uapi/drm/xe_drm_eudebug.h
+
+diff --git a/drivers/gpu/drm/xe/Kconfig b/drivers/gpu/drm/xe/Kconfig
+index 23f34e8e3151..fc3cab510405 100644
+--- a/drivers/gpu/drm/xe/Kconfig
++++ b/drivers/gpu/drm/xe/Kconfig
+@@ -85,7 +85,7 @@ config DRM_XE_FORCE_PROBE
+ 
+ 	  Use "!*" to block the probe of the driver for all known devices.
+ 
+-config DRM_XE_EUDEBUG
++config PRELIM_DRM_XE_EUDEBUG
+ 	bool "Enable gdb debugger support (eudebug)"
+ 	depends on DRM_XE
+ 	default y
+diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
+index e2aa65d4fa42..d4c47453f347 100644
+--- a/drivers/gpu/drm/xe/Makefile
++++ b/drivers/gpu/drm/xe/Makefile
+@@ -29,7 +29,7 @@ xe-y += xe_bb.o \
+ 	xe_bo.o \
+ 	xe_bo_evict.o \
+ 	xe_debugfs.o \
+-	xe_debug_metadata.o \
++	prelim/xe_debug_metadata.o \
+ 	xe_devcoredump.o \
+ 	xe_device.o \
+ 	xe_device_sysfs.o \
+@@ -50,7 +50,7 @@ xe-y += xe_bb.o \
+ 	xe_gt_debugfs.o \
+ 	xe_gt_freq.o \
+ 	xe_gt_idle.o \
+-	xe_gt_debug.o \
++	prelim/xe_gt_debug.o \
+ 	xe_gt_mcr.o \
+ 	xe_gt_pagefault.o \
+ 	xe_gt_sysfs.o \
+@@ -145,7 +145,7 @@ xe-$(CONFIG_PCI_IOV) += \
+ 	xe_pci_sriov.o \
+ 	xe_sriov_pf.o
+ 
+-xe-$(CONFIG_DRM_XE_EUDEBUG) += xe_eudebug.o
++xe-$(CONFIG_PRELIM_DRM_XE_EUDEBUG) += prelim/xe_eudebug.o
+ 
+ # include helpers for tests even when XE is built-in
+ ifdef CONFIG_DRM_XE_KUNIT_TEST
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.c b/drivers/gpu/drm/xe/prelim/xe_debug_metadata.c
+similarity index 67%
+rename from drivers/gpu/drm/xe/xe_debug_metadata.c
+rename to drivers/gpu/drm/xe/prelim/xe_debug_metadata.c
+index 31e943248cfc..a3b3b9c7bd06 100644
+--- a/drivers/gpu/drm/xe/xe_debug_metadata.c
++++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata.c
+@@ -2,32 +2,32 @@
+ /*
+  * Copyright © 2023 Intel Corporation
+  */
+-#include "xe_debug_metadata.h"
++#include "prelim/xe_debug_metadata.h"
+ 
+ #include <drm/drm_device.h>
+ #include <drm/drm_file.h>
+ #include <drm/xe_drm.h>
+ 
+ #include "xe_device.h"
+-#include "xe_eudebug.h"
++#include "prelim/xe_eudebug.h"
+ #include "xe_macros.h"
+ 
+ static void xe_debug_metadata_release(struct kref *ref)
+ {
+-	struct xe_debug_metadata *mdata = container_of(ref, struct xe_debug_metadata, refcount);
++	struct prelim_xe_debug_metadata *mdata = container_of(ref, struct prelim_xe_debug_metadata, refcount);
+ 
+ 	kvfree(mdata->ptr);
+ 	kfree(mdata);
+ }
+ 
+-void xe_debug_metadata_put(struct xe_debug_metadata *mdata)
++void prelim_xe_debug_metadata_put(struct prelim_xe_debug_metadata *mdata)
+ {
+ 	kref_put(&mdata->refcount, xe_debug_metadata_release);
+ }
+ 
+-struct xe_debug_metadata *xe_debug_metadata_get(struct xe_file *xef, u32 id)
++struct prelim_xe_debug_metadata *prelim_xe_debug_metadata_get(struct xe_file *xef, u32 id)
+ {
+-	struct xe_debug_metadata *mdata;
++	struct prelim_xe_debug_metadata *mdata;
+ 
+ 	mutex_lock(&xef->debug_metadata.lock);
+ 	mdata = xa_load(&xef->debug_metadata.xa, id);
+@@ -38,21 +38,21 @@ struct xe_debug_metadata *xe_debug_metadata_get(struct xe_file *xef, u32 id)
+ 	return mdata;
+ }
+ 
+-int xe_debug_metadata_create_ioctl(struct drm_device *dev,
++int prelim_xe_debug_metadata_create_ioctl(struct drm_device *dev,
+ 				   void *data,
+ 				   struct drm_file *file)
+ {
+ 	struct xe_device *xe = to_xe_device(dev);
+ 	struct xe_file *xef = to_xe_file(file);
+-	struct drm_xe_debug_metadata_create *args = data;
+-	struct xe_debug_metadata *mdata;
++	struct prelim_drm_xe_debug_metadata_create *args = data;
++	struct prelim_xe_debug_metadata *mdata;
+ 	int err;
+ 	u32 id;
+ 
+ 	if (XE_IOCTL_DBG(xe, args->extensions))
+ 		return -EINVAL;
+ 
+-	if (XE_IOCTL_DBG(xe, args->type >= WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_NUM))
++	if (XE_IOCTL_DBG(xe, args->type >= PRELIM_WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_NUM))
+ 		return -EINVAL;
+ 
+ 	if (XE_IOCTL_DBG(xe, !args->user_addr || !args->len))
+@@ -91,23 +91,23 @@ int xe_debug_metadata_create_ioctl(struct drm_device *dev,
+ 	if (err)
+ 		goto put_mdata;
+ 
+-	xe_eudebug_debug_metadata_create(xef, mdata);
++	prelim_xe_eudebug_debug_metadata_create(xef, mdata);
+ 
+ 	return 0;
+ 
+ put_mdata:
+-	xe_debug_metadata_put(mdata);
++	prelim_xe_debug_metadata_put(mdata);
+ 	return err;
+ }
+ 
+-int xe_debug_metadata_destroy_ioctl(struct drm_device *dev,
++int prelim_xe_debug_metadata_destroy_ioctl(struct drm_device *dev,
+ 				    void *data,
+ 				    struct drm_file *file)
+ {
+ 	struct xe_device *xe = to_xe_device(dev);
+ 	struct xe_file *xef = to_xe_file(file);
+-	struct drm_xe_debug_metadata_destroy * const args = data;
+-	struct xe_debug_metadata *mdata;
++	struct prelim_drm_xe_debug_metadata_destroy * const args = data;
++	struct prelim_xe_debug_metadata *mdata;
+ 
+ 	if (XE_IOCTL_DBG(xe, args->extensions))
+ 		return -EINVAL;
+@@ -118,8 +118,8 @@ int xe_debug_metadata_destroy_ioctl(struct drm_device *dev,
+ 	if (XE_IOCTL_DBG(xe, !mdata))
+ 		return -ENOENT;
+ 
+-	xe_eudebug_debug_metadata_destroy(xef, mdata);
++	prelim_xe_eudebug_debug_metadata_destroy(xef, mdata);
+ 
+-	xe_debug_metadata_put(mdata);
++	prelim_xe_debug_metadata_put(mdata);
+ 	return 0;
+ }
+diff --git a/drivers/gpu/drm/xe/prelim/xe_debug_metadata.h b/drivers/gpu/drm/xe/prelim/xe_debug_metadata.h
+new file mode 100644
+index 000000000000..70c04d3eb694
+--- /dev/null
++++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata.h
+@@ -0,0 +1,25 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef _XE_DEBUG_METADATA_H_
++#define _XE_DEBUG_METADATA_H_
++
++#include "prelim/xe_debug_metadata_types.h"
++
++struct drm_device;
++struct drm_file;
++struct xe_file;
++
++struct prelim_xe_debug_metadata *prelim_xe_debug_metadata_get(struct xe_file *xef, u32 id);
++void prelim_xe_debug_metadata_put(struct prelim_xe_debug_metadata *mdata);
++
++int prelim_xe_debug_metadata_create_ioctl(struct drm_device *dev,
++				   void *data,
++				   struct drm_file *file);
++
++int prelim_xe_debug_metadata_destroy_ioctl(struct drm_device *dev,
++				    void *data,
++				    struct drm_file *file);
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata_types.h b/drivers/gpu/drm/xe/prelim/xe_debug_metadata_types.h
+similarity index 92%
+rename from drivers/gpu/drm/xe/xe_debug_metadata_types.h
+rename to drivers/gpu/drm/xe/prelim/xe_debug_metadata_types.h
+index 508f2fdbbc42..d8443aa5dd17 100644
+--- a/drivers/gpu/drm/xe/xe_debug_metadata_types.h
++++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata_types.h
+@@ -8,7 +8,7 @@
+ 
+ #include <linux/kref.h>
+ 
+-struct xe_debug_metadata {
++struct prelim_xe_debug_metadata {
+ 	/** @type: type of given metadata */
+ 	u64 type;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/prelim/xe_eudebug.c
+similarity index 88%
+rename from drivers/gpu/drm/xe/xe_eudebug.c
+rename to drivers/gpu/drm/xe/prelim/xe_eudebug.c
+index fbf8213c9b8d..1965cdeb101a 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.c
+@@ -28,7 +28,7 @@
+ #include "xe_rtp.h"
+ #include "xe_wa.h"
+ #include "xe_gt.h"
+-#include "xe_gt_debug.h"
++#include "prelim/xe_gt_debug.h"
+ #include "xe_lrc.h"
+ #include "xe_hw_engine.h"
+ #include "xe_exec_queue.h"
+@@ -42,12 +42,12 @@
+ #include "xe_sync.h"
+ #include "xe_bo.h"
+ #include "xe_exec_queue_types.h"
+-#include "xe_debug_metadata.h"
++#include "prelim/xe_debug_metadata.h"
+ #include "xe_guc_exec_queue_types.h"
+ #include "xe_execlist_types.h"
+ 
+-#include "xe_eudebug_types.h"
+-#include "xe_eudebug.h"
++#include "prelim/xe_eudebug_types.h"
++#include "prelim/xe_eudebug.h"
+ 
+ /*
+  * If there is no detected event read by userspace, during this period, assume
+@@ -253,7 +253,7 @@ static void xe_eudebug_free(struct kref *ref)
+ 	kfree_rcu(d, rcu);
+ }
+ 
+-void xe_eudebug_put(struct xe_eudebug *d)
++void prelim_xe_eudebug_put(struct xe_eudebug *d)
+ {
+ 	kref_put(&d->ref, xe_eudebug_free);
+ }
+@@ -448,7 +448,7 @@ static bool xe_eudebug_detach(struct xe_device *xe,
+ 	release_acks(d);
+ 
+ 	/* Our ref with the connection_link */
+-	xe_eudebug_put(d);
++	prelim_xe_eudebug_put(d);
+ 
+ 	return true;
+ }
+@@ -477,7 +477,7 @@ static int xe_eudebug_release(struct inode *inode, struct file *file)
+ 	struct xe_eudebug *d = file->private_data;
+ 
+ 	xe_eudebug_disconnect(d, 0);
+-	xe_eudebug_put(d);
++	prelim_xe_eudebug_put(d);
+ 
+ 	return 0;
+ }
+@@ -548,7 +548,7 @@ static struct task_struct *find_task_get(struct xe_file *xef)
+ }
+ 
+ struct xe_eudebug *
+-xe_eudebug_get(struct xe_file *xef)
++prelim_xe_eudebug_get(struct xe_file *xef)
+ {
+ 	struct task_struct *task;
+ 	struct xe_eudebug *d;
+@@ -571,7 +571,7 @@ xe_eudebug_get(struct xe_file *xef)
+ 		xe_eudebug_disconnect(d, -ETIMEDOUT);
+ 
+ 	if (xe_eudebug_detached(d)) {
+-		xe_eudebug_put(d);
++		prelim_xe_eudebug_put(d);
+ 		return NULL;
+ 	}
+ 
+@@ -586,7 +586,7 @@ static int xe_eudebug_queue_event(struct xe_eudebug *d,
+ 
+ 	xe_eudebug_assert(d, event->len > sizeof(struct xe_eudebug_event));
+ 	xe_eudebug_assert(d, event->type);
+-	xe_eudebug_assert(d, event->type != DRM_XE_EUDEBUG_EVENT_READ);
++	xe_eudebug_assert(d, event->type != PRELIM_DRM_XE_EUDEBUG_EVENT_READ);
+ 
+ 	start_ts = ktime_get();
+ 	last_read_detected_ts = start_ts;
+@@ -770,16 +770,16 @@ static struct xe_vm *find_vm(struct xe_eudebug *d, const u32 id)
+ 	return NULL;
+ }
+ 
+-static struct xe_debug_metadata *find_metadata_get(struct xe_eudebug *d,
++static struct prelim_xe_debug_metadata *find_metadata_get(struct xe_eudebug *d,
+ 						   u32 id)
+ {
+-	struct xe_debug_metadata *m = NULL;
++	struct prelim_xe_debug_metadata *m = NULL;
+ 	struct xe_eudebug_handle *h;
+ 
+ 	mutex_lock(&d->res->lock);
+ 	h = __find_resource(d->res, XE_EUDEBUG_RES_TYPE_METADATA, id);
+ 	if (h) {
+-		m = (struct xe_debug_metadata *)h->key;
++		m = (struct prelim_xe_debug_metadata *)h->key;
+ 		kref_get(&m->refcount);
+ 	}
+ 	mutex_unlock(&d->res->lock);
+@@ -961,11 +961,11 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 				  const bool wait)
+ {
+ 	struct xe_device *xe = d->xe;
+-	struct drm_xe_eudebug_event __user * const user_orig =
++	struct prelim_drm_xe_eudebug_event __user * const user_orig =
+ 		u64_to_user_ptr(arg);
+-	struct drm_xe_eudebug_event user_event;
++	struct prelim_drm_xe_eudebug_event user_event;
+ 	struct xe_eudebug_event *event;
+-	const unsigned int max_event = DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA;
++	const unsigned int max_event = PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA;
+ 	long ret = 0;
+ 
+ 	if (XE_IOCTL_DBG(xe, copy_from_user(&user_event, user_orig, sizeof(user_event))))
+@@ -977,7 +977,7 @@ static long xe_eudebug_read_event(struct xe_eudebug *d,
+ 	if (XE_IOCTL_DBG(xe, user_event.type > max_event))
+ 		return -EINVAL;
+ 
+-	if (XE_IOCTL_DBG(xe, user_event.type != DRM_XE_EUDEBUG_EVENT_READ))
++	if (XE_IOCTL_DBG(xe, user_event.type != PRELIM_DRM_XE_EUDEBUG_EVENT_READ))
+ 		return -EINVAL;
+ 
+ 	if (XE_IOCTL_DBG(xe, user_event.len < sizeof(*user_orig)))
+@@ -1045,9 +1045,9 @@ xe_eudebug_ack_event_ioctl(struct xe_eudebug *d,
+ 			   const unsigned int cmd,
+ 			   const u64 arg)
+ {
+-	struct drm_xe_eudebug_ack_event __user * const user_ptr =
++	struct prelim_drm_xe_eudebug_ack_event __user * const user_ptr =
+ 		u64_to_user_ptr(arg);
+-	struct drm_xe_eudebug_ack_event user_arg;
++	struct prelim_drm_xe_eudebug_ack_event user_arg;
+ 	struct xe_eudebug_ack *ack;
+ 	struct xe_device *xe = d->xe;
+ 
+@@ -1079,8 +1079,8 @@ xe_eudebug_ack_event_ioctl(struct xe_eudebug *d,
+ }
+ 
+ static int do_eu_control(struct xe_eudebug *d,
+-			 const struct drm_xe_eudebug_eu_control * const arg,
+-			 struct drm_xe_eudebug_eu_control __user * const user_ptr)
++			 const struct prelim_drm_xe_eudebug_eu_control * const arg,
++			 struct prelim_drm_xe_eudebug_eu_control __user * const user_ptr)
+ {
+ 	void __user * const bitmask_ptr = u64_to_user_ptr(arg->bitmask_ptr);
+ 	struct xe_device *xe = d->xe;
+@@ -1123,7 +1123,7 @@ static int do_eu_control(struct xe_eudebug *d,
+ 		goto queue_put;
+ 	}
+ 
+-	hw_attn_size = xe_gt_eu_attention_bitmap_size(q->gt);
++	hw_attn_size = prelim_xe_gt_eu_attention_bitmap_size(q->gt);
+ 	attn_size = arg->bitmask_size;
+ 
+ 	if (attn_size > hw_attn_size)
+@@ -1151,15 +1151,15 @@ static int do_eu_control(struct xe_eudebug *d,
+ 	mutex_lock(&d->eu_lock);
+ 
+ 	switch (arg->cmd) {
+-	case DRM_XE_EUDEBUG_EU_CONTROL_CMD_INTERRUPT_ALL:
++	case PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_INTERRUPT_ALL:
+ 		/* Make sure we dont promise anything but interrupting all */
+ 		if (!attn_size)
+ 			ret = d->ops->interrupt_all(d, q, lrc);
+ 		break;
+-	case DRM_XE_EUDEBUG_EU_CONTROL_CMD_STOPPED:
++	case PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_STOPPED:
+ 		ret = d->ops->stopped(d, q, lrc, bits, attn_size);
+ 		break;
+-	case DRM_XE_EUDEBUG_EU_CONTROL_CMD_RESUME:
++	case PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_RESUME:
+ 		ret = d->ops->resume(d, q, lrc, bits, attn_size);
+ 		break;
+ 	default:
+@@ -1198,19 +1198,19 @@ static int do_eu_control(struct xe_eudebug *d,
+ 
+ static long xe_eudebug_eu_control(struct xe_eudebug *d, const u64 arg)
+ {
+-	struct drm_xe_eudebug_eu_control __user * const user_ptr =
++	struct prelim_drm_xe_eudebug_eu_control __user * const user_ptr =
+ 		u64_to_user_ptr(arg);
+-	struct drm_xe_eudebug_eu_control user_arg;
++	struct prelim_drm_xe_eudebug_eu_control user_arg;
+ 	struct xe_device *xe = d->xe;
+ 	int ret;
+ 
+-	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) & _IOC_WRITE)))
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(PRELIM_DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) & _IOC_WRITE)))
+ 		return -EINVAL;
+ 
+-	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) & _IOC_READ)))
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(PRELIM_DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) & _IOC_READ)))
+ 		return -EINVAL;
+ 
+-	if (XE_IOCTL_DBG(xe, _IOC_SIZE(DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) != sizeof(user_arg)))
++	if (XE_IOCTL_DBG(xe, _IOC_SIZE(PRELIM_DRM_XE_EUDEBUG_IOCTL_EU_CONTROL) != sizeof(user_arg)))
+ 		return -EINVAL;
+ 
+ 	if (copy_from_user(&user_arg,
+@@ -1246,8 +1246,8 @@ static long xe_eudebug_read_metadata(struct xe_eudebug *d,
+ 				     unsigned int cmd,
+ 				     const u64 arg)
+ {
+-	struct drm_xe_eudebug_read_metadata user_arg;
+-	struct xe_debug_metadata *mdata;
++	struct prelim_drm_xe_eudebug_read_metadata user_arg;
++	struct prelim_xe_debug_metadata *mdata;
+ 	struct xe_file *xef;
+ 	struct xe_device *xe = d->xe;
+ 	long ret = 0;
+@@ -1305,7 +1305,7 @@ static long xe_eudebug_read_metadata(struct xe_eudebug *d,
+ 		ret = -EFAULT;
+ 
+ metadata_put:
+-	xe_debug_metadata_put(mdata);
++	prelim_xe_debug_metadata_put(mdata);
+ 	return ret;
+ }
+ 
+@@ -1319,23 +1319,23 @@ static long xe_eudebug_ioctl(struct file *file,
+ 	long ret;
+ 
+ 	switch (cmd) {
+-	case DRM_XE_EUDEBUG_IOCTL_READ_EVENT:
++	case PRELIM_DRM_XE_EUDEBUG_IOCTL_READ_EVENT:
+ 		ret = xe_eudebug_read_event(d, arg,
+ 					    !(file->f_flags & O_NONBLOCK));
+ 		break;
+-	case DRM_XE_EUDEBUG_IOCTL_EU_CONTROL:
++	case PRELIM_DRM_XE_EUDEBUG_IOCTL_EU_CONTROL:
+ 		ret = xe_eudebug_eu_control(d, arg);
+ 		eu_dbg(d, "ioctl cmd=EU_CONTROL ret=%ld\n", ret);
+ 		break;
+-	case DRM_XE_EUDEBUG_IOCTL_ACK_EVENT:
++	case PRELIM_DRM_XE_EUDEBUG_IOCTL_ACK_EVENT:
+ 		ret = xe_eudebug_ack_event_ioctl(d, cmd, arg);
+ 		eu_dbg(d, "ioctl cmd=EVENT_ACK ret=%ld\n", ret);
+ 		break;
+-	case DRM_XE_EUDEBUG_IOCTL_VM_OPEN:
++	case PRELIM_DRM_XE_EUDEBUG_IOCTL_VM_OPEN:
+ 		ret = xe_eudebug_vm_open_ioctl(d, arg);
+ 		eu_dbg(d, "ioctl cmd=VM_OPEN ret=%ld\n", ret);
+ 		break;
+-	case DRM_XE_EUDEBUG_IOCTL_READ_METADATA:
++	case PRELIM_DRM_XE_EUDEBUG_IOCTL_READ_METADATA:
+ 		ret = xe_eudebug_read_metadata(d, cmd, arg);
+ 		eu_dbg(d, "ioctl cmd=READ_METADATA ret=%ld\n", ret);
+ 		break;
+@@ -1583,7 +1583,7 @@ static int send_attention_event(struct xe_eudebug *d, struct xe_exec_queue *q, i
+ 	struct xe_eudebug_event_eu_attention *ea;
+ 	struct xe_eudebug_event *event;
+ 	int h_c, h_queue, h_lrc;
+-	u32 size = xe_gt_eu_attention_bitmap_size(q->gt);
++	u32 size = prelim_xe_gt_eu_attention_bitmap_size(q->gt);
+ 	u32 sz = struct_size(ea, bitmask, size);
+ 	int ret;
+ 
+@@ -1603,21 +1603,21 @@ static int send_attention_event(struct xe_eudebug *d, struct xe_exec_queue *q, i
+ 	if (h_lrc < 0)
+ 		return h_lrc;
+ 
+-	event = __xe_eudebug_create_event(d, 0, DRM_XE_EUDEBUG_EVENT_EU_ATTENTION,
+-					  DRM_XE_EUDEBUG_EVENT_STATE_CHANGE, sz, GFP_KERNEL);
++	event = __xe_eudebug_create_event(d, 0, PRELIM_DRM_XE_EUDEBUG_EVENT_EU_ATTENTION,
++					  PRELIM_DRM_XE_EUDEBUG_EVENT_STATE_CHANGE, sz, GFP_KERNEL);
+ 
+ 	if (!event)
+ 		return -ENOSPC;
+ 
+ 	ea = cast_event(ea, event);
+-	write_member(struct drm_xe_eudebug_event_eu_attention, ea, client_handle, (u64)h_c);
+-	write_member(struct drm_xe_eudebug_event_eu_attention, ea, exec_queue_handle, (u64)h_queue);
+-	write_member(struct drm_xe_eudebug_event_eu_attention, ea, lrc_handle, (u64)h_lrc);
+-	write_member(struct drm_xe_eudebug_event_eu_attention, ea, bitmask_size, size);
++	write_member(struct prelim_drm_xe_eudebug_event_eu_attention, ea, client_handle, (u64)h_c);
++	write_member(struct prelim_drm_xe_eudebug_event_eu_attention, ea, exec_queue_handle, (u64)h_queue);
++	write_member(struct prelim_drm_xe_eudebug_event_eu_attention, ea, lrc_handle, (u64)h_lrc);
++	write_member(struct prelim_drm_xe_eudebug_event_eu_attention, ea, bitmask_size, size);
+ 
+ 	mutex_lock(&d->eu_lock);
+ 	event->seqno = atomic_long_inc_return(&d->events.seqno);
+-	ret = xe_gt_eu_attention_bitmap(q->gt, &ea->bitmask[0], ea->bitmask_size);
++	ret = prelim_xe_gt_eu_attention_bitmap(q->gt, &ea->bitmask[0], ea->bitmask_size);
+ 	mutex_unlock(&d->eu_lock);
+ 
+ 	if (ret)
+@@ -1644,7 +1644,7 @@ static int xe_send_gt_attention(struct xe_gt *gt)
+ 		goto err_exec_queue_put;
+ 	}
+ 
+-	d = xe_eudebug_get(q->vm->xef);
++	d = prelim_xe_eudebug_get(q->vm->xef);
+ 	if (!d) {
+ 		ret = -ENOTCONN;
+ 		goto err_exec_queue_put;
+@@ -1661,7 +1661,7 @@ static int xe_send_gt_attention(struct xe_gt *gt)
+ 		xe_eudebug_disconnect(d, ret);
+ 
+ err_eudebug_put:
+-	xe_eudebug_put(d);
++	prelim_xe_eudebug_put(d);
+ err_exec_queue_put:
+ 	xe_exec_queue_put(q);
+ 
+@@ -1672,7 +1672,7 @@ static int xe_eudebug_handle_gt_attention(struct xe_gt *gt)
+ {
+ 	int ret;
+ 
+-	ret = xe_gt_eu_threads_needing_attention(gt);
++	ret = prelim_xe_gt_eu_threads_needing_attention(gt);
+ 	if (ret <= 0)
+ 		return ret;
+ 
+@@ -1837,14 +1837,14 @@ static int check_attn_mcr(struct xe_gt *gt, void *data,
+ 	struct xe_eudebug *d = iter->debugger;
+ 	unsigned int row;
+ 
+-	for (row = 0; row < TD_EU_ATTENTION_MAX_ROWS; row++) {
++	for (row = 0; row < PRELIM_TD_EU_ATTENTION_MAX_ROWS; row++) {
+ 		u32 val, cur = 0;
+ 
+ 		if (iter->i >= iter->size)
+ 			return 0;
+ 
+ 		if (XE_WARN_ON((iter->i + sizeof(val)) >
+-				(xe_gt_eu_attention_bitmap_size(gt))))
++				(prelim_xe_gt_eu_attention_bitmap_size(gt))))
+ 			return -EIO;
+ 
+ 		memcpy(&val, &iter->bits[iter->i], sizeof(val));
+@@ -1870,14 +1870,14 @@ static int clear_attn_mcr(struct xe_gt *gt, void *data,
+ 	struct xe_eudebug *d = iter->debugger;
+ 	unsigned int row;
+ 
+-	for (row = 0; row < TD_EU_ATTENTION_MAX_ROWS; row++) {
++	for (row = 0; row < PRELIM_TD_EU_ATTENTION_MAX_ROWS; row++) {
+ 		u32 val;
+ 
+ 		if (iter->i >= iter->size)
+ 			return 0;
+ 
+ 		if (XE_WARN_ON((iter->i + sizeof(val)) >
+-				(xe_gt_eu_attention_bitmap_size(gt))))
++				(prelim_xe_gt_eu_attention_bitmap_size(gt))))
+ 			return -EIO;
+ 
+ 		memcpy(&val, &iter->bits[iter->i], sizeof(val));
+@@ -1932,14 +1932,14 @@ static int xe_eu_control_resume(struct xe_eudebug *d,
+ 	 * in order to avoid the EOT hang on PVC.
+ 	 */
+ 	if (GRAPHICS_VERx100(d->xe) == 1260) {
+-		ret = xe_gt_foreach_dss_group_instance(q->gt, check_attn_mcr, &iter);
++		ret = prelim_xe_gt_foreach_dss_group_instance(q->gt, check_attn_mcr, &iter);
+ 		if (ret)
+ 			return ret;
+ 
+ 		iter.i = 0;
+ 	}
+ 
+-	xe_gt_foreach_dss_group_instance(q->gt, clear_attn_mcr, &iter);
++	prelim_xe_gt_foreach_dss_group_instance(q->gt, clear_attn_mcr, &iter);
+ 	return 0;
+ }
+ 
+@@ -1973,7 +1973,7 @@ static int xe_eu_control_stopped(struct xe_eudebug *d,
+ 
+ 	xe_exec_queue_put(active);
+ 
+-	return xe_gt_eu_attention_bitmap(q->gt, bits, bitmask_size);
++	return prelim_xe_gt_eu_attention_bitmap(q->gt, bits, bitmask_size);
+ }
+ 
+ static struct xe_eudebug_eu_control_ops eu_control = {
+@@ -1986,7 +1986,7 @@ static void discovery_work_fn(struct work_struct *work);
+ 
+ static int
+ xe_eudebug_connect(struct xe_device *xe,
+-		   struct drm_xe_eudebug_connect *param)
++		   struct prelim_drm_xe_eudebug_connect *param)
+ {
+ 	const u64 known_open_flags = 0;
+ 	unsigned long f_flags = 0;
+@@ -2002,10 +2002,10 @@ xe_eudebug_connect(struct xe_device *xe,
+ 	if (param->flags & ~known_open_flags)
+ 		return -EINVAL;
+ 
+-	if (param->version && param->version != DRM_XE_EUDEBUG_VERSION)
++	if (param->version && param->version != PRELIM_DRM_XE_EUDEBUG_VERSION)
+ 		return -EINVAL;
+ 
+-	param->version = DRM_XE_EUDEBUG_VERSION;
++	param->version = PRELIM_DRM_XE_EUDEBUG_VERSION;
+ 
+ 	d = kzalloc(sizeof(*d), GFP_KERNEL);
+ 	if (!d)
+@@ -2060,12 +2060,12 @@ xe_eudebug_connect(struct xe_device *xe,
+ 	return err;
+ }
+ 
+-int xe_eudebug_connect_ioctl(struct drm_device *dev,
++int prelim_xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 			     void *data,
+ 			     struct drm_file *file)
+ {
+ 	struct xe_device *xe = to_xe_device(dev);
+-	struct drm_xe_eudebug_connect * const param = data;
++	struct prelim_drm_xe_eudebug_connect * const param = data;
+ 	int ret = 0;
+ 
+ 	mutex_lock(&xe->eudebug.enable_lock);
+@@ -2189,14 +2189,14 @@ static int xe_eudebug_enable(struct xe_device *xe, bool enable)
+ 	return 0;
+ }
+ 
+-static ssize_t enable_eudebug_show(struct device *dev, struct device_attribute *attr, char *buf)
++static ssize_t prelim_enable_eudebug_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+ 	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
+ 
+ 	return sysfs_emit(buf, "%u\n", xe->eudebug.enable);
+ }
+ 
+-static ssize_t enable_eudebug_store(struct device *dev, struct device_attribute *attr,
++static ssize_t prelim_enable_eudebug_store(struct device *dev, struct device_attribute *attr,
+ 				    const char *buf, size_t count)
+ {
+ 	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
+@@ -2214,16 +2214,16 @@ static ssize_t enable_eudebug_store(struct device *dev, struct device_attribute
+ 	return count;
+ }
+ 
+-static DEVICE_ATTR_RW(enable_eudebug);
++static DEVICE_ATTR_RW(prelim_enable_eudebug);
+ 
+ static void xe_eudebug_sysfs_fini(void *arg)
+ {
+ 	struct xe_device *xe = arg;
+ 
+-	sysfs_remove_file(&xe->drm.dev->kobj, &dev_attr_enable_eudebug.attr);
++	sysfs_remove_file(&xe->drm.dev->kobj, &dev_attr_prelim_enable_eudebug.attr);
+ }
+ 
+-void xe_eudebug_init(struct xe_device *xe)
++void prelim_xe_eudebug_init(struct xe_device *xe)
+ {
+ 	struct device *dev = xe->drm.dev;
+ 	int ret;
+@@ -2236,7 +2236,7 @@ void xe_eudebug_init(struct xe_device *xe)
+ 	xe->eudebug.enable = false;
+ 
+ 
+-	ret = sysfs_create_file(&xe->drm.dev->kobj, &dev_attr_enable_eudebug.attr);
++	ret = sysfs_create_file(&xe->drm.dev->kobj, &dev_attr_prelim_enable_eudebug.attr);
+ 	if (ret)
+ 		drm_warn(&xe->drm, "eudebug sysfs init failed: %d, debugger unavailable\n", ret);
+ 	else
+@@ -2245,7 +2245,7 @@ void xe_eudebug_init(struct xe_device *xe)
+ 	xe->eudebug.available = ret == 0;
+ }
+ 
+-void xe_eudebug_fini(struct xe_device *xe)
++void prelim_xe_eudebug_fini(struct xe_device *xe)
+ {
+ 	attention_scan_cancel(xe);
+ 	xe_assert(xe, list_empty_careful(&xe->eudebug.list));
+@@ -2263,14 +2263,14 @@ static int send_open_event(struct xe_eudebug *d, u32 flags, const u64 handle,
+ 	if (XE_WARN_ON((long)handle >= INT_MAX))
+ 		return -EINVAL;
+ 
+-	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_OPEN, seqno,
++	event = xe_eudebug_create_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_OPEN, seqno,
+ 					flags, sizeof(*eo), GFP_KERNEL);
+ 	if (!event)
+ 		return -ENOMEM;
+ 
+ 	eo = cast_event(eo, event);
+ 
+-	write_member(struct drm_xe_eudebug_event_client, eo,
++	write_member(struct prelim_drm_xe_eudebug_event_client, eo,
+ 		     client_handle, handle);
+ 
+ 	return xe_eudebug_queue_event(d, event);
+@@ -2283,7 +2283,7 @@ static int client_create_event(struct xe_eudebug *d, struct xe_file *xef)
+ 
+ 	ret = xe_eudebug_add_handle(d, XE_EUDEBUG_RES_TYPE_CLIENT, xef, &seqno);
+ 	if (ret > 0)
+-		ret = send_open_event(d, DRM_XE_EUDEBUG_EVENT_CREATE,
++		ret = send_open_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE,
+ 				      ret, seqno);
+ 
+ 	return ret;
+@@ -2297,7 +2297,7 @@ static int client_destroy_event(struct xe_eudebug *d, struct xe_file *xef)
+ 	ret = xe_eudebug_remove_handle(d, XE_EUDEBUG_RES_TYPE_CLIENT,
+ 				       xef, &seqno);
+ 	if (ret > 0)
+-		ret = send_open_event(d, DRM_XE_EUDEBUG_EVENT_DESTROY,
++		ret = send_open_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_DESTROY,
+ 				      ret, seqno);
+ 
+ 	return ret;
+@@ -2306,25 +2306,25 @@ static int client_destroy_event(struct xe_eudebug *d, struct xe_file *xef)
+ #define xe_eudebug_event_put(_d, _err) ({ \
+ 	if ((_err)) \
+ 		xe_eudebug_disconnect((_d), (_err)); \
+-	xe_eudebug_put((_d)); \
++	prelim_xe_eudebug_put((_d)); \
+ 	})
+ 
+-void xe_eudebug_file_open(struct xe_file *xef)
++void prelim_xe_eudebug_file_open(struct xe_file *xef)
+ {
+ 	struct xe_eudebug *d;
+ 
+-	d = xe_eudebug_get(xef);
++	d = prelim_xe_eudebug_get(xef);
+ 	if (!d)
+ 		return;
+ 
+ 	xe_eudebug_event_put(d, client_create_event(d, xef));
+ }
+ 
+-void xe_eudebug_file_close(struct xe_file *xef)
++void prelim_xe_eudebug_file_close(struct xe_file *xef)
+ {
+ 	struct xe_eudebug *d;
+ 
+-	d = xe_eudebug_get(xef);
++	d = prelim_xe_eudebug_get(xef);
+ 	if (!d)
+ 		return;
+ 
+@@ -2339,15 +2339,15 @@ static int send_vm_event(struct xe_eudebug *d, u32 flags,
+ 	struct xe_eudebug_event *event;
+ 	struct xe_eudebug_event_vm *e;
+ 
+-	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM,
++	event = xe_eudebug_create_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_VM,
+ 					seqno, flags, sizeof(*e), GFP_KERNEL);
+ 	if (!event)
+ 		return -ENOMEM;
+ 
+ 	e = cast_event(e, event);
+ 
+-	write_member(struct drm_xe_eudebug_event_vm, e, client_handle, client_handle);
+-	write_member(struct drm_xe_eudebug_event_vm, e, vm_handle, vm_handle);
++	write_member(struct prelim_drm_xe_eudebug_event_vm, e, client_handle, client_handle);
++	write_member(struct prelim_drm_xe_eudebug_event_vm, e, vm_handle, vm_handle);
+ 
+ 	return xe_eudebug_queue_event(d, event);
+ }
+@@ -2372,7 +2372,7 @@ static int vm_create_event(struct xe_eudebug *d,
+ 	if (h_vm <= 0)
+ 		return h_vm;
+ 
+-	ret = send_vm_event(d, DRM_XE_EUDEBUG_EVENT_CREATE, h_c, h_vm, seqno);
++	ret = send_vm_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE, h_c, h_vm, seqno);
+ 
+ 	return ret;
+ }
+@@ -2399,31 +2399,31 @@ static int vm_destroy_event(struct xe_eudebug *d,
+ 	if (h_vm <= 0)
+ 		return h_vm;
+ 
+-	return send_vm_event(d, DRM_XE_EUDEBUG_EVENT_DESTROY, h_c, h_vm, seqno);
++	return send_vm_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_DESTROY, h_c, h_vm, seqno);
+ }
+ 
+-void xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm)
++void prelim_xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm)
+ {
+ 	struct xe_eudebug *d;
+ 
+ 	if (!xe_vm_in_lr_mode(vm))
+ 		return;
+ 
+-	d = xe_eudebug_get(xef);
++	d = prelim_xe_eudebug_get(xef);
+ 	if (!d)
+ 		return;
+ 
+ 	xe_eudebug_event_put(d, vm_create_event(d, xef, vm));
+ }
+ 
+-void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm)
++void prelim_xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm)
+ {
+ 	struct xe_eudebug *d;
+ 
+ 	if (!xe_vm_in_lr_mode(vm))
+ 		return;
+ 
+-	d = xe_eudebug_get(xef);
++	d = prelim_xe_eudebug_get(xef);
+ 	if (!d)
+ 		return;
+ 
+@@ -2457,19 +2457,19 @@ static int send_exec_queue_event(struct xe_eudebug *d, u32 flags,
+ 	if (!exec_queue_class_is_tracked(class))
+ 		return -EINVAL;
+ 
+-	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE,
++	event = xe_eudebug_create_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE,
+ 					seqno, flags, sz, GFP_KERNEL);
+ 	if (!event)
+ 		return -ENOMEM;
+ 
+ 	e = cast_event(e, event);
+ 
+-	write_member(struct drm_xe_eudebug_event_exec_queue, e, client_handle, client_handle);
+-	write_member(struct drm_xe_eudebug_event_exec_queue, e, vm_handle, vm_handle);
+-	write_member(struct drm_xe_eudebug_event_exec_queue, e, exec_queue_handle,
++	write_member(struct prelim_drm_xe_eudebug_event_exec_queue, e, client_handle, client_handle);
++	write_member(struct prelim_drm_xe_eudebug_event_exec_queue, e, vm_handle, vm_handle);
++	write_member(struct prelim_drm_xe_eudebug_event_exec_queue, e, exec_queue_handle,
+ 		     exec_queue_handle);
+-	write_member(struct drm_xe_eudebug_event_exec_queue, e, engine_class, xe_engine_class);
+-	write_member(struct drm_xe_eudebug_event_exec_queue, e, width, width);
++	write_member(struct prelim_drm_xe_eudebug_event_exec_queue, e, engine_class, xe_engine_class);
++	write_member(struct prelim_drm_xe_eudebug_event_exec_queue, e, width, width);
+ 
+ 	memcpy(e->lrc_handle, lrc_handles, width);
+ 
+@@ -2522,7 +2522,7 @@ static int exec_queue_create_event(struct xe_eudebug *d,
+ 	 * we disconnect
+ 	 */
+ 
+-	return send_exec_queue_event(d, DRM_XE_EUDEBUG_EVENT_CREATE,
++	return send_exec_queue_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE,
+ 				     h_c, h_vm, h_queue, q->class,
+ 				     q->width, h_lrc, seqno);
+ }
+@@ -2571,33 +2571,33 @@ static int exec_queue_destroy_event(struct xe_eudebug *d,
+ 		h_lrc[i] = ret;
+ 	}
+ 
+-	return send_exec_queue_event(d, DRM_XE_EUDEBUG_EVENT_DESTROY,
++	return send_exec_queue_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_DESTROY,
+ 				     h_c, h_vm, h_queue, q->class,
+ 				     q->width, h_lrc, seqno);
+ }
+ 
+-void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q)
++void prelim_xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q)
+ {
+ 	struct xe_eudebug *d;
+ 
+ 	if (!exec_queue_class_is_tracked(q->class))
+ 		return;
+ 
+-	d = xe_eudebug_get(xef);
++	d = prelim_xe_eudebug_get(xef);
+ 	if (!d)
+ 		return;
+ 
+ 	xe_eudebug_event_put(d, exec_queue_create_event(d, xef, q));
+ }
+ 
+-void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q)
++void prelim_xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q)
+ {
+ 	struct xe_eudebug *d;
+ 
+ 	if (!exec_queue_class_is_tracked(q->class))
+ 		return;
+ 
+-	d = xe_eudebug_get(xef);
++	d = prelim_xe_eudebug_get(xef);
+ 	if (!d)
+ 		return;
+ 
+@@ -2622,7 +2622,7 @@ static int xe_eudebug_queue_bind_event(struct xe_eudebug *d,
+ 	spin_lock(&vm->eudebug_bind.lock);
+ 	list_add_tail(&env->link, &vm->eudebug_bind.events);
+ 
+-	if (event->type == DRM_XE_EUDEBUG_EVENT_VM_BIND_OP)
++	if (event->type == PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP)
+ 		++vm->eudebug_bind.ops;
+ 	spin_unlock(&vm->eudebug_bind.lock);
+ 
+@@ -2639,20 +2639,20 @@ static int queue_vm_bind_event(struct xe_eudebug *d,
+ 	struct xe_eudebug_event_vm_bind *e;
+ 	struct xe_eudebug_event *event;
+ 	const u32 sz = sizeof(*e);
+-	const u32 base_flags = DRM_XE_EUDEBUG_EVENT_STATE_CHANGE;
++	const u32 base_flags = PRELIM_DRM_XE_EUDEBUG_EVENT_STATE_CHANGE;
+ 
+ 	*seqno = atomic_long_inc_return(&d->events.seqno);
+ 
+-	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM_BIND,
++	event = xe_eudebug_create_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND,
+ 					*seqno, base_flags, sz, GFP_KERNEL);
+ 	if (!event)
+ 		return -ENOMEM;
+ 
+ 	e = cast_event(e, event);
+-	write_member(struct drm_xe_eudebug_event_vm_bind, e, client_handle, client_handle);
+-	write_member(struct drm_xe_eudebug_event_vm_bind, e, vm_handle, vm_handle);
+-	write_member(struct drm_xe_eudebug_event_vm_bind, e, flags, bind_flags);
+-	write_member(struct drm_xe_eudebug_event_vm_bind, e, num_binds, num_ops);
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind, e, client_handle, client_handle);
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind, e, vm_handle, vm_handle);
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind, e, flags, bind_flags);
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind, e, num_binds, num_ops);
+ 
+ 	/* If in discovery, no need to collect ops */
+ 	if (!completion_done(&d->discovery)) {
+@@ -2696,17 +2696,17 @@ static int vm_bind_op_event(struct xe_eudebug *d,
+ 
+ 	*op_seqno = atomic_long_inc_return(&d->events.seqno);
+ 
+-	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM_BIND_OP,
++	event = xe_eudebug_create_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP,
+ 					*op_seqno, flags, sz, GFP_KERNEL);
+ 	if (!event)
+ 		return -ENOMEM;
+ 
+ 	e = cast_event(e, event);
+ 
+-	write_member(struct drm_xe_eudebug_event_vm_bind_op, e, vm_bind_ref_seqno, bind_ref_seqno);
+-	write_member(struct drm_xe_eudebug_event_vm_bind_op, e, num_extensions, num_extensions);
+-	write_member(struct drm_xe_eudebug_event_vm_bind_op, e, addr, addr);
+-	write_member(struct drm_xe_eudebug_event_vm_bind_op, e, range, range);
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind_op, e, vm_bind_ref_seqno, bind_ref_seqno);
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind_op, e, num_extensions, num_extensions);
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind_op, e, addr, addr);
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind_op, e, range, range);
+ 
+ 	/* If in discovery, no need to collect ops */
+ 	if (!completion_done(&d->discovery))
+@@ -2729,18 +2729,18 @@ static int vm_bind_op_metadata_event(struct xe_eudebug *d,
+ 
+ 	seqno = atomic_long_inc_return(&d->events.seqno);
+ 
+-	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA,
++	event = xe_eudebug_create_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA,
+ 					seqno, flags, sz, GFP_KERNEL);
+ 	if (!event)
+ 		return -ENOMEM;
+ 
+ 	e = cast_event(e, event);
+ 
+-	write_member(struct drm_xe_eudebug_event_vm_bind_op_metadata, e,
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind_op_metadata, e,
+ 		     vm_bind_op_ref_seqno, ref_seqno);
+-	write_member(struct drm_xe_eudebug_event_vm_bind_op_metadata, e,
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind_op_metadata, e,
+ 		     metadata_handle, metadata_handle);
+-	write_member(struct drm_xe_eudebug_event_vm_bind_op_metadata, e,
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind_op_metadata, e,
+ 		     metadata_cookie, metadata_cookie);
+ 
+ 	/* If in discovery, no need to collect ops */
+@@ -2755,17 +2755,17 @@ static int vm_bind_op_metadata_count(struct xe_eudebug *d,
+ 				     struct list_head *debug_metadata)
+ {
+ 	struct xe_vma_debug_metadata *metadata;
+-	struct xe_debug_metadata *mdata;
++	struct prelim_xe_debug_metadata *mdata;
+ 	int h_m = 0, metadata_count = 0;
+ 
+ 	if (!debug_metadata)
+ 		return 0;
+ 
+ 	list_for_each_entry(metadata, debug_metadata, link) {
+-		mdata = xe_debug_metadata_get(vm->xef, metadata->metadata_id);
++		mdata = prelim_xe_debug_metadata_get(vm->xef, metadata->metadata_id);
+ 		if (mdata) {
+ 			h_m = find_handle(d->res, XE_EUDEBUG_RES_TYPE_METADATA, mdata);
+-			xe_debug_metadata_put(mdata);
++			prelim_xe_debug_metadata_put(mdata);
+ 		}
+ 
+ 		if (!mdata || h_m < 0) {
+@@ -2797,15 +2797,15 @@ static int vm_bind_op_metadata(struct xe_eudebug *d, struct xe_vm *vm,
+ 	if (!debug_metadata)
+ 		return 0;
+ 
+-	XE_WARN_ON(flags != DRM_XE_EUDEBUG_EVENT_CREATE);
++	XE_WARN_ON(flags != PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE);
+ 
+ 	list_for_each_entry(metadata, debug_metadata, link) {
+-		struct xe_debug_metadata *mdata;
++		struct prelim_xe_debug_metadata *mdata;
+ 
+-		mdata = xe_debug_metadata_get(vm->xef, metadata->metadata_id);
++		mdata = prelim_xe_debug_metadata_get(vm->xef, metadata->metadata_id);
+ 		if (mdata) {
+ 			h_m = find_handle(d->res, XE_EUDEBUG_RES_TYPE_METADATA, mdata);
+-			xe_debug_metadata_put(mdata);
++			prelim_xe_debug_metadata_put(mdata);
+ 		}
+ 
+ 		if (!mdata || h_m < 0) {
+@@ -2897,21 +2897,21 @@ static int vm_bind_ufence_event(struct xe_eudebug *d,
+ 	struct xe_eudebug_event *event;
+ 	struct xe_eudebug_event_vm_bind_ufence *e;
+ 	const u32 sz = sizeof(*e);
+-	const u32 flags = DRM_XE_EUDEBUG_EVENT_CREATE |
+-		DRM_XE_EUDEBUG_EVENT_NEED_ACK;
++	const u32 flags = PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE |
++		PRELIM_DRM_XE_EUDEBUG_EVENT_NEED_ACK;
+ 	u64 seqno;
+ 	int ret;
+ 
+ 	seqno = atomic_long_inc_return(&d->events.seqno);
+ 
+-	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE,
++	event = xe_eudebug_create_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE,
+ 					seqno, flags, sz, GFP_KERNEL);
+ 	if (!event)
+ 		return -ENOMEM;
+ 
+ 	e = cast_event(e, event);
+ 
+-	write_member(struct drm_xe_eudebug_event_vm_bind_ufence,
++	write_member(struct prelim_drm_xe_eudebug_event_vm_bind_ufence,
+ 		     e, vm_bind_ref_seqno, ufence->eudebug.bind_ref_seqno);
+ 
+ 	ret = xe_eudebug_track_ufence(d, ufence, seqno);
+@@ -2921,7 +2921,7 @@ static int vm_bind_ufence_event(struct xe_eudebug *d,
+ 	return ret;
+ }
+ 
+-void xe_eudebug_vm_bind_start(struct xe_vm *vm)
++void prelim_xe_eudebug_vm_bind_start(struct xe_vm *vm)
+ {
+ 	struct xe_eudebug *d;
+ 	u64 seqno = 0;
+@@ -2930,7 +2930,7 @@ void xe_eudebug_vm_bind_start(struct xe_vm *vm)
+ 	if (!xe_vm_in_lr_mode(vm))
+ 		return;
+ 
+-	d = xe_eudebug_get(vm->xef);
++	d = prelim_xe_eudebug_get(vm->xef);
+ 	if (!d)
+ 		return;
+ 
+@@ -2955,10 +2955,10 @@ void xe_eudebug_vm_bind_start(struct xe_vm *vm)
+ 	vm->eudebug_bind.ops = 0;
+ 	spin_unlock(&vm->eudebug_bind.lock);
+ 
+-	xe_eudebug_put(d);
++	prelim_xe_eudebug_put(d);
+ }
+ 
+-void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
++void prelim_xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
+ 			       struct drm_gpuva_ops *ops)
+ {
+ 	struct xe_eudebug *d;
+@@ -2974,7 +2974,7 @@ void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
+ 	{
+ 		struct drm_gpuva_op *__op;
+ 
+-		flags = DRM_XE_EUDEBUG_EVENT_CREATE;
++		flags = PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE;
+ 
+ 		/* OP_MAP will be last and singleton */
+ 		drm_gpuva_for_each_op(__op, ops) {
+@@ -2987,7 +2987,7 @@ void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
+ 	}
+ 	case DRM_XE_VM_BIND_OP_UNMAP:
+ 	case DRM_XE_VM_BIND_OP_UNMAP_ALL:
+-		flags = DRM_XE_EUDEBUG_EVENT_DESTROY;
++		flags = PRELIM_DRM_XE_EUDEBUG_EVENT_DESTROY;
+ 		break;
+ 	default:
+ 		flags = 0;
+@@ -2997,7 +2997,7 @@ void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
+ 	if (!flags)
+ 		return;
+ 
+-	d = xe_eudebug_get(vm->xef);
++	d = prelim_xe_eudebug_get(vm->xef);
+ 	if (!d)
+ 		return;
+ 
+@@ -3032,7 +3032,7 @@ static void fill_vm_bind_fields(struct xe_vm *vm,
+ 	struct xe_eudebug_event_vm_bind *eb = cast_event(eb, e);
+ 
+ 	eb->flags = ufence ?
+-		DRM_XE_EUDEBUG_EVENT_VM_BIND_FLAG_UFENCE : 0;
++		PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_FLAG_UFENCE : 0;
+ 	eb->num_binds = bind_ops;
+ }
+ 
+@@ -3042,14 +3042,14 @@ static void fill_vm_bind_op_fields(struct xe_vm *vm,
+ {
+ 	struct xe_eudebug_event_vm_bind_op *op;
+ 
+-	if (e->type != DRM_XE_EUDEBUG_EVENT_VM_BIND_OP)
++	if (e->type != PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP)
+ 		return;
+ 
+ 	op = cast_event(op, e);
+ 	op->vm_bind_ref_seqno = ref_seqno;
+ }
+ 
+-void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int bind_err)
++void prelim_xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int bind_err)
+ {
+ 	struct xe_eudebug_event *e;
+ 	struct xe_eudebug *d;
+@@ -3072,7 +3072,7 @@ void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int bind_err)
+ 
+ 	d = NULL;
+ 	if (!bind_err && ref) {
+-		d = xe_eudebug_get(vm->xef);
++		d = prelim_xe_eudebug_get(vm->xef);
+ 		if (d) {
+ 			if (bind_ops) {
+ 				fill_vm_bind_fields(vm, e, has_ufence, bind_ops);
+@@ -3081,7 +3081,7 @@ void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int bind_err)
+ 				 * If there was no ops we are interested in,
+ 				 * we can omit the whole sequence
+ 				 */
+-				xe_eudebug_put(d);
++				prelim_xe_eudebug_put(d);
+ 				d = NULL;
+ 			}
+ 		}
+@@ -3098,7 +3098,7 @@ void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int bind_err)
+ 
+ 		if (err) {
+ 			xe_eudebug_disconnect(d, err);
+-			xe_eudebug_put(d);
++			prelim_xe_eudebug_put(d);
+ 			d = NULL;
+ 		}
+ 
+@@ -3110,10 +3110,10 @@ void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int bind_err)
+ 	}
+ 
+ 	if (d)
+-		xe_eudebug_put(d);
++		prelim_xe_eudebug_put(d);
+ }
+ 
+-int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence)
++int prelim_xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence)
+ {
+ 	struct xe_eudebug *d;
+ 	int err;
+@@ -3138,23 +3138,23 @@ static int send_debug_metadata_event(struct xe_eudebug *d, u32 flags,
+ 	struct xe_eudebug_event *event;
+ 	struct xe_eudebug_event_metadata *e;
+ 
+-	event = xe_eudebug_create_event(d, DRM_XE_EUDEBUG_EVENT_METADATA, seqno,
++	event = xe_eudebug_create_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_METADATA, seqno,
+ 					flags, sizeof(*e), GFP_KERNEL);
+ 	if (!event)
+ 		return -ENOMEM;
+ 
+ 	e = cast_event(e, event);
+ 
+-	write_member(struct drm_xe_eudebug_event_metadata, e, client_handle, client_handle);
+-	write_member(struct drm_xe_eudebug_event_metadata, e, metadata_handle, metadata_handle);
+-	write_member(struct drm_xe_eudebug_event_metadata, e, type, type);
+-	write_member(struct drm_xe_eudebug_event_metadata, e, len, len);
++	write_member(struct prelim_drm_xe_eudebug_event_metadata, e, client_handle, client_handle);
++	write_member(struct prelim_drm_xe_eudebug_event_metadata, e, metadata_handle, metadata_handle);
++	write_member(struct prelim_drm_xe_eudebug_event_metadata, e, type, type);
++	write_member(struct prelim_drm_xe_eudebug_event_metadata, e, len, len);
+ 
+ 	return xe_eudebug_queue_event(d, event);
+ }
+ 
+ static int debug_metadata_create_event(struct xe_eudebug *d,
+-				       struct xe_file *xef, struct xe_debug_metadata *m)
++				       struct xe_file *xef, struct prelim_xe_debug_metadata *m)
+ {
+ 	int h_c, h_m;
+ 	u64 seqno;
+@@ -3167,12 +3167,12 @@ static int debug_metadata_create_event(struct xe_eudebug *d,
+ 	if (h_m <= 0)
+ 		return h_m;
+ 
+-	return send_debug_metadata_event(d, DRM_XE_EUDEBUG_EVENT_CREATE,
++	return send_debug_metadata_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE,
+ 					 h_c, h_m, m->type, m->len, seqno);
+ }
+ 
+ static int debug_metadata_destroy_event(struct xe_eudebug *d,
+-					struct xe_file *xef, struct xe_debug_metadata *m)
++					struct xe_file *xef, struct prelim_xe_debug_metadata *m)
+ {
+ 	int h_c, h_m;
+ 	u64 seqno;
+@@ -3185,26 +3185,26 @@ static int debug_metadata_destroy_event(struct xe_eudebug *d,
+ 	if (h_m < 0)
+ 		return h_m;
+ 
+-	return send_debug_metadata_event(d, DRM_XE_EUDEBUG_EVENT_DESTROY,
++	return send_debug_metadata_event(d, PRELIM_DRM_XE_EUDEBUG_EVENT_DESTROY,
+ 					 h_c, h_m, m->type, m->len, seqno);
+ }
+ 
+-void xe_eudebug_debug_metadata_create(struct xe_file *xef, struct xe_debug_metadata *m)
++void prelim_xe_eudebug_debug_metadata_create(struct xe_file *xef, struct prelim_xe_debug_metadata *m)
+ {
+ 	struct xe_eudebug *d;
+ 
+-	d = xe_eudebug_get(xef);
++	d = prelim_xe_eudebug_get(xef);
+ 	if (!d)
+ 		return;
+ 
+ 	xe_eudebug_event_put(d, debug_metadata_create_event(d, xef, m));
+ }
+ 
+-void xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct xe_debug_metadata *m)
++void prelim_xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct prelim_xe_debug_metadata *m)
+ {
+ 	struct xe_eudebug *d;
+ 
+-	d = xe_eudebug_get(xef);
++	d = prelim_xe_eudebug_get(xef);
+ 	if (!d)
+ 		return;
+ 
+@@ -3235,7 +3235,7 @@ static int vm_discover_binds(struct xe_eudebug *d, struct xe_vm *vm)
+ 		if (send_ops >= num_ops)
+ 			break;
+ 
+-		err = vm_bind_op(d, vm, DRM_XE_EUDEBUG_EVENT_CREATE, ref_seqno,
++		err = vm_bind_op(d, vm, PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE, ref_seqno,
+ 				 xe_vma_start(vma), xe_vma_size(vma),
+ 				 &vma->debug_metadata);
+ 		if (err)
+@@ -3249,7 +3249,7 @@ static int vm_discover_binds(struct xe_eudebug *d, struct xe_vm *vm)
+ 
+ static int discover_client(struct xe_eudebug *d, struct xe_file *xef)
+ {
+-	struct xe_debug_metadata *m;
++	struct prelim_xe_debug_metadata *m;
+ 	struct xe_exec_queue *q;
+ 	struct xe_vm *vm;
+ 	unsigned long i;
+@@ -3348,7 +3348,7 @@ static void discovery_work_fn(struct work_struct *work)
+ 
+ 	complete_all(&d->discovery);
+ 
+-	xe_eudebug_put(d);
++	prelim_xe_eudebug_put(d);
+ }
+ 
+ static int xe_eudebug_bovma_access(struct xe_bo *bo, u64 offset,
+@@ -3674,7 +3674,7 @@ static int xe_eudebug_vm_release(struct inode *inode, struct file *file)
+ 
+ 	drm_dev_put(&d->xe->drm);
+ 	xe_vm_put(vmf->vm);
+-	xe_eudebug_put(d);
++	prelim_xe_eudebug_put(d);
+ 	kfree(vmf);
+ 
+ 	return 0;
+@@ -3693,7 +3693,7 @@ static const struct file_operations vm_fops = {
+ static long
+ xe_eudebug_vm_open_ioctl(struct xe_eudebug *d, unsigned long arg)
+ {
+-	struct drm_xe_eudebug_vm_open param;
++	struct prelim_drm_xe_eudebug_vm_open param;
+ 	struct xe_device * const xe = d->xe;
+ 	struct xe_eudebug *d_ref = NULL;
+ 	struct vm_file *vmf = NULL;
+@@ -3703,10 +3703,10 @@ xe_eudebug_vm_open_ioctl(struct xe_eudebug *d, unsigned long arg)
+ 	long ret = 0;
+ 	int fd;
+ 
+-	if (XE_IOCTL_DBG(xe, _IOC_SIZE(DRM_XE_EUDEBUG_IOCTL_VM_OPEN) != sizeof(param)))
++	if (XE_IOCTL_DBG(xe, _IOC_SIZE(PRELIM_DRM_XE_EUDEBUG_IOCTL_VM_OPEN) != sizeof(param)))
+ 		return -EINVAL;
+ 
+-	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(DRM_XE_EUDEBUG_IOCTL_VM_OPEN) & _IOC_WRITE)))
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(PRELIM_DRM_XE_EUDEBUG_IOCTL_VM_OPEN) & _IOC_WRITE)))
+ 		return -EINVAL;
+ 
+ 	if (XE_IOCTL_DBG(xe, copy_from_user(&param, (void __user *)arg, sizeof(param))))
+@@ -3726,7 +3726,7 @@ xe_eudebug_vm_open_ioctl(struct xe_eudebug *d, unsigned long arg)
+ 		return -EINVAL;
+ 	}
+ 
+-	d_ref = xe_eudebug_get(xef);
++	d_ref = prelim_xe_eudebug_get(xef);
+ 	if (XE_IOCTL_DBG(xe, !d_ref)) {
+ 		mutex_unlock(&d->xe->files.lock);
+ 		return -EINVAL;
+@@ -3794,11 +3794,11 @@ xe_eudebug_vm_open_ioctl(struct xe_eudebug *d, unsigned long arg)
+ out_vm_put:
+ 	xe_vm_put(vm);
+ out_eudebug_put:
+-	xe_eudebug_put(d_ref);
++	prelim_xe_eudebug_put(d_ref);
+ 
+ 	return ret;
+ }
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_KUNIT_TEST)
+-#include "tests/xe_eudebug.c"
++#include "tests/prelim/xe_eudebug.c"
+ #endif
+diff --git a/drivers/gpu/drm/xe/prelim/xe_eudebug.h b/drivers/gpu/drm/xe/prelim/xe_eudebug.h
+new file mode 100644
+index 000000000000..1d264c1a688c
+--- /dev/null
++++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.h
+@@ -0,0 +1,87 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef _XE_EUDEBUG_H_
++
++#include <linux/types.h>
++
++struct drm_device;
++struct drm_file;
++struct xe_device;
++struct xe_file;
++struct xe_vm;
++struct xe_vma;
++struct xe_exec_queue;
++struct xe_hw_engine;
++struct xe_user_fence;
++struct prelim_xe_debug_metadata;
++struct drm_gpuva_ops;
++
++#if IS_ENABLED(CONFIG_PRELIM_DRM_XE_EUDEBUG)
++
++int prelim_xe_eudebug_connect_ioctl(struct drm_device *dev,
++			     void *data,
++			     struct drm_file *file);
++
++void prelim_xe_eudebug_init(struct xe_device *xe);
++void prelim_xe_eudebug_fini(struct xe_device *xe);
++
++void prelim_xe_eudebug_file_open(struct xe_file *xef);
++void prelim_xe_eudebug_file_close(struct xe_file *xef);
++
++void prelim_xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm);
++void prelim_xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm);
++
++void prelim_xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q);
++void prelim_xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q);
++
++void prelim_xe_eudebug_vm_bind_start(struct xe_vm *vm);
++void prelim_xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
++			       struct drm_gpuva_ops *ops);
++void prelim_xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err);
++
++int prelim_xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence);
++
++struct xe_eudebug *prelim_xe_eudebug_get(struct xe_file *xef);
++void prelim_xe_eudebug_put(struct xe_eudebug *d);
++
++void prelim_xe_eudebug_debug_metadata_create(struct xe_file *xef, struct prelim_xe_debug_metadata *m);
++void prelim_xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct prelim_xe_debug_metadata *m);
++
++#else
++
++static inline int prelim_xe_eudebug_connect_ioctl(struct drm_device *dev,
++					   void *data,
++					   struct drm_file *file) { return 0; }
++
++static inline void prelim_xe_eudebug_init(struct xe_device *xe) { }
++static inline void prelim_xe_eudebug_init_late(struct xe_device *xe) { }
++static inline void prelim_xe_eudebug_fini(struct xe_device *xe) { }
++static inline void prelim_xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe) { }
++
++static inline void prelim_xe_eudebug_file_open(struct xe_file *xef) { }
++static inline void prelim_xe_eudebug_file_close(struct xe_file *xef) { }
++
++static inline void prelim_xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm) { }
++static inline void prelim_xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm) { }
++
++static inline void prelim_xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q) { }
++static inline void prelim_xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q) { }
++
++static inline void prelim_xe_eudebug_vm_bind_start(struct xe_vm *vm) { }
++static inline void prelim_xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range, struct drm_gpuva_ops *ops) { }
++static inline void prelim_xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err) { }
++
++static inline int prelim_xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence) { return 0; }
++
++static inline struct xe_eudebug *prelim_xe_eudebug_get(struct xe_file *xef) { return NULL; }
++static inline void prelim_xe_eudebug_put(struct xe_eudebug *d) { }
++
++static inline void prelim_xe_eudebug_debug_metadata_create(struct xe_file *xef, struct prelim_xe_debug_metadata *m) { }
++static inline void prelim_xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct prelim_xe_debug_metadata *m) { }
++
++#endif /* CONFIG_PRELIM_DRM_XE_EUDEBUG */
++
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/prelim/xe_eudebug_types.h
+similarity index 100%
+rename from drivers/gpu/drm/xe/xe_eudebug_types.h
+rename to drivers/gpu/drm/xe/prelim/xe_eudebug_types.h
+diff --git a/drivers/gpu/drm/xe/xe_gt_debug.c b/drivers/gpu/drm/xe/prelim/xe_gt_debug.c
+similarity index 72%
+rename from drivers/gpu/drm/xe/xe_gt_debug.c
+rename to drivers/gpu/drm/xe/prelim/xe_gt_debug.c
+index fcf32c7c77d8..c0bf2a0a7f2f 100644
+--- a/drivers/gpu/drm/xe/xe_gt_debug.c
++++ b/drivers/gpu/drm/xe/prelim/xe_gt_debug.c
+@@ -8,12 +8,12 @@
+ #include "xe_force_wake.h"
+ #include "xe_gt.h"
+ #include "xe_gt_topology.h"
+-#include "xe_gt_debug.h"
++#include "prelim/xe_gt_debug.h"
+ #include "xe_gt_mcr.h"
+ #include "xe_pm.h"
+ #include "xe_macros.h"
+ 
+-int xe_gt_foreach_dss_group_instance(struct xe_gt *gt,
++int prelim_xe_gt_foreach_dss_group_instance(struct xe_gt *gt,
+ 				     int (*fn)(struct xe_gt *gt,
+ 					       void *data,
+ 					       u16 group,
+@@ -61,13 +61,13 @@ static int read_first_attention_mcr(struct xe_gt *gt, void *data,
+ #define MAX_THREADS 8u
+ 
+ /**
+- * xe_gt_eu_attention_bitmap_size - query size of the attention bitmask
++ * prelim_xe_gt_eu_attention_bitmap_size - query size of the attention bitmask
+  *
+  * @gt: pointer to struct xe_gt
+  *
+  * Return: size in bytes.
+  */
+-int xe_gt_eu_attention_bitmap_size(struct xe_gt *gt)
++int prelim_xe_gt_eu_attention_bitmap_size(struct xe_gt *gt)
+ {
+ 	xe_dss_mask_t dss_mask;
+ 
+@@ -75,7 +75,7 @@ int xe_gt_eu_attention_bitmap_size(struct xe_gt *gt)
+ 		  gt->fuse_topo.g_dss_mask, XE_MAX_DSS_FUSE_BITS);
+ 
+ 	return  bitmap_weight(dss_mask, XE_MAX_DSS_FUSE_BITS) *
+-		TD_EU_ATTENTION_MAX_ROWS * MAX_THREADS *
++		PRELIM_TD_EU_ATTENTION_MAX_ROWS * MAX_THREADS *
+ 		MAX_EUS_PER_ROW / 8;
+ }
+ 
+@@ -92,13 +92,13 @@ static int read_eu_attentions_mcr(struct xe_gt *gt, void *data,
+ 	struct attn_read_iter * const iter = data;
+ 	unsigned int row;
+ 
+-	for (row = 0; row < TD_EU_ATTENTION_MAX_ROWS; row++) {
++	for (row = 0; row < PRELIM_TD_EU_ATTENTION_MAX_ROWS; row++) {
+ 		u32 val;
+ 
+ 		if (iter->i >= iter->size)
+ 			return 0;
+ 
+-		XE_WARN_ON(iter->i + sizeof(val) > xe_gt_eu_attention_bitmap_size(gt));
++		XE_WARN_ON(iter->i + sizeof(val) > prelim_xe_gt_eu_attention_bitmap_size(gt));
+ 
+ 		val = xe_gt_mcr_unicast_read(gt, TD_ATT(row), group, instance);
+ 
+@@ -110,13 +110,13 @@ static int read_eu_attentions_mcr(struct xe_gt *gt, void *data,
+ }
+ 
+ /**
+- * xe_gt_eu_attention_bitmap - query host attention
++ * prelim_xe_gt_eu_attention_bitmap - query host attention
+  *
+  * @gt: pointer to struct xe_gt
+  *
+  * Return: 0 on success, negative otherwise.
+  */
+-int xe_gt_eu_attention_bitmap(struct xe_gt *gt, u8 *bits,
++int prelim_xe_gt_eu_attention_bitmap(struct xe_gt *gt, u8 *bits,
+ 			      unsigned int bitmap_size)
+ {
+ 	struct attn_read_iter iter = {
+@@ -126,21 +126,21 @@ int xe_gt_eu_attention_bitmap(struct xe_gt *gt, u8 *bits,
+ 		.bits = bits
+ 	};
+ 
+-	return xe_gt_foreach_dss_group_instance(gt, read_eu_attentions_mcr, &iter);
++	return prelim_xe_gt_foreach_dss_group_instance(gt, read_eu_attentions_mcr, &iter);
+ }
+ 
+ /**
+- * xe_gt_eu_threads_needing_attention - Query host attention
++ * prelim_xe_gt_eu_threads_needing_attention - Query host attention
+  *
+  * @gt: pointer to struct xe_gt
+  *
+  * Return: 1 if threads waiting host attention, 0 otherwise.
+  */
+-int xe_gt_eu_threads_needing_attention(struct xe_gt *gt)
++int prelim_xe_gt_eu_threads_needing_attention(struct xe_gt *gt)
+ {
+ 	int err;
+ 
+-	err = xe_gt_foreach_dss_group_instance(gt, read_first_attention_mcr, NULL);
++	err = prelim_xe_gt_foreach_dss_group_instance(gt, read_first_attention_mcr, NULL);
+ 
+ 	XE_WARN_ON(err < 0);
+ 
+diff --git a/drivers/gpu/drm/xe/prelim/xe_gt_debug.h b/drivers/gpu/drm/xe/prelim/xe_gt_debug.h
+new file mode 100644
+index 000000000000..d047ceb9090a
+--- /dev/null
++++ b/drivers/gpu/drm/xe/prelim/xe_gt_debug.h
+@@ -0,0 +1,27 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023 Intel Corporation
++ */
++
++#ifndef __XE_GT_DEBUG_
++#define __XE_GT_DEBUG_
++
++#define PRELIM_TD_EU_ATTENTION_MAX_ROWS 2u
++
++#include "xe_gt_types.h"
++
++#define PRELIM_XE_GT_ATTENTION_TIMEOUT_MS 100
++
++int prelim_xe_gt_eu_threads_needing_attention(struct xe_gt *gt);
++int prelim_xe_gt_foreach_dss_group_instance(struct xe_gt *gt,
++				     int (*fn)(struct xe_gt *gt,
++					       void *data,
++					       u16 group,
++					       u16 instance),
++				     void *data);
++
++int prelim_xe_gt_eu_attention_bitmap_size(struct xe_gt *gt);
++int prelim_xe_gt_eu_attention_bitmap(struct xe_gt *gt, u8 *bits,
++			      unsigned int bitmap_size);
++
++#endif
+diff --git a/drivers/gpu/drm/xe/tests/xe_eudebug.c b/drivers/gpu/drm/xe/tests/prelim/xe_eudebug.c
+similarity index 100%
+rename from drivers/gpu/drm/xe/tests/xe_eudebug.c
+rename to drivers/gpu/drm/xe/tests/prelim/xe_eudebug.c
+diff --git a/drivers/gpu/drm/xe/tests/xe_live_test_mod.c b/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
+index e95b1c6f5695..26c58eea7a4c 100644
+--- a/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
++++ b/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
+@@ -4,7 +4,7 @@
+  */
+ #include <linux/module.h>
+ 
+-#if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
++#if IS_ENABLED(CONFIG_PRELIM_DRM_XE_EUDEBUG)
+ extern struct kunit_suite xe_eudebug_test_suite;
+ kunit_test_suite(xe_eudebug_test_suite);
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.h b/drivers/gpu/drm/xe/xe_debug_metadata.h
+deleted file mode 100644
+index deca24fa2cba..000000000000
+--- a/drivers/gpu/drm/xe/xe_debug_metadata.h
++++ /dev/null
+@@ -1,25 +0,0 @@
+-/* SPDX-License-Identifier: MIT */
+-/*
+- * Copyright © 2023 Intel Corporation
+- */
+-
+-#ifndef _XE_DEBUG_METADATA_H_
+-#define _XE_DEBUG_METADATA_H_
+-
+-#include "xe_debug_metadata_types.h"
+-
+-struct drm_device;
+-struct drm_file;
+-struct xe_file;
+-
+-struct xe_debug_metadata *xe_debug_metadata_get(struct xe_file *xef, u32 id);
+-void xe_debug_metadata_put(struct xe_debug_metadata *mdata);
+-
+-int xe_debug_metadata_create_ioctl(struct drm_device *dev,
+-				   void *data,
+-				   struct drm_file *file);
+-
+-int xe_debug_metadata_destroy_ioctl(struct drm_device *dev,
+-				    void *data,
+-				    struct drm_file *file);
+-#endif
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index ed56ec080b90..447397ced909 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -24,7 +24,7 @@
+ #include "xe_bo.h"
+ #include "xe_debugfs.h"
+ #include "xe_devcoredump.h"
+-#include "xe_debug_metadata.h"
++#include "prelim/xe_debug_metadata.h"
+ #include "xe_dma_buf.h"
+ #include "xe_drm_client.h"
+ #include "xe_drv.h"
+@@ -56,7 +56,7 @@
+ #include "xe_vram.h"
+ #include "xe_wait_user_fence.h"
+ #include "xe_wa.h"
+-#include "xe_eudebug.h"
++#include "prelim/xe_eudebug.h"
+ 
+ #include <generated/xe_wa_oob.h>
+ 
+@@ -106,7 +106,7 @@ static int xe_file_open(struct drm_device *dev, struct drm_file *file)
+ 	file->driver_priv = xef;
+ 	kref_init(&xef->refcount);
+ 
+-	xe_eudebug_file_open(xef);
++	prelim_xe_eudebug_file_open(xef);
+ 
+ 	return 0;
+ }
+@@ -164,12 +164,12 @@ static void xe_file_close(struct drm_device *dev, struct drm_file *file)
+ 	struct xe_file *xef = file->driver_priv;
+ 	struct xe_vm *vm;
+ 	struct xe_exec_queue *q;
+-	struct xe_debug_metadata *mdata;
++	struct prelim_xe_debug_metadata *mdata;
+ 	unsigned long idx;
+ 
+ 	xe_pm_runtime_get(xe);
+ 
+-	xe_eudebug_file_close(xef);
++	prelim_xe_eudebug_file_close(xef);
+ 
+ 	mutex_lock(&xef->xe->files.lock);
+ 	xa_erase(&xef->xe->files.xa, xef->id);
+@@ -192,7 +192,7 @@ static void xe_file_close(struct drm_device *dev, struct drm_file *file)
+ 
+ 	mutex_lock(&xef->debug_metadata.lock);
+ 	xa_for_each(&xef->debug_metadata.xa, idx, mdata)
+-		xe_debug_metadata_put(mdata);
++		prelim_xe_debug_metadata_put(mdata);
+ 	mutex_unlock(&xef->debug_metadata.lock);
+ 
+ 	xe_file_put(xef);
+@@ -226,10 +226,10 @@ static const struct drm_ioctl_desc xe_ioctls[] = {
+ 	DRM_IOCTL_DEF_DRV(XE_WAIT_USER_FENCE, xe_wait_user_fence_ioctl,
+ 			  DRM_RENDER_ALLOW),
+ 	DRM_IOCTL_DEF_DRV(XE_OBSERVATION, xe_observation_ioctl, DRM_RENDER_ALLOW),
+-	DRM_IOCTL_DEF_DRV(XE_EUDEBUG_CONNECT, xe_eudebug_connect_ioctl, DRM_RENDER_ALLOW),
+-	DRM_IOCTL_DEF_DRV(XE_DEBUG_METADATA_CREATE, xe_debug_metadata_create_ioctl,
++	PRELIM_DRM_IOCTL_DEF_DRV(XE_EUDEBUG_CONNECT, prelim_xe_eudebug_connect_ioctl, DRM_RENDER_ALLOW),
++	PRELIM_DRM_IOCTL_DEF_DRV(XE_DEBUG_METADATA_CREATE, prelim_xe_debug_metadata_create_ioctl,
+ 			  DRM_RENDER_ALLOW),
+-	DRM_IOCTL_DEF_DRV(XE_DEBUG_METADATA_DESTROY, xe_debug_metadata_destroy_ioctl,
++	PRELIM_DRM_IOCTL_DEF_DRV(XE_DEBUG_METADATA_DESTROY, prelim_xe_debug_metadata_destroy_ioctl,
+ 			  DRM_RENDER_ALLOW),
+ };
+ 
+@@ -320,7 +320,7 @@ static void xe_device_destroy(struct drm_device *dev, void *dummy)
+ {
+ 	struct xe_device *xe = to_xe_device(dev);
+ 
+-	xe_eudebug_fini(xe);
++	prelim_xe_eudebug_fini(xe);
+ 
+ 	if (xe->preempt_fence_wq)
+ 		destroy_workqueue(xe->preempt_fence_wq);
+@@ -399,7 +399,7 @@ struct xe_device *xe_device_create(struct pci_dev *pdev,
+ 	INIT_LIST_HEAD(&xe->pinned.external_vram);
+ 	INIT_LIST_HEAD(&xe->pinned.evicted);
+ 
+-	xe_eudebug_init(xe);
++	prelim_xe_eudebug_init(xe);
+ 
+ 	xe->preempt_fence_wq = alloc_ordered_workqueue("xe-preempt-fence-wq", 0);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+deleted file mode 100644
+index 1ebc0e48c902..000000000000
+--- a/drivers/gpu/drm/xe/xe_eudebug.h
++++ /dev/null
+@@ -1,87 +0,0 @@
+-/* SPDX-License-Identifier: MIT */
+-/*
+- * Copyright © 2023 Intel Corporation
+- */
+-
+-#ifndef _XE_EUDEBUG_H_
+-
+-#include <linux/types.h>
+-
+-struct drm_device;
+-struct drm_file;
+-struct xe_device;
+-struct xe_file;
+-struct xe_vm;
+-struct xe_vma;
+-struct xe_exec_queue;
+-struct xe_hw_engine;
+-struct xe_user_fence;
+-struct xe_debug_metadata;
+-struct drm_gpuva_ops;
+-
+-#if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
+-
+-int xe_eudebug_connect_ioctl(struct drm_device *dev,
+-			     void *data,
+-			     struct drm_file *file);
+-
+-void xe_eudebug_init(struct xe_device *xe);
+-void xe_eudebug_fini(struct xe_device *xe);
+-
+-void xe_eudebug_file_open(struct xe_file *xef);
+-void xe_eudebug_file_close(struct xe_file *xef);
+-
+-void xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm);
+-void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm);
+-
+-void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q);
+-void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q);
+-
+-void xe_eudebug_vm_bind_start(struct xe_vm *vm);
+-void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range,
+-			       struct drm_gpuva_ops *ops);
+-void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err);
+-
+-int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence);
+-
+-struct xe_eudebug *xe_eudebug_get(struct xe_file *xef);
+-void xe_eudebug_put(struct xe_eudebug *d);
+-
+-void xe_eudebug_debug_metadata_create(struct xe_file *xef, struct xe_debug_metadata *m);
+-void xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct xe_debug_metadata *m);
+-
+-#else
+-
+-static inline int xe_eudebug_connect_ioctl(struct drm_device *dev,
+-					   void *data,
+-					   struct drm_file *file) { return 0; }
+-
+-static inline void xe_eudebug_init(struct xe_device *xe) { }
+-static inline void xe_eudebug_init_late(struct xe_device *xe) { }
+-static inline void xe_eudebug_fini(struct xe_device *xe) { }
+-static inline void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe) { }
+-
+-static inline void xe_eudebug_file_open(struct xe_file *xef) { }
+-static inline void xe_eudebug_file_close(struct xe_file *xef) { }
+-
+-static inline void xe_eudebug_vm_create(struct xe_file *xef, struct xe_vm *vm) { }
+-static inline void xe_eudebug_vm_destroy(struct xe_file *xef, struct xe_vm *vm) { }
+-
+-static inline void xe_eudebug_exec_queue_create(struct xe_file *xef, struct xe_exec_queue *q) { }
+-static inline void xe_eudebug_exec_queue_destroy(struct xe_file *xef, struct xe_exec_queue *q) { }
+-
+-static inline void xe_eudebug_vm_bind_start(struct xe_vm *vm) { }
+-static inline void xe_eudebug_vm_bind_op_add(struct xe_vm *vm, u32 op, u64 addr, u64 range, struct drm_gpuva_ops *ops) { }
+-static inline void xe_eudebug_vm_bind_end(struct xe_vm *vm, bool has_ufence, int err) { }
+-
+-static inline int xe_eudebug_vm_bind_ufence(struct xe_user_fence *ufence) { return 0; }
+-
+-static inline struct xe_eudebug *xe_eudebug_get(struct xe_file *xef) { return NULL; }
+-static inline void xe_eudebug_put(struct xe_eudebug *d) { }
+-
+-static inline void xe_eudebug_debug_metadata_create(struct xe_file *xef, struct xe_debug_metadata *m) { }
+-static inline void xe_eudebug_debug_metadata_destroy(struct xe_file *xef, struct xe_debug_metadata *m) { }
+-
+-#endif /* CONFIG_DRM_XE_EUDEBUG */
+-
+-#endif
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index 1c4287a764fa..2897e5d2e2ce 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -22,7 +22,7 @@
+ #include "xe_ring_ops_types.h"
+ #include "xe_trace.h"
+ #include "xe_vm.h"
+-#include "xe_eudebug.h"
++#include "prelim/xe_eudebug.h"
+ 
+ enum xe_exec_queue_sched_prop {
+ 	XE_EXEC_QUEUE_JOB_TIMEOUT = 0,
+@@ -396,7 +396,7 @@ static int exec_queue_set_timeslice(struct xe_device *xe, struct xe_exec_queue *
+ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
+ 				  u64 value)
+ {
+-	const u64 known_flags = DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE;
++	const u64 known_flags = PRELIM_DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE;
+ 
+ 	if (XE_IOCTL_DBG(xe, (q->class != XE_ENGINE_CLASS_RENDER &&
+ 			      q->class != XE_ENGINE_CLASS_COMPUTE)))
+@@ -405,7 +405,7 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
+ 	if (XE_IOCTL_DBG(xe, (value & ~known_flags)))
+ 		return -EINVAL;
+ 
+-	if (XE_IOCTL_DBG(xe, !IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)))
++	if (XE_IOCTL_DBG(xe, !IS_ENABLED(CONFIG_PRELIM_DRM_XE_EUDEBUG)))
+ 		return -EOPNOTSUPP;
+ 
+ 	if (XE_IOCTL_DBG(xe, !xe_exec_queue_is_lr(q)))
+@@ -415,7 +415,7 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
+ 	 * property is set.
+ 	 */
+ 	if (XE_IOCTL_DBG(xe,
+-			 !(value & DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE)))
++			 !(value & PRELIM_DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE)))
+ 		return -EINVAL;
+ 
+ 	if (XE_IOCTL_DBG(xe, !xe->eudebug.enable))
+@@ -439,7 +439,7 @@ typedef int (*xe_exec_queue_set_property_fn)(struct xe_device *xe,
+ static const xe_exec_queue_set_property_fn exec_queue_set_property_funcs[] = {
+ 	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY] = exec_queue_set_priority,
+ 	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE] = exec_queue_set_timeslice,
+-	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG] = exec_queue_set_eudebug,
++	[PRELIM_DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG] = exec_queue_set_eudebug,
+ };
+ 
+ static int exec_queue_user_ext_set_property(struct xe_device *xe,
+@@ -460,7 +460,7 @@ static int exec_queue_user_ext_set_property(struct xe_device *xe,
+ 	    XE_IOCTL_DBG(xe, ext.pad) ||
+ 	    XE_IOCTL_DBG(xe, ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY &&
+ 			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE &&
+-			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG))
++			 ext.property != PRELIM_DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG))
+ 		return -EINVAL;
+ 
+ 	idx = array_index_nospec(ext.property, ARRAY_SIZE(exec_queue_set_property_funcs));
+@@ -680,7 +680,7 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
+ 	args->exec_queue_id = id;
+ 	q->xef = xe_file_get(xef);
+ 
+-	xe_eudebug_exec_queue_create(xef, q);
++	prelim_xe_eudebug_exec_queue_create(xef, q);
+ 
+ 	return 0;
+ 
+@@ -853,7 +853,7 @@ int xe_exec_queue_destroy_ioctl(struct drm_device *dev, void *data,
+ 	if (XE_IOCTL_DBG(xe, !q))
+ 		return -ENOENT;
+ 
+-	xe_eudebug_exec_queue_destroy(xef, q);
++	prelim_xe_eudebug_exec_queue_destroy(xef, q);
+ 
+ 	xe_exec_queue_kill(q);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue_types.h b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+index b37642ebfc5e..8028aa591887 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue_types.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+@@ -92,7 +92,7 @@ struct xe_exec_queue {
+ 
+ 	/**
+ 	 * @eudebug_flags: immutable eudebug flags for this exec queue.
+-	 * Set up with DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG.
++	 * Set up with PRELIM_DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG.
+ 	 */
+ #define EXEC_QUEUE_EUDEBUG_FLAG_ENABLE		BIT(0)
+ 	unsigned long eudebug_flags;
+diff --git a/drivers/gpu/drm/xe/xe_gt_debug.h b/drivers/gpu/drm/xe/xe_gt_debug.h
+deleted file mode 100644
+index 342082699ff6..000000000000
+--- a/drivers/gpu/drm/xe/xe_gt_debug.h
++++ /dev/null
+@@ -1,27 +0,0 @@
+-/* SPDX-License-Identifier: MIT */
+-/*
+- * Copyright © 2023 Intel Corporation
+- */
+-
+-#ifndef __XE_GT_DEBUG_
+-#define __XE_GT_DEBUG_
+-
+-#define TD_EU_ATTENTION_MAX_ROWS 2u
+-
+-#include "xe_gt_types.h"
+-
+-#define XE_GT_ATTENTION_TIMEOUT_MS 100
+-
+-int xe_gt_eu_threads_needing_attention(struct xe_gt *gt);
+-int xe_gt_foreach_dss_group_instance(struct xe_gt *gt,
+-				     int (*fn)(struct xe_gt *gt,
+-					       void *data,
+-					       u16 group,
+-					       u16 instance),
+-				     void *data);
+-
+-int xe_gt_eu_attention_bitmap_size(struct xe_gt *gt);
+-int xe_gt_eu_attention_bitmap(struct xe_gt *gt, u8 *bits,
+-			      unsigned int bitmap_size);
+-
+-#endif
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
+index 2bf038b87a29..98d883978f7a 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine.c
+@@ -15,7 +15,7 @@
+ #include "xe_assert.h"
+ #include "xe_bo.h"
+ #include "xe_device.h"
+-#include "xe_eudebug.h"
++#include "prelim/xe_eudebug.h"
+ #include "xe_execlist.h"
+ #include "xe_force_wake.h"
+ #include "xe_gsc.h"
+diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
+index fc7f4913d701..24922f714fea 100644
+--- a/drivers/gpu/drm/xe/xe_sync.c
++++ b/drivers/gpu/drm/xe/xe_sync.c
+@@ -18,7 +18,7 @@
+ #include "xe_exec_queue.h"
+ #include "xe_macros.h"
+ #include "xe_sched_job_types.h"
+-#include "xe_eudebug.h"
++#include "prelim/xe_eudebug.h"
+ 
+ static void user_fence_destroy(struct kref *kref)
+ {
+@@ -28,7 +28,7 @@ static void user_fence_destroy(struct kref *kref)
+ 	mmdrop(ufence->mm);
+ 
+ 	if (ufence->eudebug.debugger)
+-		xe_eudebug_put(ufence->eudebug.debugger);
++		prelim_xe_eudebug_put(ufence->eudebug.debugger);
+ 
+ 	kfree(ufence);
+ }
+@@ -72,7 +72,7 @@ static struct xe_user_fence *user_fence_create(struct xe_device *xe,
+ 	spin_unlock(&vm->eudebug_bind.lock);
+ 
+ 	if (bind_ref) {
+-		ufence->eudebug.debugger = xe_eudebug_get(xef);
++		ufence->eudebug.debugger = prelim_xe_eudebug_get(xef);
+ 
+ 		if (ufence->eudebug.debugger)
+ 			ufence->eudebug.bind_ref_seqno = bind_ref;
+@@ -104,7 +104,7 @@ static void user_fence_worker(struct work_struct *w)
+ 	WRITE_ONCE(ufence->signalled, 1);
+ 
+ 	/* Lets see if debugger wants to track this */
+-	ret = xe_eudebug_vm_bind_ufence(ufence);
++	ret = prelim_xe_eudebug_vm_bind_ufence(ufence);
+ 	if (ret)
+ 		xe_sync_ufence_signal(ufence);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 408c3afbac62..c9ec21319237 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -24,7 +24,7 @@
+ #include "regs/xe_gtt_defs.h"
+ #include "xe_assert.h"
+ #include "xe_bo.h"
+-#include "xe_debug_metadata.h"
++#include "prelim/xe_debug_metadata.h"
+ #include "xe_device.h"
+ #include "xe_drm_client.h"
+ #include "xe_exec_queue.h"
+@@ -40,7 +40,7 @@
+ #include "xe_trace_bo.h"
+ #include "xe_wa.h"
+ #include "xe_hmm.h"
+-#include "xe_eudebug.h"
++#include "prelim/xe_eudebug.h"
+ 
+ static struct drm_gem_object *xe_vm_obj(struct xe_vm *vm)
+ {
+@@ -1699,7 +1699,7 @@ static void vm_destroy_work_func(struct work_struct *w)
+ 	struct xe_tile *tile;
+ 	u8 id;
+ 
+-	xe_eudebug_vm_bind_end(vm, 0, -ENOENT);
++	prelim_xe_eudebug_vm_bind_end(vm, 0, -ENOENT);
+ 
+ 	/* xe_vm_close_and_put was not called? */
+ 	xe_assert(xe, !vm->size);
+@@ -1864,7 +1864,7 @@ int xe_vm_create_ioctl(struct drm_device *dev, void *data,
+ 	args->reserved[0] = xe_bo_main_addr(vm->pt_root[0]->bo, XE_PAGE_SIZE);
+ #endif
+ 
+-	xe_eudebug_vm_create(xef, vm);
++	prelim_xe_eudebug_vm_create(xef, vm);
+ 
+ 	return 0;
+ 
+@@ -1902,7 +1902,7 @@ int xe_vm_destroy_ioctl(struct drm_device *dev, void *data,
+ 	mutex_unlock(&xef->vm.lock);
+ 
+ 	if (!err) {
+-		xe_eudebug_vm_destroy(xef, vm);
++		prelim_xe_eudebug_vm_destroy(xef, vm);
+ 		xe_vm_close_and_put(vm);
+ 	}
+ 
+@@ -2639,8 +2639,8 @@ static int vm_bind_op_ext_attach_debug(struct xe_device *xe,
+ 				       u32 operation, u64 extension)
+ {
+ 	u64 __user *address = u64_to_user_ptr(extension);
+-	struct drm_xe_vm_bind_op_ext_attach_debug ext;
+-	struct xe_debug_metadata *mdata;
++	struct prelim_drm_xe_vm_bind_op_ext_attach_debug ext;
++	struct prelim_xe_debug_metadata *mdata;
+ 	struct drm_gpuva_op *__op;
+ 	int err;
+ 
+@@ -2656,12 +2656,12 @@ static int vm_bind_op_ext_attach_debug(struct xe_device *xe,
+ 	if (XE_IOCTL_DBG(xe, ext.flags))
+ 		return -EINVAL;
+ 
+-	mdata = xe_debug_metadata_get(xef, (u32)ext.metadata_id);
++	mdata = prelim_xe_debug_metadata_get(xef, (u32)ext.metadata_id);
+ 	if (XE_IOCTL_DBG(xe, !mdata))
+ 		return -ENOENT;
+ 
+ 	/* care about metadata existence only on the time of attach */
+-	xe_debug_metadata_put(mdata);
++	prelim_xe_debug_metadata_put(mdata);
+ 
+ 	if (!ops)
+ 		return 0;
+@@ -2682,7 +2682,7 @@ static int vm_bind_op_ext_attach_debug(struct xe_device *xe,
+ }
+ 
+ static const xe_vm_bind_op_user_extension_fn vm_bind_op_extension_funcs[] = {
+-	[XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG] = vm_bind_op_ext_attach_debug,
++	[PRELIM_XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG] = vm_bind_op_ext_attach_debug,
+ };
+ 
+ #define MAX_USER_EXTENSIONS	16
+@@ -2865,7 +2865,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+ 				       fence);
+ 	}
+ 
+-	xe_eudebug_vm_bind_end(vm, ufence, 0);
++	prelim_xe_eudebug_vm_bind_end(vm, ufence, 0);
+ 
+ 	if (ufence)
+ 		xe_sync_ufence_put(ufence);
+@@ -3236,7 +3236,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		}
+ 	}
+ 
+-	xe_eudebug_vm_bind_start(vm);
++	prelim_xe_eudebug_vm_bind_start(vm);
+ 
+ 	syncs_user = u64_to_user_ptr(args->syncs);
+ 	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
+@@ -3293,7 +3293,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		if (err)
+ 			goto unwind_ops;
+ 
+-		xe_eudebug_vm_bind_op_add(vm, op, addr, range, ops[i]);
++		prelim_xe_eudebug_vm_bind_op_add(vm, op, addr, range, ops[i]);
+ 
+ #ifdef TEST_VM_OPS_ERROR
+ 		if (flags & FORCE_OP_ERROR) {
+@@ -3319,7 +3319,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 
+ unwind_ops:
+ 	if (err && err != -ENODATA) {
+-		xe_eudebug_vm_bind_end(vm, num_ufence > 0, err);
++		prelim_xe_eudebug_vm_bind_end(vm, num_ufence > 0, err);
+ 		vm_bind_ioctl_ops_unwind(vm, ops, args->num_binds);
+ 	}
+ 
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index 430635249908..3e0e39176927 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -102,9 +102,7 @@ extern "C" {
+ #define DRM_XE_EXEC			0x09
+ #define DRM_XE_WAIT_USER_FENCE		0x0a
+ #define DRM_XE_OBSERVATION		0x0b
+-#define DRM_XE_EUDEBUG_CONNECT		0x0c
+-#define DRM_XE_DEBUG_METADATA_CREATE	0x0d
+-#define DRM_XE_DEBUG_METADATA_DESTROY	0x0e
++
+ /* Must be kept compact -- no holes */
+ 
+ #define DRM_IOCTL_XE_DEVICE_QUERY		DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_DEVICE_QUERY, struct drm_xe_device_query)
+@@ -119,9 +117,6 @@ extern "C" {
+ #define DRM_IOCTL_XE_EXEC			DRM_IOW(DRM_COMMAND_BASE + DRM_XE_EXEC, struct drm_xe_exec)
+ #define DRM_IOCTL_XE_WAIT_USER_FENCE		DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_WAIT_USER_FENCE, struct drm_xe_wait_user_fence)
+ #define DRM_IOCTL_XE_OBSERVATION		DRM_IOW(DRM_COMMAND_BASE + DRM_XE_OBSERVATION, struct drm_xe_observation_param)
+-#define DRM_IOCTL_XE_EUDEBUG_CONNECT		DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_EUDEBUG_CONNECT, struct drm_xe_eudebug_connect)
+-#define DRM_IOCTL_XE_DEBUG_METADATA_CREATE	 DRM_IOWR(DRM_COMMAND_BASE + DRM_XE_DEBUG_METADATA_CREATE, struct drm_xe_debug_metadata_create)
+-#define DRM_IOCTL_XE_DEBUG_METADATA_DESTROY	 DRM_IOW(DRM_COMMAND_BASE + DRM_XE_DEBUG_METADATA_DESTROY, struct drm_xe_debug_metadata_destroy)
+ 
+ /**
+  * DOC: Xe IOCTL Extensions
+@@ -886,23 +881,6 @@ struct drm_xe_vm_destroy {
+ 	__u64 reserved[2];
+ };
+ 
+-struct drm_xe_vm_bind_op_ext_attach_debug {
+-	/** @base: base user extension */
+-	struct drm_xe_user_extension base;
+-
+-	/** @id: Debug object id from create metadata */
+-	__u64 metadata_id;
+-
+-	/** @flags: Flags */
+-	__u64 flags;
+-
+-	/** @cookie: Cookie */
+-	__u64 cookie;
+-
+-	/** @reserved: Reserved */
+-	__u64 reserved;
+-};
+-
+ /**
+  * struct drm_xe_vm_bind_op - run bind operations
+  *
+@@ -927,9 +905,7 @@ struct drm_xe_vm_bind_op_ext_attach_debug {
+  *    handle MBZ, and the BO offset MBZ. This flag is intended to
+  *    implement VK sparse bindings.
+  */
+-
+ struct drm_xe_vm_bind_op {
+-#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG 0
+ 	/** @extensions: Pointer to the first extension struct, if any */
+ 	__u64 extensions;
+ 
+@@ -1132,8 +1108,7 @@ struct drm_xe_exec_queue_create {
+ #define DRM_XE_EXEC_QUEUE_EXTENSION_SET_PROPERTY		0
+ #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY		0
+ #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE		1
+-#define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG		2
+-#define     DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE		(1 << 0)
++
+ 	/** @extensions: Pointer to the first extension struct, if any */
+ 	__u64 extensions;
+ 
+@@ -1719,72 +1694,6 @@ struct drm_xe_oa_stream_info {
+ 	__u64 reserved[3];
+ };
+ 
+-/*
+- * Debugger ABI (ioctl and events) Version History:
+- * 0 - No debugger available
+- * 1 - Initial version
+- */
+-#define DRM_XE_EUDEBUG_VERSION 1
+-
+-struct drm_xe_eudebug_connect {
+-	/** @extensions: Pointer to the first extension struct, if any */
+-	__u64 extensions;
+-
+-	__u64 pid; /* input: Target process ID */
+-	__u32 flags; /* MBZ */
+-
+-	__u32 version; /* output: current ABI (ioctl / events) version */
+-};
+-
+-/*
+- * struct drm_xe_debug_metadata_create - Create debug metadata
+- *
+- * Add a region of user memory to be marked as debug metadata.
+- * When the debugger attaches, the metadata regions will be delivered
+- * for debugger. Debugger can then map these regions to help decode
+- * the program state.
+- *
+- * Returns handle to created metadata entry.
+- */
+-struct drm_xe_debug_metadata_create {
+-	/** @extensions: Pointer to the first extension struct, if any */
+-	__u64 extensions;
+-
+-#define DRM_XE_DEBUG_METADATA_ELF_BINARY     0
+-#define DRM_XE_DEBUG_METADATA_PROGRAM_MODULE 1
+-#define WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_MODULE_AREA 2
+-#define WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SBA_AREA 3
+-#define WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SIP_AREA 4
+-#define WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_NUM (1 + \
+-	  WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SIP_AREA)
+-
+-	/** @type: Type of metadata */
+-	__u64 type;
+-
+-	/** @user_addr: pointer to start of the metadata */
+-	__u64 user_addr;
+-
+-	/** @len: length, in bytes of the medata */
+-	__u64 len;
+-
+-	/** @metadata_id: created metadata handle (out) */
+-	__u32 metadata_id;
+-};
+-
+-/**
+- * struct drm_xe_debug_metadata_destroy - Destroy debug metadata
+- *
+- * Destroy debug metadata.
+- */
+-struct drm_xe_debug_metadata_destroy {
+-	/** @extensions: Pointer to the first extension struct, if any */
+-	__u64 extensions;
+-
+-	/** @metadata_id: metadata handle to destroy */
+-	__u32 metadata_id;
+-};
+-
+-#include "xe_drm_eudebug.h"
+ #include "xe_drm_prelim.h"
+ 
+ #if defined(__cplusplus)
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+deleted file mode 100644
+index 2ebf21e15f5b..000000000000
+--- a/include/uapi/drm/xe_drm_eudebug.h
++++ /dev/null
+@@ -1,225 +0,0 @@
+-/* SPDX-License-Identifier: MIT */
+-/*
+- * Copyright © 2023 Intel Corporation
+- */
+-
+-#ifndef _UAPI_XE_DRM_EUDEBUG_H_
+-#define _UAPI_XE_DRM_EUDEBUG_H_
+-
+-#if defined(__cplusplus)
+-extern "C" {
+-#endif
+-
+-/**
+- * Do a eudebug event read for a debugger connection.
+- *
+- * This ioctl is available in debug version 1.
+- */
+-#define DRM_XE_EUDEBUG_IOCTL_READ_EVENT		_IO('j', 0x0)
+-#define DRM_XE_EUDEBUG_IOCTL_EU_CONTROL		_IOWR('j', 0x2, struct drm_xe_eudebug_eu_control)
+-#define DRM_XE_EUDEBUG_IOCTL_ACK_EVENT		_IOW('j', 0x4, struct drm_xe_eudebug_ack_event)
+-#define DRM_XE_EUDEBUG_IOCTL_VM_OPEN		_IOW('j', 0x1, struct drm_xe_eudebug_vm_open)
+-#define DRM_XE_EUDEBUG_IOCTL_READ_METADATA	_IOWR('j', 0x3, struct drm_xe_eudebug_read_metadata)
+-
+-/* XXX: Document events to match their internal counterparts when moved to xe_drm.h */
+-struct drm_xe_eudebug_event {
+-	__u32 len;
+-
+-	__u16 type;
+-#define DRM_XE_EUDEBUG_EVENT_NONE		0
+-#define DRM_XE_EUDEBUG_EVENT_READ		1
+-#define DRM_XE_EUDEBUG_EVENT_OPEN		2
+-#define DRM_XE_EUDEBUG_EVENT_VM			3
+-#define DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE		4
+-#define DRM_XE_EUDEBUG_EVENT_EU_ATTENTION	5
+-#define DRM_XE_EUDEBUG_EVENT_VM_BIND		6
+-#define DRM_XE_EUDEBUG_EVENT_VM_BIND_OP		7
+-#define DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE	8
+-#define DRM_XE_EUDEBUG_EVENT_METADATA		9
+-#define DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA 10
+-
+-	__u16 flags;
+-#define DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
+-#define DRM_XE_EUDEBUG_EVENT_DESTROY		(1 << 1)
+-#define DRM_XE_EUDEBUG_EVENT_STATE_CHANGE	(1 << 2)
+-#define DRM_XE_EUDEBUG_EVENT_NEED_ACK		(1 << 3)
+-
+-	__u64 seqno;
+-	__u64 reserved;
+-};
+-
+-struct drm_xe_eudebug_event_client {
+-	struct drm_xe_eudebug_event base;
+-
+-	__u64 client_handle; /* This is unique per debug connection */
+-};
+-
+-struct drm_xe_eudebug_event_vm {
+-	struct drm_xe_eudebug_event base;
+-
+-	__u64 client_handle;
+-	__u64 vm_handle;
+-};
+-
+-struct drm_xe_eudebug_event_exec_queue {
+-	struct drm_xe_eudebug_event base;
+-
+-	__u64 client_handle;
+-	__u64 vm_handle;
+-	__u64 exec_queue_handle;
+-	__u32 engine_class;
+-	__u32 width;
+-	__u64 lrc_handle[];
+-};
+-
+-struct drm_xe_eudebug_event_eu_attention {
+-	struct drm_xe_eudebug_event base;
+-
+-	__u64 client_handle;
+-	__u64 exec_queue_handle;
+-	__u64 lrc_handle;
+-	__u32 flags;
+-	__u32 bitmask_size;
+-	__u8 bitmask[];
+-};
+-
+-struct drm_xe_eudebug_eu_control {
+-	__u64 client_handle;
+-
+-#define DRM_XE_EUDEBUG_EU_CONTROL_CMD_INTERRUPT_ALL	0
+-#define DRM_XE_EUDEBUG_EU_CONTROL_CMD_STOPPED		1
+-#define DRM_XE_EUDEBUG_EU_CONTROL_CMD_RESUME		2
+-	__u32 cmd;
+-	__u32 flags;
+-
+-	__u64 seqno;
+-
+-	__u64 exec_queue_handle;
+-	__u64 lrc_handle;
+-	__u32 reserved;
+-	__u32 bitmask_size;
+-	__u64 bitmask_ptr;
+-};
+-
+-/*
+- *  When client (debuggee) does vm_bind_ioctl() following event
+- *  sequence will be created (for the debugger):
+- *
+- *  ┌───────────────────────┐
+- *  │  EVENT_VM_BIND        ├───────┬─┬─┐
+- *  └───────────────────────┘       │ │ │
+- *      ┌───────────────────────┐   │ │ │
+- *      │ EVENT_VM_BIND_OP #1   ├───┘ │ │
+- *      └───────────────────────┘     │ │
+- *                 ...                │ │
+- *      ┌───────────────────────┐     │ │
+- *      │ EVENT_VM_BIND_OP #n   ├─────┘ │
+- *      └───────────────────────┘       │
+- *                                      │
+- *      ┌───────────────────────┐       │
+- *      │ EVENT_UFENCE          ├───────┘
+- *      └───────────────────────┘
+- *
+- * All the events below VM_BIND will reference the VM_BIND
+- * they associate with, by field .vm_bind_ref_seqno.
+- * event_ufence will only be included if the client did
+- * attach sync of type UFENCE into its vm_bind_ioctl().
+- *
+- * When EVENT_UFENCE is sent by the driver, all the OPs of
+- * the original VM_BIND are completed and the [addr,range]
+- * contained in them are present and modifiable through the
+- * vm accessors. Accessing [addr, range] before related ufence
+- * event will lead to undefined results as the actual bind
+- * operations are async and the backing storage might not
+- * be there on a moment of receiving the event.
+- *
+- * Client's UFENCE sync will be held by the driver: client's
+- * drm_xe_wait_ufence will not complete and the value of the ufence
+- * won't appear until ufence is acked by the debugger process calling
+- * DRM_XE_EUDEBUG_IOCTL_ACK_EVENT with the event_ufence.base.seqno.
+- * This will signal the fence, .value will update and the wait will
+- * complete allowing the client to continue.
+- *
+- */
+-
+-struct drm_xe_eudebug_event_vm_bind {
+-	struct drm_xe_eudebug_event base;
+-
+-	__u64 client_handle;
+-	__u64 vm_handle;
+-
+-	__u32 flags;
+-#define DRM_XE_EUDEBUG_EVENT_VM_BIND_FLAG_UFENCE (1 << 0)
+-
+-	__u32 num_binds;
+-};
+-
+-struct drm_xe_eudebug_event_vm_bind_op {
+-	struct drm_xe_eudebug_event base;
+-	__u64 vm_bind_ref_seqno; /* *_event_vm_bind.base.seqno */
+-	__u64 num_extensions;
+-
+-	__u64 addr; /* XXX: Zero for unmap all? */
+-	__u64 range; /* XXX: Zero for unmap all? */
+-};
+-
+-struct drm_xe_eudebug_event_vm_bind_ufence {
+-	struct drm_xe_eudebug_event base;
+-	__u64 vm_bind_ref_seqno; /* *_event_vm_bind.base.seqno */
+-};
+-
+-struct drm_xe_eudebug_ack_event {
+-	__u32 type;
+-	__u32 flags; /* MBZ */
+-	__u64 seqno;
+-};
+-
+-struct drm_xe_eudebug_vm_open {
+-	/** @extensions: Pointer to the first extension struct, if any */
+-	__u64 extensions;
+-
+-	/** @client_handle: id of client */
+-	__u64 client_handle;
+-
+-	/** @vm_handle: id of vm */
+-	__u64 vm_handle;
+-
+-	/** @flags: flags */
+-	__u64 flags;
+-
+-	/** @timeout_ns: Timeout value in nanoseconds operations (fsync) */
+-	__u64 timeout_ns;
+-};
+-
+-struct drm_xe_eudebug_read_metadata {
+-	__u64 client_handle;
+-	__u64 metadata_handle;
+-	__u32 flags;
+-	__u32 reserved;
+-	__u64 ptr;
+-	__u64 size;
+-};
+-
+-struct drm_xe_eudebug_event_metadata {
+-	struct drm_xe_eudebug_event base;
+-
+-	__u64 client_handle;
+-	__u64 metadata_handle;
+-	/* XXX: Refer to xe_drm.h for fields */
+-	__u64 type;
+-	__u64 len;
+-};
+-
+-struct drm_xe_eudebug_event_vm_bind_op_metadata {
+-	struct drm_xe_eudebug_event base;
+-	__u64 vm_bind_op_ref_seqno; /* *_event_vm_bind_op.base.seqno */
+-
+-	__u64 metadata_handle;
+-	__u64 metadata_cookie;
+-};
+-
+-#if defined(__cplusplus)
+-}
+-#endif
+-
+-#endif
+diff --git a/include/uapi/drm/xe_drm_prelim.h b/include/uapi/drm/xe_drm_prelim.h
+index 9c86f5969500..18b2d144b1ce 100644
+--- a/include/uapi/drm/xe_drm_prelim.h
++++ b/include/uapi/drm/xe_drm_prelim.h
+@@ -70,4 +70,306 @@
+  * components. Please add an unreserved ioctl number here to reserve that
+  * number.
+  */
++#define PRELIM_DRM_XE_EUDEBUG_CONNECT		0x5f
++#define PRELIM_DRM_XE_DEBUG_METADATA_CREATE	0x5e
++#define PRELIM_DRM_XE_DEBUG_METADATA_DESTROY	0x5d
++#define PRELIM_DRM_IOCTL_XE_EUDEBUG_CONNECT		DRM_IOWR(DRM_COMMAND_BASE + PRELIM_DRM_XE_EUDEBUG_CONNECT, struct prelim_drm_xe_eudebug_connect)
++#define PRELIM_DRM_IOCTL_XE_DEBUG_METADATA_CREATE	 DRM_IOWR(DRM_COMMAND_BASE + PRELIM_DRM_XE_DEBUG_METADATA_CREATE, struct prelim_drm_xe_debug_metadata_create)
++#define PRELIM_DRM_IOCTL_XE_DEBUG_METADATA_DESTROY	 DRM_IOW(DRM_COMMAND_BASE + PRELIM_DRM_XE_DEBUG_METADATA_DESTROY, struct prelim_drm_xe_debug_metadata_destroy)
++
++struct prelim_drm_xe_vm_bind_op_ext_attach_debug {
++	/** @base: base user extension */
++	struct drm_xe_user_extension base;
++
++	/** @id: Debug object id from create metadata */
++	__u64 metadata_id;
++
++	/** @flags: Flags */
++	__u64 flags;
++
++	/** @cookie: Cookie */
++	__u64 cookie;
++
++	/** @reserved: Reserved */
++	__u64 reserved;
++};
++
++#define PRELIM_XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG 0
++#define   PRELIM_DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG		2
++#define     PRELIM_DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE		(1 << 0)
++/*
++ * Debugger ABI (ioctl and events) Version History:
++ * 0 - No debugger available
++ * 1 - Initial version
++ */
++#define PRELIM_DRM_XE_EUDEBUG_VERSION 1
++
++struct prelim_drm_xe_eudebug_connect {
++	/** @extensions: Pointer to the first extension struct, if any */
++	__u64 extensions;
++
++	__u64 pid; /* input: Target process ID */
++	__u32 flags; /* MBZ */
++
++	__u32 version; /* output: current ABI (ioctl / events) version */
++};
++
++/*
++ * struct prelim_drm_xe_debug_metadata_create - Create debug metadata
++ *
++ * Add a region of user memory to be marked as debug metadata.
++ * When the debugger attaches, the metadata regions will be delivered
++ * for debugger. Debugger can then map these regions to help decode
++ * the program state.
++ *
++ * Returns handle to created metadata entry.
++ */
++struct prelim_drm_xe_debug_metadata_create {
++	/** @extensions: Pointer to the first extension struct, if any */
++	__u64 extensions;
++
++#define PRELIM_DRM_XE_DEBUG_METADATA_ELF_BINARY     0
++#define PRELIM_DRM_XE_DEBUG_METADATA_PROGRAM_MODULE 1
++#define PRELIM_WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_MODULE_AREA 2
++#define PRELIM_WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SBA_AREA 3
++#define PRELIM_WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SIP_AREA 4
++#define PRELIM_WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_NUM (1 + \
++	  PRELIM_WORK_IN_PROGRESS_DRM_XE_DEBUG_METADATA_SIP_AREA)
++
++	/** @type: Type of metadata */
++	__u64 type;
++
++	/** @user_addr: pointer to start of the metadata */
++	__u64 user_addr;
++
++	/** @len: length, in bytes of the medata */
++	__u64 len;
++
++	/** @metadata_id: created metadata handle (out) */
++	__u32 metadata_id;
++};
++
++/**
++ * struct prelim_drm_xe_debug_metadata_destroy - Destroy debug metadata
++ *
++ * Destroy debug metadata.
++ */
++struct prelim_drm_xe_debug_metadata_destroy {
++	/** @extensions: Pointer to the first extension struct, if any */
++	__u64 extensions;
++
++	/** @metadata_id: metadata handle to destroy */
++	__u32 metadata_id;
++};
++
++#include "xe_drm_prelim.h"
++
++/**
++ * Do a eudebug event read for a debugger connection.
++ *
++ * This ioctl is available in debug version 1.
++ */
++#define PRELIM_DRM_XE_EUDEBUG_IOCTL_READ_EVENT		_IO('j', 0x0)
++#define PRELIM_DRM_XE_EUDEBUG_IOCTL_EU_CONTROL		_IOWR('j', 0x2, struct prelim_drm_xe_eudebug_eu_control)
++#define PRELIM_DRM_XE_EUDEBUG_IOCTL_ACK_EVENT		_IOW('j', 0x4, struct prelim_drm_xe_eudebug_ack_event)
++#define PRELIM_DRM_XE_EUDEBUG_IOCTL_VM_OPEN		_IOW('j', 0x1, struct prelim_drm_xe_eudebug_vm_open)
++#define PRELIM_DRM_XE_EUDEBUG_IOCTL_READ_METADATA	_IOWR('j', 0x3, struct prelim_drm_xe_eudebug_read_metadata)
++
++/* XXX: Document events to match their internal counterparts when moved to xe_drm.h */
++struct prelim_drm_xe_eudebug_event {
++	__u32 len;
++
++	__u16 type;
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_NONE		0
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_READ		1
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_OPEN		2
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM			3
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE		4
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_EU_ATTENTION	5
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND		6
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP		7
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE	8
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_METADATA		9
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA 10
++
++	__u16 flags;
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_DESTROY		(1 << 1)
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_STATE_CHANGE	(1 << 2)
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_NEED_ACK		(1 << 3)
++
++	__u64 seqno;
++	__u64 reserved;
++};
++
++struct prelim_drm_xe_eudebug_event_client {
++	struct prelim_drm_xe_eudebug_event base;
++
++	__u64 client_handle; /* This is unique per debug connection */
++};
++
++struct prelim_drm_xe_eudebug_event_vm {
++	struct prelim_drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 vm_handle;
++};
++
++struct prelim_drm_xe_eudebug_event_exec_queue {
++	struct prelim_drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 vm_handle;
++	__u64 exec_queue_handle;
++	__u32 engine_class;
++	__u32 width;
++	__u64 lrc_handle[];
++};
++
++struct prelim_drm_xe_eudebug_event_eu_attention {
++	struct prelim_drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 exec_queue_handle;
++	__u64 lrc_handle;
++	__u32 flags;
++	__u32 bitmask_size;
++	__u8 bitmask[];
++};
++
++struct prelim_drm_xe_eudebug_eu_control {
++	__u64 client_handle;
++
++#define PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_INTERRUPT_ALL	0
++#define PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_STOPPED		1
++#define PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_RESUME		2
++	__u32 cmd;
++	__u32 flags;
++
++	__u64 seqno;
++
++	__u64 exec_queue_handle;
++	__u64 lrc_handle;
++	__u32 reserved;
++	__u32 bitmask_size;
++	__u64 bitmask_ptr;
++};
++
++/*
++ *  When client (debuggee) does vm_bind_ioctl() following event
++ *  sequence will be created (for the debugger):
++ *
++ *  ┌───────────────────────┐
++ *  │  EVENT_VM_BIND        ├───────┬─┬─┐
++ *  └───────────────────────┘       │ │ │
++ *      ┌───────────────────────┐   │ │ │
++ *      │ EVENT_VM_BIND_OP #1   ├───┘ │ │
++ *      └───────────────────────┘     │ │
++ *                 ...                │ │
++ *      ┌───────────────────────┐     │ │
++ *      │ EVENT_VM_BIND_OP #n   ├─────┘ │
++ *      └───────────────────────┘       │
++ *                                      │
++ *      ┌───────────────────────┐       │
++ *      │ EVENT_UFENCE          ├───────┘
++ *      └───────────────────────┘
++ *
++ * All the events below VM_BIND will reference the VM_BIND
++ * they associate with, by field .vm_bind_ref_seqno.
++ * event_ufence will only be included if the client did
++ * attach sync of type UFENCE into its vm_bind_ioctl().
++ *
++ * When EVENT_UFENCE is sent by the driver, all the OPs of
++ * the original VM_BIND are completed and the [addr,range]
++ * contained in them are present and modifiable through the
++ * vm accessors. Accessing [addr, range] before related ufence
++ * event will lead to undefined results as the actual bind
++ * operations are async and the backing storage might not
++ * be there on a moment of receiving the event.
++ *
++ * Client's UFENCE sync will be held by the driver: client's
++ * drm_xe_wait_ufence will not complete and the value of the ufence
++ * won't appear until ufence is acked by the debugger process calling
++ * PRELIM_DRM_XE_EUDEBUG_IOCTL_ACK_EVENT with the event_ufence.base.seqno.
++ * This will signal the fence, .value will update and the wait will
++ * complete allowing the client to continue.
++ *
++ */
++
++struct prelim_drm_xe_eudebug_event_vm_bind {
++	struct prelim_drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 vm_handle;
++
++	__u32 flags;
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_FLAG_UFENCE (1 << 0)
++
++	__u32 num_binds;
++};
++
++struct prelim_drm_xe_eudebug_event_vm_bind_op {
++	struct prelim_drm_xe_eudebug_event base;
++	__u64 vm_bind_ref_seqno; /* *_event_vm_bind.base.seqno */
++	__u64 num_extensions;
++
++	__u64 addr; /* XXX: Zero for unmap all? */
++	__u64 range; /* XXX: Zero for unmap all? */
++};
++
++struct prelim_drm_xe_eudebug_event_vm_bind_ufence {
++	struct prelim_drm_xe_eudebug_event base;
++	__u64 vm_bind_ref_seqno; /* *_event_vm_bind.base.seqno */
++};
++
++struct prelim_drm_xe_eudebug_ack_event {
++	__u32 type;
++	__u32 flags; /* MBZ */
++	__u64 seqno;
++};
++
++struct prelim_drm_xe_eudebug_vm_open {
++	/** @extensions: Pointer to the first extension struct, if any */
++	__u64 extensions;
++
++	/** @client_handle: id of client */
++	__u64 client_handle;
++
++	/** @vm_handle: id of vm */
++	__u64 vm_handle;
++
++	/** @flags: flags */
++	__u64 flags;
++
++	/** @timeout_ns: Timeout value in nanoseconds operations (fsync) */
++	__u64 timeout_ns;
++};
++
++struct prelim_drm_xe_eudebug_read_metadata {
++	__u64 client_handle;
++	__u64 metadata_handle;
++	__u32 flags;
++	__u32 reserved;
++	__u64 ptr;
++	__u64 size;
++};
++
++struct prelim_drm_xe_eudebug_event_metadata {
++	struct prelim_drm_xe_eudebug_event base;
++
++	__u64 client_handle;
++	__u64 metadata_handle;
++	/* XXX: Refer to xe_drm.h for fields */
++	__u64 type;
++	__u64 len;
++};
++
++struct prelim_drm_xe_eudebug_event_vm_bind_op_metadata {
++	struct prelim_drm_xe_eudebug_event base;
++	__u64 vm_bind_op_ref_seqno; /* *_event_vm_bind_op.base.seqno */
++
++	__u64 metadata_handle;
++	__u64 metadata_cookie;
++};
++
+ #endif /* _UAPI_XE_DRM_PRELIM_H_ */
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-hw-enablement-for-eudebug.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-hw-enablement-for-eudebug.patch
@@ -1,0 +1,228 @@
+From f5dbb31457cc9ef6b5d729d561080a9d7e0e6890 Mon Sep 17 00:00:00 2001
+From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Date: Fri, 26 May 2023 12:30:42 +0200
+Subject: drm/xe/eudebug: hw enablement for eudebug
+
+In order to turn on debug capabilities, (i.e. breakpoints), TD_CTL
+and some other registers needs to be programmed. Implement eudebug
+mode enabling including eudebug related workarounds.
+
+v2: Move workarounds to xe_wa_oob. Use reg_sr directly instead of
+xe_rtp as it suits better for dynamic manipulation of those register we
+do later in the series.
+
+Signed-off-by: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 154655ed37c89b812ffe81646d08eeedfbf24186 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_engine_regs.h |  4 ++
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h     | 10 ++++
+ drivers/gpu/drm/xe/xe_eudebug.c          | 70 ++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_eudebug.h          |  3 +
+ drivers/gpu/drm/xe/xe_hw_engine.c        |  2 +
+ drivers/gpu/drm/xe/xe_wa_oob.rules       |  2 +
+ 6 files changed, 91 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
+index 81b71903675e..e004423a66bf 100644
+--- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
+@@ -115,6 +115,10 @@
+ 
+ #define INDIRECT_RING_STATE(base)		XE_REG((base) + 0x108)
+ 
++#define CS_DEBUG_MODE2(base)			XE_REG((base) + 0xd8, XE_REG_OPTION_MASKED)
++#define   INST_STATE_CACHE_INVALIDATE		REG_BIT(6)
++#define   GLOBAL_DEBUG_ENABLE			REG_BIT(5)
++
+ #define RING_BBADDR(base)			XE_REG((base) + 0x140)
+ #define RING_BBADDR_UDW(base)			XE_REG((base) + 0x168)
+ 
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index 16b7f6aa2b6b..f7f6e52173af 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -427,6 +427,14 @@
+ #define   DG2_DISABLE_ROUND_ENABLE_ALLOW_FOR_SSLA	REG_BIT(15)
+ #define   CLEAR_OPTIMIZATION_DISABLE			REG_BIT(6)
+ 
++#define TD_CTL					XE_REG_MCR(0xe400)
++#define   TD_CTL_FEH_AND_FEE_ENABLE		REG_BIT(7) /* forced halt and exception */
++#define   TD_CTL_FORCE_EXTERNAL_HALT		REG_BIT(6)
++#define   TD_CTL_FORCE_THREAD_BREAKPOINT_ENABLE	REG_BIT(4)
++#define   TD_CTL_FORCE_EXCEPTION		REG_BIT(3)
++#define   TD_CTL_BREAKPOINT_ENABLE		REG_BIT(2)
++#define   TD_CTL_GLOBAL_DEBUG_ENABLE		REG_BIT(0) /* XeHP */
++
+ #define CACHE_MODE_SS				XE_REG_MCR(0xe420, XE_REG_OPTION_MASKED)
+ #define   DISABLE_ECC				REG_BIT(5)
+ #define   ENABLE_PREFETCH_INTO_IC		REG_BIT(3)
+@@ -453,11 +461,13 @@
+ #define   MDQ_ARBITRATION_MODE			REG_BIT(12)
+ #define   STALL_DOP_GATING_DISABLE		REG_BIT(5)
+ #define   EARLY_EOT_DIS				REG_BIT(1)
++#define   STALL_DOP_GATING_DISABLE		REG_BIT(5)
+ 
+ #define ROW_CHICKEN2				XE_REG_MCR(0xe4f4, XE_REG_OPTION_MASKED)
+ #define   DISABLE_READ_SUPPRESSION		REG_BIT(15)
+ #define   DISABLE_EARLY_READ			REG_BIT(14)
+ #define   ENABLE_LARGE_GRF_MODE			REG_BIT(12)
++#define   XEHPC_DISABLE_BTB			REG_BIT(11)
+ #define   PUSH_CONST_DEREF_HOLD_DIS		REG_BIT(8)
+ #define   DISABLE_TDL_SVHS_GATING		REG_BIT(1)
+ #define   DISABLE_DOP_GATING			REG_BIT(0)
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 27ad278ab569..8c0599a10a3c 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -11,11 +11,19 @@
+ 
+ #include <drm/drm_managed.h>
+ 
++#include <generated/xe_wa_oob.h>
++
++#include "regs/xe_gt_regs.h"
++#include "regs/xe_engine_regs.h"
++
+ #include "xe_device.h"
+ #include "xe_assert.h"
+ #include "xe_macros.h"
+ #include "xe_vm.h"
+ #include "xe_exec_queue.h"
++#include "xe_reg_sr.h"
++#include "xe_rtp.h"
++#include "xe_wa.h"
+ 
+ #include "xe_eudebug_types.h"
+ #include "xe_eudebug.h"
+@@ -930,6 +938,68 @@ int xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 	return ret;
+ }
+ 
++#undef XE_REG_MCR
++#define XE_REG_MCR(...)     XE_REG(__VA_ARGS__, .mcr = 1)
++
++void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe)
++{
++	struct xe_gt *gt = hwe->gt;
++	struct xe_device *xe = gt_to_xe(gt);
++
++	if (!xe->eudebug.available)
++		return;
++
++	if (!xe_rtp_match_first_render_or_compute(gt, hwe))
++		return;
++
++	if (XE_WA(gt, 18022722726)) {
++		struct xe_reg_sr_entry sr_entry = {
++			.reg = ROW_CHICKEN,
++			.clr_bits = STALL_DOP_GATING_DISABLE,
++			.set_bits = STALL_DOP_GATING_DISABLE,
++			.read_mask = STALL_DOP_GATING_DISABLE,
++		};
++
++		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt);
++	}
++
++	if (XE_WA(gt, 14015474168)) {
++		struct xe_reg_sr_entry sr_entry = {
++			.reg = ROW_CHICKEN2,
++			.clr_bits = XEHPC_DISABLE_BTB,
++			.set_bits = XEHPC_DISABLE_BTB,
++			.read_mask = XEHPC_DISABLE_BTB,
++		};
++
++		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt);
++	}
++
++	if (xe->info.graphics_verx100 >= 1200) {
++		u32 mask = TD_CTL_BREAKPOINT_ENABLE |
++			   TD_CTL_FORCE_THREAD_BREAKPOINT_ENABLE |
++			   TD_CTL_FEH_AND_FEE_ENABLE;
++		struct xe_reg_sr_entry sr_entry = {
++			.reg = TD_CTL,
++			.clr_bits = mask,
++			.set_bits = mask,
++			.read_mask = mask,
++		};
++
++		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt);
++	}
++
++	if (xe->info.graphics_verx100 >= 1250) {
++		struct xe_reg_sr_entry sr_entry = {
++			.reg = TD_CTL,
++			.clr_bits = TD_CTL_GLOBAL_DEBUG_ENABLE,
++			.set_bits = TD_CTL_GLOBAL_DEBUG_ENABLE,
++			.read_mask = TD_CTL_GLOBAL_DEBUG_ENABLE,
++		};
++
++		xe_reg_sr_add(&hwe->reg_sr, &sr_entry, gt);
++	}
++}
++
+ void xe_eudebug_init(struct xe_device *xe)
+ {
+ 	spin_lock_init(&xe->eudebug.lock);
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
+index 326ddbd50651..3cd6bc7bb682 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.h
++++ b/drivers/gpu/drm/xe/xe_eudebug.h
+@@ -11,6 +11,7 @@ struct xe_device;
+ struct xe_file;
+ struct xe_vm;
+ struct xe_exec_queue;
++struct xe_hw_engine;
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
+ 
+@@ -20,6 +21,7 @@ int xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 
+ void xe_eudebug_init(struct xe_device *xe);
+ void xe_eudebug_fini(struct xe_device *xe);
++void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe);
+ 
+ void xe_eudebug_file_open(struct xe_file *xef);
+ void xe_eudebug_file_close(struct xe_file *xef);
+@@ -38,6 +40,7 @@ static inline int xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 
+ static inline void xe_eudebug_init(struct xe_device *xe) { }
+ static inline void xe_eudebug_fini(struct xe_device *xe) { }
++static inline void xe_eudebug_init_hw_engine(struct xe_hw_engine *hwe) { }
+ 
+ static inline void xe_eudebug_file_open(struct xe_file *xef) { }
+ static inline void xe_eudebug_file_close(struct xe_file *xef) { }
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
+index f1e69ef2e27d..9ed992adb136 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine.c
+@@ -15,6 +15,7 @@
+ #include "xe_assert.h"
+ #include "xe_bo.h"
+ #include "xe_device.h"
++#include "xe_eudebug.h"
+ #include "xe_execlist.h"
+ #include "xe_force_wake.h"
+ #include "xe_gsc.h"
+@@ -530,6 +531,7 @@ static void hw_engine_init_early(struct xe_gt *gt, struct xe_hw_engine *hwe,
+ 	xe_tuning_process_engine(hwe);
+ 	xe_wa_process_engine(hwe);
+ 	hw_engine_setup_default_state(hwe);
++	xe_eudebug_init_hw_engine(hwe);
+ 
+ 	xe_reg_sr_init(&hwe->reg_whitelist, hwe->name, gt_to_xe(gt));
+ 	xe_reg_whitelist_process_engine(hwe);
+diff --git a/drivers/gpu/drm/xe/xe_wa_oob.rules b/drivers/gpu/drm/xe/xe_wa_oob.rules
+index 5cf27ff27ce6..be73ef87f747 100644
+--- a/drivers/gpu/drm/xe/xe_wa_oob.rules
++++ b/drivers/gpu/drm/xe/xe_wa_oob.rules
+@@ -35,3 +35,5 @@
+ 		GRAPHICS_VERSION(2001)
+ 22019338487_display	PLATFORM(LUNARLAKE)
+ 16023588340	GRAPHICS_VERSION(2001)
++18022722726	GRAPHICS_VERSION_RANGE(1250, 1274)
++14015474168	PLATFORM(PVC)
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-implement-userptr_vma-access.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-implement-userptr_vma-access.patch
@@ -1,0 +1,105 @@
+From 99e603bbb4c4c2629fe552d1321d9f29b48d25fa Mon Sep 17 00:00:00 2001
+From: Andrzej Hajda <andrzej.hajda@intel.com>
+Date: Mon, 5 Aug 2024 18:54:21 +0200
+Subject: drm/xe/eudebug: implement userptr_vma access
+
+Debugger needs to read/write program's vmas including userptr_vma.
+Since hmm_range_fault is used to pin userptr vmas, it is possible
+to map those vmas from debugger context.
+
+v2: pin pages vs notifier, move to vm.c (Matthew)
+
+Signed-off-by: Andrzej Hajda <andrzej.hajda@intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Reviewed-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+(cherry picked from commit aaab8ff5bf34bcc05ec3664203651b49d0ada502 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_eudebug.c |  2 +-
+ drivers/gpu/drm/xe/xe_vm.c      | 47 +++++++++++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_vm.h      |  3 +++
+ 3 files changed, 51 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 7f645d689fd3..523ffb627539 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -2945,7 +2945,7 @@ static int xe_eudebug_vma_access(struct xe_vma *vma, u64 offset,
+ 	if (bo)
+ 		return xe_eudebug_bovma_access(bo, offset, buf, bytes, write);
+ 
+-	return -EOPNOTSUPP;
++	return xe_uvma_access(to_userptr_vma(vma), offset, buf, bytes, write);
+ }
+ 
+ static int xe_eudebug_vm_access(struct xe_vm *vm, u64 offset,
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 634af1c36c60..f420cc4380f5 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -3443,3 +3443,50 @@ void xe_vm_snapshot_free(struct xe_vm_snapshot *snap)
+ 	}
+ 	kvfree(snap);
+ }
++
++int xe_uvma_access(struct xe_userptr_vma *uvma, u64 offset,
++		   void *buf, u64 len, bool write)
++{
++	struct xe_vm *vm = xe_vma_vm(&uvma->vma);
++	struct xe_userptr *up = &uvma->userptr;
++	struct xe_res_cursor cur = {};
++	int cur_len, ret = 0;
++
++	while (true) {
++		down_read(&vm->userptr.notifier_lock);
++		if (!xe_vma_userptr_check_repin(uvma))
++			break;
++
++		spin_lock(&vm->userptr.invalidated_lock);
++		list_del_init(&uvma->userptr.invalidate_link);
++		spin_unlock(&vm->userptr.invalidated_lock);
++
++		up_read(&vm->userptr.notifier_lock);
++		ret = xe_vma_userptr_pin_pages(uvma);
++		if (ret)
++			return ret;
++	}
++
++	if (!up->sg) {
++		ret = -EINVAL;
++		goto out_unlock_notifier;
++	}
++
++	for (xe_res_first_sg(up->sg, offset, len, &cur); cur.remaining;
++	     xe_res_next(&cur, cur_len)) {
++		void *ptr = kmap_local_page(sg_page(cur.sgl)) + cur.start;
++
++		cur_len = min(cur.size, cur.remaining);
++		if (write)
++			memcpy(ptr, buf, cur_len);
++		else
++			memcpy(buf, ptr, cur_len);
++		kunmap_local(ptr);
++		buf += cur_len;
++	}
++	ret = len;
++
++out_unlock_notifier:
++	up_read(&vm->userptr.notifier_lock);
++	return ret;
++}
+diff --git a/drivers/gpu/drm/xe/xe_vm.h b/drivers/gpu/drm/xe/xe_vm.h
+index c864dba35e1d..99b9a9b011de 100644
+--- a/drivers/gpu/drm/xe/xe_vm.h
++++ b/drivers/gpu/drm/xe/xe_vm.h
+@@ -281,3 +281,6 @@ struct xe_vm_snapshot *xe_vm_snapshot_capture(struct xe_vm *vm);
+ void xe_vm_snapshot_capture_delayed(struct xe_vm_snapshot *snap);
+ void xe_vm_snapshot_print(struct xe_vm_snapshot *snap, struct drm_printer *p);
+ void xe_vm_snapshot_free(struct xe_vm_snapshot *snap);
++
++int xe_uvma_access(struct xe_userptr_vma *uvma, u64 offset,
++		   void *buf, u64 len, bool write);
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-vm-open-pread-pwrite.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-vm-open-pread-pwrite.patch
@@ -1,0 +1,618 @@
+From 563ef5e5ad896bf10a1159891671b8eb148440b5 Mon Sep 17 00:00:00 2001
+From: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Date: Mon, 26 Jun 2023 13:05:02 +0300
+Subject: drm/xe/eudebug: vm open/pread/pwrite
+
+Debugger needs access to the client's vm to read and write. For
+example inspecting ISA/ELF and setting up breakpoints.
+
+Add ioctl to open target vm with debugger client and vm_handle
+and hook up pread/pwrite possibility.
+
+Open will take timeout argument so that standard fsync
+can be used for explicit flushing between cpu/gpu for
+the target vm.
+
+Implement this for bo backed storage. userptr will
+be done in following patch.
+
+v2: checkpatch (Maciej)
+
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+(cherry picked from commit fa7f342cfe84c437ae5eed47048e3a73bc13c741 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h |  24 ++
+ drivers/gpu/drm/xe/xe_eudebug.c      | 470 +++++++++++++++++++++++++++
+ include/uapi/drm/xe_drm_eudebug.h    |  18 +
+ 3 files changed, 512 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index 41ff01abea1b..29dbaf9c7a9b 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -523,6 +523,30 @@
+ #define   CCS_MODE_CSLICE(cslice, ccs) \
+ 	((ccs) << ((cslice) * CCS_MODE_CSLICE_WIDTH))
+ 
++#define RCU_ASYNC_FLUSH				XE_REG(0x149fc)
++#define   RCU_ASYNC_FLUSH_IN_PROGRESS	REG_BIT(31)
++#define   RCU_ASYNC_FLUSH_ENGINE_ID_SHIFT	28
++#define   RCU_ASYNC_FLUSH_ENGINE_ID_DECODE1 REG_BIT(26)
++#define   RCU_ASYNC_FLUSH_AMFS		REG_BIT(8)
++#define   RCU_ASYNC_FLUSH_PREFETCH	REG_BIT(7)
++#define   RCU_ASYNC_FLUSH_DATA_PORT	REG_BIT(6)
++#define   RCU_ASYNC_FLUSH_DATA_CACHE	REG_BIT(5)
++#define   RCU_ASYNC_FLUSH_HDC_PIPELINE	REG_BIT(4)
++#define   RCU_ASYNC_INVALIDATE_HDC_PIPELINE REG_BIT(3)
++#define   RCU_ASYNC_INVALIDATE_CONSTANT_CACHE REG_BIT(2)
++#define   RCU_ASYNC_INVALIDATE_TEXTURE_CACHE REG_BIT(1)
++#define   RCU_ASYNC_INVALIDATE_INSTRUCTION_CACHE REG_BIT(0)
++#define   RCU_ASYNC_FLUSH_AND_INVALIDATE_ALL ( \
++	RCU_ASYNC_FLUSH_AMFS | \
++	RCU_ASYNC_FLUSH_PREFETCH | \
++	RCU_ASYNC_FLUSH_DATA_PORT | \
++	RCU_ASYNC_FLUSH_DATA_CACHE | \
++	RCU_ASYNC_FLUSH_HDC_PIPELINE | \
++	RCU_ASYNC_INVALIDATE_HDC_PIPELINE | \
++	RCU_ASYNC_INVALIDATE_CONSTANT_CACHE | \
++	RCU_ASYNC_INVALIDATE_TEXTURE_CACHE | \
++	RCU_ASYNC_INVALIDATE_INSTRUCTION_CACHE)
++
+ #define RCU_DEBUG_1				XE_REG(0x14a00)
+ #define   RCU_DEBUG_1_ENGINE_STATUS		REG_GENMASK(2, 0)
+ #define   RCU_DEBUG_1_RUNALONE_ACTIVE		REG_BIT(2)
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 3e607a1eea01..7f645d689fd3 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -8,7 +8,10 @@
+ #include <linux/anon_inodes.h>
+ #include <linux/poll.h>
+ #include <linux/delay.h>
++#include <linux/file.h>
++#include <linux/vmalloc.h>
+ 
++#include <drm/drm_drv.h>
+ #include <drm/drm_managed.h>
+ 
+ #include <generated/xe_wa_oob.h>
+@@ -37,6 +40,7 @@
+ #include "xe_rtp.h"
+ #include "xe_gt_mcr.h"
+ #include "xe_sync.h"
++#include "xe_bo.h"
+ 
+ #include "xe_eudebug_types.h"
+ #include "xe_eudebug.h"
+@@ -751,6 +755,17 @@ static struct xe_lrc *find_lrc(struct xe_eudebug *d, const u32 id)
+ 	return l;
+ }
+ 
++static struct xe_vm *find_vm(struct xe_eudebug *d, const u32 id)
++{
++	struct xe_eudebug_handle *h;
++
++	h = find_resource(d->res, XE_EUDEBUG_RES_TYPE_VM, id);
++	if (h)
++		return (void *)h->key;
++
++	return NULL;
++}
++
+ static int _xe_eudebug_add_handle(struct xe_eudebug *d,
+ 				  int type,
+ 				  void *p,
+@@ -1206,6 +1221,8 @@ static long xe_eudebug_eu_control(struct xe_eudebug *d, const u64 arg)
+ 	return ret;
+ }
+ 
++static long xe_eudebug_vm_open_ioctl(struct xe_eudebug *d, unsigned long arg);
++
+ static long xe_eudebug_ioctl(struct file *file,
+ 			     unsigned int cmd,
+ 			     unsigned long arg)
+@@ -1226,6 +1243,11 @@ static long xe_eudebug_ioctl(struct file *file,
+ 		ret = xe_eudebug_ack_event_ioctl(d, cmd, arg);
+ 		eu_dbg(d, "ioctl cmd=EVENT_ACK ret=%ld\n", ret);
+ 		break;
++	case DRM_XE_EUDEBUG_IOCTL_VM_OPEN:
++		ret = xe_eudebug_vm_open_ioctl(d, arg);
++		eu_dbg(d, "ioctl cmd=VM_OPEN ret=%ld\n", ret);
++		break;
++
+ 	default:
+ 		ret = -EINVAL;
+ 	}
+@@ -2879,3 +2901,451 @@ static void discovery_work_fn(struct work_struct *work)
+ 
+ 	xe_eudebug_put(d);
+ }
++
++static int xe_eudebug_bovma_access(struct xe_bo *bo, u64 offset,
++				   void *buf, u64 len, bool write)
++{
++	struct xe_device * const xe = xe_bo_device(bo);
++	struct iosys_map src;
++	int ret;
++
++	dma_resv_lock(bo->ttm.base.resv, NULL);
++
++	ret = ttm_bo_vmap(&bo->ttm, &src);
++	if (!ret) {
++		if (write)
++			xe_map_memcpy_to(xe, &src, offset, buf, len);
++		else
++			xe_map_memcpy_from(xe, buf, &src, offset, len);
++
++		ttm_bo_vunmap(&bo->ttm, &src);
++
++		ret = len;
++	}
++
++	dma_resv_unlock(bo->ttm.base.resv);
++
++	return ret;
++}
++
++static int xe_eudebug_vma_access(struct xe_vma *vma, u64 offset,
++				 void *buf, u64 len, bool write)
++{
++	struct xe_bo *bo;
++	u64 bytes;
++
++	if (XE_WARN_ON(offset >= xe_vma_size(vma)))
++		return -EINVAL;
++
++	bytes = min_t(u64, len, xe_vma_size(vma) - offset);
++	if (!bytes)
++		return 0;
++
++	bo = xe_vma_bo(vma);
++	if (bo)
++		return xe_eudebug_bovma_access(bo, offset, buf, bytes, write);
++
++	return -EOPNOTSUPP;
++}
++
++static int xe_eudebug_vm_access(struct xe_vm *vm, u64 offset,
++				void *buf, u64 len, bool write)
++{
++	struct xe_vma *vma;
++	int ret;
++
++	down_write(&vm->lock);
++
++	vma = xe_vm_find_overlapping_vma(vm, offset, len);
++	if (vma) {
++#ifdef VERBOSE_VM_ACCESS
++		drm_dbg(&xe_vma_vm(vma)->xe->drm,
++			"eudbg: offset: 0x%llx: vma start 0x%llx, size 0x%llx, offset_in_vma 0x%llx",
++			offset, xe_vma_start(vma), xe_vma_size(vma), offset - xe_vma_start(vma));
++#endif
++		/* XXX: why find overlapping returns below start? */
++		if (offset < xe_vma_start(vma) ||
++		    offset >= (xe_vma_start(vma) + xe_vma_size(vma))) {
++			ret = -EINVAL;
++			goto out;
++		}
++
++		/* Offset into vma */
++		offset -= xe_vma_start(vma);
++		ret = xe_eudebug_vma_access(vma, offset, buf, len, write);
++	} else {
++		ret = -EINVAL;
++	}
++
++out:
++	up_write(&vm->lock);
++
++	return ret;
++}
++
++struct vm_file {
++	struct xe_eudebug *debugger;
++	struct xe_vm *vm;
++	u64 flags;
++	u64 client_id;
++	u64 vm_handle;
++	u64 timeout_ns;
++};
++
++static ssize_t __vm_read_write(struct xe_vm *vm,
++			       void *bb,
++			       char __user *r_buffer,
++			       const char __user *w_buffer,
++			       unsigned long offset,
++			       unsigned long len,
++			       const bool write)
++{
++	ssize_t ret;
++
++	if (!len)
++		return 0;
++
++	if (write) {
++		ret = copy_from_user(bb, w_buffer, len);
++		if (ret)
++			return -EFAULT;
++
++		ret = xe_eudebug_vm_access(vm, offset, bb, len, true);
++		if (ret < 0)
++			return ret;
++
++		len = ret;
++	} else {
++		ret = xe_eudebug_vm_access(vm, offset, bb, len, false);
++		if (ret < 0)
++			return ret;
++
++		len = ret;
++
++		ret = copy_to_user(r_buffer, bb, len);
++		if (ret)
++			return -EFAULT;
++	}
++
++	return len;
++}
++
++static ssize_t __xe_eudebug_vm_access(struct file *file,
++				      char __user *r_buffer,
++				      const char __user *w_buffer,
++				      size_t count, loff_t *__pos)
++{
++	struct vm_file *vmf = file->private_data;
++	struct xe_eudebug * const d = vmf->debugger;
++	struct xe_device * const xe = d->xe;
++	const bool write = !!w_buffer;
++	struct xe_vm *vm;
++	ssize_t copied = 0;
++	ssize_t bytes_left = count;
++	ssize_t ret;
++	unsigned long alloc_len;
++	loff_t pos = *__pos;
++	void *k_buffer;
++
++#ifdef VERBOSE_VM_ACCESS
++	eu_dbg(d, "vm_access(%s): client_handle=%llu, vm_handle=%llu, flags=0x%llx, pos=0x%llx, count=0x%lx",
++	       write ? "write" : "read",
++	       vmf->client_id, vmf->vm_handle, vmf->flags, pos, count);
++#endif
++	if (XE_IOCTL_DBG(xe, write && r_buffer))
++		return -EINVAL;
++
++	vm = find_vm(d, vmf->vm_handle);
++	if (XE_IOCTL_DBG(xe, !vm))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, vm != vmf->vm)) {
++		eu_warn(d, "vm_access(%s): vm handle mismatch client_handle=%llu, vm_handle=%llu, flags=0x%llx, pos=%llu, count=%lu\n",
++			write ? "write" : "read",
++			vmf->client_id, vmf->vm_handle, vmf->flags, pos, count);
++		return -EINVAL;
++	}
++
++	if (!count)
++		return 0;
++
++	alloc_len = min_t(unsigned long, ALIGN(count, PAGE_SIZE), 64 * SZ_1M);
++	do  {
++		k_buffer = vmalloc(alloc_len);
++		if (k_buffer)
++			break;
++
++		alloc_len >>= 1;
++	} while (alloc_len > PAGE_SIZE);
++
++	if (XE_IOCTL_DBG(xe, !k_buffer))
++		return -ENOMEM;
++
++	do {
++		const ssize_t len = min_t(ssize_t, bytes_left, alloc_len);
++
++		ret = __vm_read_write(vm, k_buffer,
++				      write ? NULL : r_buffer + copied,
++				      write ? w_buffer + copied : NULL,
++				      pos + copied,
++				      len,
++				      write);
++#ifdef VERBOSE_VM_ACCESS
++		eu_dbg(d, "vm_access(%s): pos=0x%llx, len=0x%lx, copied=%lu bytes_left=%lu, ret=%ld",
++		       write ? "write" : "read", pos + copied, len, copied, bytes_left, ret);
++#endif
++		if (ret <= 0)
++			break;
++
++		bytes_left -= ret;
++		copied += ret;
++	} while (bytes_left > 0);
++
++	vfree(k_buffer);
++
++	if (XE_WARN_ON(copied < 0))
++		copied = 0;
++
++	*__pos += copied;
++
++#ifdef VERBOSE_VM_ACCESS
++	eu_dbg(d, "vm_access(%s): pos=0x%llx, count=0x%lx, copied=%lu bytes_left=%lu, ret=%ld",
++	       write ? "write" : "read", pos, count, copied, bytes_left, copied ?: ret);
++#endif
++
++	return copied ?: ret;
++}
++
++static ssize_t xe_eudebug_vm_read(struct file *file,
++				  char __user *buffer,
++				  size_t count, loff_t *pos)
++{
++	return __xe_eudebug_vm_access(file, buffer, NULL, count, pos);
++}
++
++static ssize_t xe_eudebug_vm_write(struct file *file,
++				   const char __user *buffer,
++				   size_t count, loff_t *pos)
++{
++	return __xe_eudebug_vm_access(file, NULL, buffer, count, pos);
++}
++
++static int engine_rcu_flush(struct xe_eudebug *d,
++			    struct xe_hw_engine *hwe,
++			    unsigned int timeout_us)
++{
++	const struct xe_reg psmi_addr = RING_PSMI_CTL(hwe->mmio_base);
++	struct xe_gt *gt = hwe->gt;
++	u32 mask = RCU_ASYNC_FLUSH_AND_INVALIDATE_ALL;
++	u32 psmi_ctrl;
++	u32 id;
++	int ret;
++
++	if (hwe->class == XE_ENGINE_CLASS_RENDER)
++		id = 0;
++	else if (hwe->class == XE_ENGINE_CLASS_COMPUTE)
++		id = hwe->instance + 1;
++	else
++		return -EINVAL;
++
++	if (id < 8)
++		mask |= id << RCU_ASYNC_FLUSH_ENGINE_ID_SHIFT;
++	else
++		mask |= (id - 8) << RCU_ASYNC_FLUSH_ENGINE_ID_SHIFT |
++			RCU_ASYNC_FLUSH_ENGINE_ID_DECODE1;
++
++	ret = xe_force_wake_get(gt_to_fw(gt), hwe->domain);
++	if (ret)
++		return ret;
++
++	/* Prevent concurrent flushes */
++	mutex_lock(&d->eu_lock);
++	psmi_ctrl = xe_mmio_read32(gt, psmi_addr);
++	if (!(psmi_ctrl & IDLE_MSG_DISABLE))
++		xe_mmio_write32(gt, psmi_addr, _MASKED_BIT_ENABLE(IDLE_MSG_DISABLE));
++
++	ret = xe_mmio_wait32(gt, RCU_ASYNC_FLUSH,
++			     RCU_ASYNC_FLUSH_IN_PROGRESS, 0,
++			     timeout_us, NULL, false);
++	if (ret)
++		goto out;
++
++	xe_mmio_write32(gt, RCU_ASYNC_FLUSH, mask);
++
++	ret = xe_mmio_wait32(gt, RCU_ASYNC_FLUSH,
++			     RCU_ASYNC_FLUSH_IN_PROGRESS, 0,
++			     timeout_us, NULL, false);
++out:
++	if (!(psmi_ctrl & IDLE_MSG_DISABLE))
++		xe_mmio_write32(gt, psmi_addr, _MASKED_BIT_DISABLE(IDLE_MSG_DISABLE));
++
++	mutex_unlock(&d->eu_lock);
++	xe_force_wake_put(gt_to_fw(gt), hwe->domain);
++
++	return ret;
++}
++
++static int xe_eudebug_vm_fsync(struct file *file, loff_t start, loff_t end, int datasync)
++{
++	struct vm_file *vmf = file->private_data;
++	struct xe_eudebug *d = vmf->debugger;
++	struct xe_gt *gt;
++	int gt_id;
++	int ret = -EINVAL;
++
++	eu_dbg(d, "vm_fsync: client_handle=%llu, vm_handle=%llu, flags=0x%llx, start=%llu, end=%llu datasync=%d\n",
++	       vmf->client_id, vmf->vm_handle, vmf->flags, start, end, datasync);
++
++	for_each_gt(gt, d->xe, gt_id) {
++		struct xe_hw_engine *hwe;
++		enum xe_hw_engine_id id;
++
++		/* XXX: vm open per engine? */
++		for_each_hw_engine(hwe, gt, id) {
++			if (hwe->class != XE_ENGINE_CLASS_RENDER &&
++			    hwe->class != XE_ENGINE_CLASS_COMPUTE)
++				continue;
++
++			ret = engine_rcu_flush(d, hwe, vmf->timeout_ns / 1000ull);
++			if (ret)
++				break;
++		}
++	}
++
++	return ret;
++}
++
++static int xe_eudebug_vm_release(struct inode *inode, struct file *file)
++{
++	struct vm_file *vmf = file->private_data;
++	struct xe_eudebug *d = vmf->debugger;
++
++	eu_dbg(d, "vm_release: client_handle=%llu, vm_handle=%llu, flags=0x%llx",
++	       vmf->client_id, vmf->vm_handle, vmf->flags);
++
++	drm_dev_put(&d->xe->drm);
++	xe_vm_put(vmf->vm);
++	xe_eudebug_put(d);
++	kfree(vmf);
++
++	return 0;
++}
++
++static const struct file_operations vm_fops = {
++	.owner   = THIS_MODULE,
++	.llseek  = generic_file_llseek,
++	.read    = xe_eudebug_vm_read,
++	.write   = xe_eudebug_vm_write,
++	.fsync   = xe_eudebug_vm_fsync,
++	.mmap    = NULL,
++	.release = xe_eudebug_vm_release,
++};
++
++static long
++xe_eudebug_vm_open_ioctl(struct xe_eudebug *d, unsigned long arg)
++{
++	struct drm_xe_eudebug_vm_open param;
++	struct xe_device * const xe = d->xe;
++	struct xe_eudebug *d_ref = NULL;
++	struct vm_file *vmf = NULL;
++	struct xe_file *xef;
++	struct xe_vm *vm;
++	struct file *file;
++	long ret = 0;
++	int fd;
++
++	if (XE_IOCTL_DBG(xe, _IOC_SIZE(DRM_XE_EUDEBUG_IOCTL_VM_OPEN) != sizeof(param)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, !(_IOC_DIR(DRM_XE_EUDEBUG_IOCTL_VM_OPEN) & _IOC_WRITE)))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, copy_from_user(&param, (void __user *)arg, sizeof(param))))
++		return -EFAULT;
++
++	if (XE_IOCTL_DBG(xe, param.flags))
++		return -EINVAL;
++
++	if (XE_IOCTL_DBG(xe, xe_eudebug_detached(d)))
++		return -ENOTCONN;
++
++	vm = NULL;
++	mutex_lock(&d->xe->files.lock);
++	xef = find_client(d, param.client_handle);
++	if (XE_IOCTL_DBG(xe, !xef)) {
++		mutex_unlock(&d->xe->files.lock);
++		return -EINVAL;
++	}
++
++	d_ref = xe_eudebug_get(xef);
++	if (XE_IOCTL_DBG(xe, !d_ref)) {
++		mutex_unlock(&d->xe->files.lock);
++		return -EINVAL;
++	}
++
++	mutex_lock(&xef->vm.lock);
++	vm = find_vm(d, param.vm_handle);
++	if (vm)
++		xe_vm_get(vm);
++	mutex_unlock(&xef->vm.lock);
++	mutex_unlock(&d->xe->files.lock);
++
++	XE_WARN_ON(d != d_ref);
++
++	if (XE_IOCTL_DBG(xe, !vm)) {
++		ret = -EINVAL;
++		goto out_eudebug_put;
++	}
++
++	vmf = kmalloc(sizeof(*vmf), GFP_KERNEL);
++	if (XE_IOCTL_DBG(xe, !vmf)) {
++		ret = -ENOMEM;
++		goto out_vm_put;
++	}
++
++	fd = get_unused_fd_flags(O_CLOEXEC);
++	if (XE_IOCTL_DBG(xe, fd < 0)) {
++		ret = fd;
++		goto out_free;
++	}
++
++	vmf->debugger = d_ref;
++	vmf->vm = vm;
++	vmf->flags = param.flags;
++	vmf->client_id = param.client_handle;
++	vmf->vm_handle = param.vm_handle;
++	vmf->timeout_ns = param.timeout_ns;
++
++	file = anon_inode_getfile("[xe_eudebug.vm]", &vm_fops, vmf, O_RDWR);
++	if (IS_ERR(file)) {
++		ret = PTR_ERR(file);
++		XE_IOCTL_DBG(xe, ret);
++		file = NULL;
++		goto out_file_put;
++	}
++
++	drm_dev_get(&d->xe->drm);
++
++	file->f_mode |= FMODE_PREAD | FMODE_PWRITE |
++		FMODE_READ | FMODE_WRITE | FMODE_LSEEK;
++
++	fd_install(fd, file);
++
++	eu_dbg(d, "vm_open: client_handle=%llu, handle=%llu, flags=0x%llx, fd=%d",
++	       vmf->client_id, vmf->vm_handle, vmf->flags, fd);
++
++	XE_WARN_ON(ret);
++
++	return fd;
++
++out_file_put:
++	put_unused_fd(fd);
++out_free:
++	kfree(vmf);
++out_vm_put:
++	xe_vm_put(vm);
++out_eudebug_put:
++	xe_eudebug_put(d_ref);
++
++	return ret;
++}
+diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
+index b2f6038ccc59..9917280400d6 100644
+--- a/include/uapi/drm/xe_drm_eudebug.h
++++ b/include/uapi/drm/xe_drm_eudebug.h
+@@ -18,6 +18,7 @@ extern "C" {
+ #define DRM_XE_EUDEBUG_IOCTL_READ_EVENT		_IO('j', 0x0)
+ #define DRM_XE_EUDEBUG_IOCTL_EU_CONTROL		_IOWR('j', 0x2, struct drm_xe_eudebug_eu_control)
+ #define DRM_XE_EUDEBUG_IOCTL_ACK_EVENT		_IOW('j', 0x4, struct drm_xe_eudebug_ack_event)
++#define DRM_XE_EUDEBUG_IOCTL_VM_OPEN		_IOW('j', 0x1, struct drm_xe_eudebug_vm_open)
+ 
+ /* XXX: Document events to match their internal counterparts when moved to xe_drm.h */
+ struct drm_xe_eudebug_event {
+@@ -170,6 +171,23 @@ struct drm_xe_eudebug_ack_event {
+ 	__u64 seqno;
+ };
+ 
++struct drm_xe_eudebug_vm_open {
++	/** @extensions: Pointer to the first extension struct, if any */
++	__u64 extensions;
++
++	/** @client_handle: id of client */
++	__u64 client_handle;
++
++	/** @vm_handle: id of vm */
++	__u64 vm_handle;
++
++	/** @flags: flags */
++	__u64 flags;
++
++	/** @timeout_ns: Timeout value in nanoseconds operations (fsync) */
++	__u64 timeout_ns;
++};
++
+ #if defined(__cplusplus)
+ }
+ #endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug_test-Introduce-xe_eudebug-wa-kunit-te.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug_test-Introduce-xe_eudebug-wa-kunit-te.patch
@@ -1,0 +1,233 @@
+From 39abe7aaf410cc861c4db00c7bf99a088e2b394c Mon Sep 17 00:00:00 2001
+From: Christoph Manszewski <christoph.manszewski@intel.com>
+Date: Tue, 26 Mar 2024 19:31:42 +0100
+Subject: drm/xe/eudebug_test: Introduce xe_eudebug wa kunit test
+
+Introduce kunit test for eudebug. For now it checks the dynamic
+application of WAs.
+
+v2: adapt to removal of call_for_each_device (Mika)
+
+Signed-off-by: Christoph Manszewski <christoph.manszewski@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+(cherry picked from commit 924316e7ceee63cf0a41789a2d07d85533ec0b3f eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/tests/xe_eudebug.c       | 175 ++++++++++++++++++++
+ drivers/gpu/drm/xe/tests/xe_live_test_mod.c |   5 +
+ drivers/gpu/drm/xe/xe_eudebug.c             |   4 +
+ 3 files changed, 184 insertions(+)
+ create mode 100644 drivers/gpu/drm/xe/tests/xe_eudebug.c
+
+diff --git a/drivers/gpu/drm/xe/tests/xe_eudebug.c b/drivers/gpu/drm/xe/tests/xe_eudebug.c
+new file mode 100644
+index 000000000000..2bab41693b9b
+--- /dev/null
++++ b/drivers/gpu/drm/xe/tests/xe_eudebug.c
+@@ -0,0 +1,175 @@
++// SPDX-License-Identifier: GPL-2.0 AND MIT
++/*
++ * Copyright © 2024 Intel Corporation
++ */
++
++#include <kunit/visibility.h>
++
++#include "tests/xe_kunit_helpers.h"
++#include "tests/xe_pci_test.h"
++#include "tests/xe_test.h"
++
++#undef XE_REG_MCR
++#define XE_REG_MCR(r_, ...)	((const struct xe_reg_mcr){					\
++				 .__reg = XE_REG_INITIALIZER(r_,  ##__VA_ARGS__, .mcr = 1)	\
++				 })
++
++static const char *reg_to_str(struct xe_reg reg)
++{
++	if (reg.raw == TD_CTL.__reg.raw)
++		return "TD_CTL";
++	else if (reg.raw == CS_DEBUG_MODE2(RENDER_RING_BASE).raw)
++		return "CS_DEBUG_MODE2";
++	else if (reg.raw == ROW_CHICKEN.__reg.raw)
++		return "ROW_CHICKEN";
++	else if (reg.raw == ROW_CHICKEN2.__reg.raw)
++		return "ROW_CHICKEN2";
++	else if (reg.raw == ROW_CHICKEN3.__reg.raw)
++		return "ROW_CHICKEN3";
++	else
++		return "UNKNOWN REG";
++}
++
++static u32 get_reg_mask(struct xe_device *xe, struct xe_reg reg)
++{
++	struct kunit *test = kunit_get_current_test();
++	u32 val = 0;
++
++	if (reg.raw == TD_CTL.__reg.raw) {
++		val = TD_CTL_BREAKPOINT_ENABLE |
++		      TD_CTL_FORCE_THREAD_BREAKPOINT_ENABLE |
++		      TD_CTL_FEH_AND_FEE_ENABLE;
++
++		if (GRAPHICS_VERx100(xe) >= 1250)
++			val |= TD_CTL_GLOBAL_DEBUG_ENABLE;
++
++	} else if (reg.raw == CS_DEBUG_MODE2(RENDER_RING_BASE).raw) {
++		val = GLOBAL_DEBUG_ENABLE;
++	} else if (reg.raw == ROW_CHICKEN.__reg.raw) {
++		val = STALL_DOP_GATING_DISABLE;
++	} else if (reg.raw == ROW_CHICKEN2.__reg.raw) {
++		val = XEHPC_DISABLE_BTB;
++	} else if (reg.raw == ROW_CHICKEN3.__reg.raw) {
++		val = XE2_EUPEND_CHK_FLUSH_DIS;
++	} else {
++		kunit_warn(test, "Invalid register selection: %u\n", reg.raw);
++	}
++
++	return val;
++}
++
++static u32 get_reg_expected(struct xe_device *xe, struct xe_reg reg, bool enable_eudebug)
++{
++	u32 reg_mask = get_reg_mask(xe, reg);
++	u32 reg_bits = 0;
++
++	if (enable_eudebug || reg.raw == ROW_CHICKEN3.__reg.raw)
++		reg_bits = reg_mask;
++	else
++		reg_bits = 0;
++
++	return reg_bits;
++}
++
++static void check_reg(struct xe_gt *gt, bool enable_eudebug, struct xe_reg reg)
++{
++	struct kunit *test = kunit_get_current_test();
++	struct xe_device *xe = gt_to_xe(gt);
++	u32 reg_bits_expected = get_reg_expected(xe, reg, enable_eudebug);
++	u32 reg_mask = get_reg_mask(xe, reg);
++	u32 reg_bits = 0;
++
++	if (reg.mcr)
++		reg_bits = xe_gt_mcr_unicast_read_any(gt, (struct xe_reg_mcr){.__reg = reg});
++	else
++		reg_bits = xe_mmio_read32(gt, reg);
++
++	reg_bits &= reg_mask;
++
++	kunit_printk(KERN_DEBUG, test, "%s bits: expected == 0x%x; actual == 0x%x\n",
++		     reg_to_str(reg), reg_bits_expected, reg_bits);
++	KUNIT_EXPECT_EQ_MSG(test, reg_bits_expected, reg_bits,
++			    "Invalid bits set for %s\n", reg_to_str(reg));
++}
++
++static void __check_regs(struct xe_gt *gt, bool enable_eudebug)
++{
++	struct xe_device *xe = gt_to_xe(gt);
++
++	if (GRAPHICS_VERx100(xe) >= 1200)
++		check_reg(gt, enable_eudebug, TD_CTL.__reg);
++
++	if (GRAPHICS_VERx100(xe) >= 1250 && GRAPHICS_VERx100(xe) <= 1274)
++		check_reg(gt, enable_eudebug, ROW_CHICKEN.__reg);
++
++	if (xe->info.platform == XE_PVC)
++		check_reg(gt, enable_eudebug, ROW_CHICKEN2.__reg);
++
++	if (GRAPHICS_VERx100(xe) >= 2000 && GRAPHICS_VERx100(xe) <= 2004)
++		check_reg(gt, enable_eudebug, ROW_CHICKEN3.__reg);
++}
++
++static void check_regs(struct xe_device *xe, bool enable_eudebug)
++{
++	struct kunit *test = kunit_get_current_test();
++	struct xe_gt *gt;
++	u8 id;
++	int ret = 0;
++
++	kunit_printk(KERN_DEBUG, test, "Check regs for eudebug %s\n",
++		     enable_eudebug ? "enabled" : "disabled");
++
++	xe_pm_runtime_get(xe);
++	for_each_gt(gt, xe, id) {
++		if (xe_gt_is_media_type(gt))
++			continue;
++
++		ret = xe_force_wake_get(gt_to_fw(gt), XE_FW_RENDER);
++		KUNIT_ASSERT_EQ_MSG(test, ret, 0, "Forcewake failed.\n");
++
++		__check_regs(gt, enable_eudebug);
++
++		xe_force_wake_put(gt_to_fw(gt), XE_FW_RENDER);
++	}
++	xe_pm_runtime_put(xe);
++}
++
++static int toggle_reg_value(struct xe_device *xe)
++{
++	struct kunit *test = kunit_get_current_test();
++	bool enable_eudebug = xe->eudebug.enable;
++
++	kunit_printk(KERN_DEBUG, test, "Test eudebug WAs for graphics version: %u\n",
++		     GRAPHICS_VERx100(xe));
++
++	check_regs(xe, enable_eudebug);
++
++	xe_eudebug_enable(xe, !enable_eudebug);
++	check_regs(xe, !enable_eudebug);
++
++	xe_eudebug_enable(xe, enable_eudebug);
++	check_regs(xe, enable_eudebug);
++
++	return 0;
++}
++
++static void xe_eudebug_toggle_reg_kunit(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++
++	toggle_reg_value(xe);
++}
++
++static struct kunit_case xe_eudebug_tests[] = {
++	KUNIT_CASE_PARAM(xe_eudebug_toggle_reg_kunit,
++			 xe_pci_live_device_gen_param),
++	{}
++};
++
++VISIBLE_IF_KUNIT
++struct kunit_suite xe_eudebug_test_suite = {
++	.name = "xe_eudebug",
++	.test_cases = xe_eudebug_tests,
++	.init = xe_kunit_helper_xe_device_live_test_init,
++};
++EXPORT_SYMBOL_IF_KUNIT(xe_eudebug_test_suite);
+diff --git a/drivers/gpu/drm/xe/tests/xe_live_test_mod.c b/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
+index eb1ea99a5a8b..e95b1c6f5695 100644
+--- a/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
++++ b/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
+@@ -4,6 +4,11 @@
+  */
+ #include <linux/module.h>
+ 
++#if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
++extern struct kunit_suite xe_eudebug_test_suite;
++kunit_test_suite(xe_eudebug_test_suite);
++#endif
++
+ MODULE_AUTHOR("Intel Corporation");
+ MODULE_LICENSE("GPL");
+ MODULE_DESCRIPTION("xe live kunit tests");
+diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
+index 22e920cd2115..fbf8213c9b8d 100644
+--- a/drivers/gpu/drm/xe/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/xe_eudebug.c
+@@ -3798,3 +3798,7 @@ xe_eudebug_vm_open_ioctl(struct xe_eudebug *d, unsigned long arg)
+ 
+ 	return ret;
+ }
++
++#if IS_ENABLED(CONFIG_DRM_XE_KUNIT_TEST)
++#include "tests/xe_eudebug.c"
++#endif
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
+++ b/backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
@@ -1,0 +1,53 @@
+From 6c6b9d1e009aca6cd1f3b3039784d68331b613f2 Mon Sep 17 00:00:00 2001
+From: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Date: Wed, 20 Jan 2021 12:40:46 +0200
+Subject: ptrace: export ptrace_may_access
+
+xe driver would like to allow fine grained access control
+for GBU debugger. Without this export, the only option would
+be to check for CAP_SYS_ADMIN.
+
+The check intended for an ioctl to attach a GPU debugger
+is similar to the ptrace use case: allow a calling process
+to manipulate a target process if it has the necessary
+capabilities or the same permissions, as described in
+Documentation/process/adding-syscalls.rst.
+
+Export ptrace_may_access function to allow GPU debugger to
+have identical access control for debugger as a CPU debugger.
+
+v2: proper commit message (Lucas)
+
+Cc: Oleg Nesterov <oleg@redhat.com>
+Cc: linux-kernel@vger.kernel.org
+Cc: Dave Airlie <airlied@redhat.com>
+CC: Lucas De Marchi <lucas.demarchi@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+CC: Andi Shyti <andi.shyti@intel.com>
+Cc: Joonas Lahtinen <joonas.lahtinen@linux.intel.com>
+CC: Maciej Patelczyk <maciej.patelczyk@linux.intel.com>
+Cc: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Signed-off-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Reviewed-by: Andi Shyti <andi.shyti@linux.intel.com>
+(cherry picked from commit a3258ab6e9ea555c4d6693567276b6008051e574 eudebug-dev-prelim)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ kernel/ptrace.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/ptrace.c b/kernel/ptrace.c
+index d5f89f9ef29f..86be1805ebd8 100644
+--- a/kernel/ptrace.c
++++ b/kernel/ptrace.c
+@@ -354,6 +354,7 @@ bool ptrace_may_access(struct task_struct *task, unsigned int mode)
+ 	task_unlock(task);
+ 	return !err;
+ }
++EXPORT_SYMBOL_GPL(ptrace_may_access);
+ 
+ static int check_ptrace_options(unsigned long data)
+ {
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -102,3 +102,25 @@
 ../backport/patches/base/0001-drm-xe-display-Avoid-encoder_suspend-at-runtime-susp.patch
 ../backport/patches/base/0001-drm-xe-Use-xe_pm_runtime_get-in-xe_bo_move-if-reclai.patch
 ../backport/patches/base/0001-drm-xe-Remove-extra-dma_fence_put-on-xe_sync_entry_a.patch
+# features/eu-debug
+../backport/patches/features/eu-debug/0001-drm-xe-Export-xe_hw_engine-s-mmio-accessors.patch
+../backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-discovery-for-resources.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-exec_queue-events.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-hw-enablement-for-eudebug.patch
+../backport/patches/features/eu-debug/0001-drm-xe-Add-EUDEBUG_ENABLE-exec-queue-property.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-per-device-attention-scan-w.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-EU-control-interface.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-vm-bind-and-vm-bind-ops.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-UFENCE-events-with-acks.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-vm-open-pread-pwrite.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-implement-userptr_vma-access.patch
+../backport/patches/features/eu-debug/0001-drm-xe-Debug-metadata-create-destroy-ioctls.patch
+../backport/patches/features/eu-debug/0001-drm-xe-Attach-debug-metadata-to-vma.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-debug-metadata-support-for-xe_eud.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Implement-vm_bind_op-discovery.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Dynamically-toggle-debugger-functiona.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug_test-Introduce-xe_eudebug-wa-kunit-te.patch
+../backport/patches/features/eu-debug/0001-drm-xe-Add-PRELIM-infrastructure.patch
+../backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch


### PR DESCRIPTION
eu-debugger preview patches on top of 6.11-rc6. eu-debug merge of drm-tip
is going to take some time so to avoid frequent uapi break, prelim uapi
is being used and it will be changed during merge of drm-tip.

Patches are under review in drm mailinglist at
https://patchwork.freedesktop.org/series/136572/ and is being updated as
review continue, we are maintaining feature at
https://gitlab.freedesktop.org/miku/kernel/-/tree/eudebug-dev

Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>