### PR TITLE
patches/base: Add fixup for xe_pt_abort_unbind

### DIFF
--- a/backport/patches/base/0001-drm-xe-Fix-xe_pt_abort_unbind.patch
+++ b/backport/patches/base/0001-drm-xe-Fix-xe_pt_abort_unbind.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Mon, 22 Jul 2024 18:02:30 -0700
+Subject: [PATCH] drm/xe: Fix xe_pt_abort_unbind
+
+When restoring the children PT entries on a bind failure the incorrect
+loop index has used resulting in PT entries being leaked. This is shown
+by running xe_vm.bind-array-conflict-error-inject on a VRAM device going
+into a suspend state after the test completes.
+
+v2:
+ - s/childern/children (CI, Matt Auld)
+
+Fixes: a708f6501c69 ("drm/xe: Update PT layer with better error handling")
+Cc: Matthew Auld <matthew.auld@intel.com>
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20240723010230.1652707-1-matthew.brost@intel.com
+(cherry picked from commit 649b93dbb902ae3237fddbe998eb1f4de1a14b71 drm-tip)
+Signed-off-by: Ayaz A Siddiqui <ayaz.siddiqui@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_pt.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pt.c b/drivers/gpu/drm/xe/xe_pt.c
+index c24e869b7eae..97a6a0b0b8ba 100644
+--- a/drivers/gpu/drm/xe/xe_pt.c
++++ b/drivers/gpu/drm/xe/xe_pt.c
+@@ -1564,7 +1564,7 @@ static void xe_pt_abort_unbind(struct xe_vma *vma,
+ 			continue;
+ 
+ 		for (j = entry->ofs; j < entry->ofs + entry->qwords; j++)
+-			pt_dir->children[i] =
++			pt_dir->children[j] =
+ 				entries[i].pt_entries[j - entry->ofs].pt ?
+ 				&entries[i].pt_entries[j - entry->ofs].pt->base : NULL;
+ 	}
+-- 
+2.47.1
+

--- a/series
+++ b/series
@@ -96,6 +96,7 @@ backport/patches/base/0001-drm-xe-Remove-extra-dma_fence_put-on-xe_sync_entry_a.
 backport/patches/base/0001-drm-xe-Don-t-keep-stale-pointer-to-bo-ggtt_node.patch
 backport/patches/base/0001-drm-xe-guc-Fix-GUC_-SUBMIT-FIRMWARE-_VER-helper-macr.patch
 backport/patches/base/0001-drm-xe-Fix-memory-leak-when-aborting-binds.patch
+backport/patches/base/0001-drm-xe-Fix-xe_pt_abort_unbind.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-drm-xe-Use-the-filelist-from-drm-for-ccs_mode-change.patch
 backport/patches/features/eu-debug/0001-drm-xe-Export-xe_hw_engine-s-mmio-accessors.patch


### PR DESCRIPTION
Backport "drm/xe: Fix xe_pt_abort_unbind". Missing this fixup leads to
warn on during x11perf testing.

Signed-off-by: Ayaz A Siddiqui <ayaz.siddiqui@intel.com>