### PR TITLE
backport.sh: Add the reset-tree option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ backport.sh < options >
 
 |options:| | |
 |-- |--|--| 
-|1. |createtree| Create kernel tree|
-|2. |backport| Backport patches based on given option <base/features>|
-|3. |deletetree| Delete kernel tree|
+|1. |create-tree| Create kernel tree based on given option <base/features>|
+|2. |delete-tree| Delete the tree|
+|3. |reset-tree| Delete the existing tree and re-create it|
 
 
 # License

--- a/backport.sh
+++ b/backport.sh
@@ -8,72 +8,29 @@ KERNEL_TAG="$BASELINE"
 wget=/usr/bin/wget
 tar=/bin/tar
 WORKING_DIR="$PWD"
+TIME_STAMP=$(date +%Y%m%d_%H%M%S)
 
 KERNEL_BASE="https://git.kernel.org/torvalds/t/"
 KERNEL="linux-${KERNEL_TAG/v}"
 
-SHORT=c,d,h,b:
-LONG=create-tree,delete-tree,help,backport:
+SHORT=:c,d,h,r
+LONG=create-tree:delete-tree,help,reset-tree
 OPTS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 
 flavor="features"
-
+is_existing_tree=0
 usage () {
           echo ""
-          echo "Usage: $0 [-c|--create-tree] [-b | backport <base/features>] [-d|--delete-tree]"
+          echo "Usage: $0 [-c|--create-tree] [-d|--delete-tree] [-r|--reset-tree]"
           echo ""
           echo "Options:"
-          echo "  -c, --create-tree                   	Creates the kernel tree and apply the backport patches"
-          echo "  -b, --backport <base/features>      	backport options: default <features>"
+          echo "  -c, --create-tree                   	Create kernel tree based on given option <base/features>"
           echo "  -d, --delete-tree    	      		Delete the tree"
+          echo "  -r, --reset-tree    	      		Delete the existing tree and re-create it"
           exit 1
 }
 
-
-create_kernel_tree () {
-
-	if [ ! -x "$wget" ]; then
-		echo "ERROR: wget not found." >&2
-		exit 1
-	elif [ ! -x "$tar" ]; then
-		echo "ERROR: tar not found" >&2
-		exit 1
-	fi
-
-	#check if tree is alreday created
-	if [ -d "kernel" ]; then
-		read -p "WARNING: Tree already exists, do you want to overwrite? (y/n) " yn
-		case $yn in
-			[yY] ) echo ok, we will proceed;
-				rm -rf kernel;
-				;;
-			* ) echo exiting;
-				exit;;
-		esac
-	fi
-
-
-	# wget to download tarball
-	if [ -f  "$KERNEL.tar.gz" ]; then
-		echo "Using already downloaded $KERNEL.tar.gz" >&2
-	elif ! $wget "$KERNEL_BASE$KERNEL.tar.gz" ; then
-		echo "ERROR: can't find source" >&2
-		exit 1
-	fi
-
-
-	tar zxf "$WORKING_DIR/$KERNEL.tar.gz"
-
-	mv "$WORKING_DIR/$KERNEL" "$WORKING_DIR/kernel"
-
-	cd "$WORKING_DIR/kernel"
-
-	echo  "Initialising git and adding downloaded kernel"
-
-	git init -q
-	git add  *
-	git commit -s -q -m "base $KERNEL"
-
+apply_patches() {
 	echo "Applying local patches"
 	while read p; do
 		case "$p" in \#*)
@@ -97,8 +54,76 @@ create_kernel_tree () {
 	done <$WORKING_DIR/series
 
 	echo "Tree created in the kernel folder, Now follow normal kernel build process"
+	exit;
 }
 
+create_kernel_tree () {
+
+	if [ ! -x "$wget" ]; then
+		echo "ERROR: wget not found." >&2
+		exit 1
+	elif [ ! -x "$tar" ]; then
+		echo "ERROR: tar not found" >&2
+		exit 1
+	fi
+
+	#check if tree is already created
+	if [ -d "kernel" ]; then
+		echo "Tree already exist"
+		base=$(git -C $SCRIPT_DIR"/kernel" log -1 --oneline | grep ${KERNEL_TAG/v} 2>&1)
+		if [ -n "$base" ]; then
+			echo "INFO: Tree already exists with given config, hence proceeding with it"
+			cd "kernel"
+			echo "$flavor backport"
+			apply_patches
+		else
+			echo "WARNING: Existing tree is not based on given config"
+			read -p "Do you want to reset it? (y/n)" yn
+			case $yn in
+				[yY] ) echo "resetting the existing tree";
+					rm -rf "kernel"
+					;;
+				[nN] ) echo "Storing the current tree to bkp_tree_$TIME_STAMP";
+					git -C "$WORKING_DIR/kernel" branch "bkp_tree_$TIME_STAMP"
+					base_sha=$(git -C "$WORKING_DIR/kernel" log --pretty=format:"%h" --reverse | head -1 2>&1)
+					git -C "$WORKING_DIR/kernel" reset --hard $base_sha
+					is_existing_tree=1
+					;;
+				* ) echo "Invalid option";
+					exit;;
+			esac
+		fi
+	fi
+
+	# wget to download tarball
+	if [ -f  "$KERNEL.tar.gz" ]; then
+		echo "Using already downloaded $KERNEL.tar.gz" >&2
+	elif ! $wget "$KERNEL_BASE$KERNEL.tar.gz" ; then
+		echo "ERROR: can't find source" >&2
+		exit 1
+	fi
+
+	if [ $is_existing_tree -gt 0 ]; then
+		tar zxf "$WORKING_DIR/$KERNEL.tar.gz" -C "$WORKING_DIR/kernel" --strip-components=1
+		cd "$WORKING_DIR/kernel"
+
+	else
+		tar zxf "$WORKING_DIR/$KERNEL.tar.gz"
+		mv "$WORKING_DIR/$KERNEL" "$WORKING_DIR/kernel"
+		cd "$WORKING_DIR/kernel"
+
+		echo  "Initialising git and adding downloaded kernel"
+
+		git init -q
+		git commit --allow-empty -m "Empty commit"
+	fi
+
+	git add  *
+	git commit -s -q -m "base $KERNEL"
+
+	echo "$flavor backport"
+	apply_patches
+}
 
 delete_kernel_tree () {
 	if [ -d "kernel" ]; then
@@ -107,7 +132,6 @@ delete_kernel_tree () {
 	if [ -f "$KERNEL.tar.gz" ]; then
 		rm -rf "$KERNEL.tar.gz"
 	fi
-	exit;
 }
 
 if [ ! $# -gt 0 ]; then
@@ -118,24 +142,25 @@ fi
 while [ $# -gt 0 ]; do
         case $1 in
                 -c|--create-tree)
-                        echo "Creating the tree"
+			if [ ! $# -gt 1 ]; then
+				echo "No option provided for creating the tree"
+			else
+				flavor=$2
+			fi
+                        echo "Creating the tree with $flavor"
                         create_kernel_tree
-                        shift
-                        ;;
+                        exit;;
                 -d|--delete-tree)
                         echo "Deleting the tree"
                         delete_kernel_tree
-                        shift
-                        ;;
-		-b|--backport)
-			flavor="$2"
-			echo "$2 backport"
+			exit;;
+		-r|--reset-tree)
+			echo "Deleting the existing tree and re-creating it"
+			delete_kernel_tree
 			create_kernel_tree
-			shift 2
-			;;
+			exit;;
                 -h|--help)
                         usage
-                        shift
                         ;;
                 *)
                         echo "Invalid option: $1"


### PR DESCRIPTION
Adds reset-tree option to remove the existing tree and re-creating it as
per the given config version. Also removes the backport option as it
doesn't provide any additional benefit compare to create-tree.

Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>