### PR TITLE
features/eu-debug: Add changes to fence to resolve dmesg warn

### DIFF
--- a/backport/patches/features/eu-debug/0001-drm-xe-Only-check-last-fence-on-user-binds.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Only-check-last-fence-on-user-binds.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Mon, 5 Aug 2024 13:02:33 -0700
+Subject: drm/xe: Only check last fence on user binds
+
+We only set the last fence on user binds, so no need to check last fence
+kernel issued binds. Will avoid blowing up last fence lockdep asserts.
+
+Cc: Francois Dugast <francois.dugast@intel.com>
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20240805200233.3050325-1-matthew.brost@intel.com
+(cherry picked from commit 8d5309b7f67571bc0c95d430f4722a99d38f3b79 linux-next)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pt.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pt.c b/drivers/gpu/drm/xe/xe_pt.c
+index 97a6a0b0b8ba..579ed31b46db 100644
+--- a/drivers/gpu/drm/xe/xe_pt.c
++++ b/drivers/gpu/drm/xe/xe_pt.c
+@@ -1149,10 +1149,12 @@ static int xe_pt_vm_dependencies(struct xe_sched_job *job,
+ 			return err;
+ 	}
+ 
+-	if (job)
+-		err = xe_sched_job_last_fence_add_dep(job, vm);
+-	else
+-		err = xe_exec_queue_last_fence_test_dep(pt_update_ops->q, vm);
++	if (!(pt_update_ops->q->flags & EXEC_QUEUE_FLAG_KERNEL)) {
++		if (job)
++			err = xe_sched_job_last_fence_add_dep(job, vm);
++		else
++			err = xe_exec_queue_last_fence_test_dep(pt_update_ops->q, vm);
++	}
+ 
+ 	for (i = 0; job && !err && i < vops->num_syncs; i++)
+ 		err = xe_sync_entry_add_deps(&vops->syncs[i], job);
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -144,3 +144,4 @@ backport/patches/features/eu-debug/0001-drm-xe-hw_engine_group-Ensure-safe-trans
 backport/patches/features/eu-debug/0001-drm-xe-exec-Switch-hw-engine-group-execution-mode-up.patch
 backport/patches/features/eu-debug/0001-drm-xe-vm-Remove-restriction-that-all-VMs-must-be-fa.patch
 backport/patches/features/eu-debug/0001-drm-xe-device-Remove-unused-xe_device-usm-num_vm_in_.patch
+backport/patches/features/eu-debug/0001-drm-xe-Only-check-last-fence-on-user-binds.patch


### PR DESCRIPTION
Backport "drm/xe: Only check last fence on user binds".
Missing this fixup leads to warning for xe_exec_fault_mode tests.

Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>