### PR TITLE
features/eu-debug: Resolves the taint for xe_migrate test

### DIFF
--- a/backport/patches/features/eu-debug/0001-drm-xe-Set-XE_BO_FLAG_PINNED-in-migrate-selftest-BOs.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Set-XE_BO_FLAG_PINNED-in-migrate-selftest-BOs.patch
@@ -12,15 +12,16 @@ Reviewed-by: Matthew Auld <matthew.auld@intel.com>
 Link: https://patchwork.freedesktop.org/patch/msgid/20241126174615.2665852-8-matthew.brost@intel.com
 (cherry picked from commit e03b0aa67ac0106d8961581a426649fabab50827 linux-next)
 Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
 ---
- drivers/gpu/drm/xe/tests/xe_migrate.c | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ drivers/gpu/drm/xe/tests/xe_migrate.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/tests/xe_migrate.c b/drivers/gpu/drm/xe/tests/xe_migrate.c
-index 962f6438e219..bfdab83658a0 100644
+index 4af27847f..a4cb41f61 100644
 --- a/drivers/gpu/drm/xe/tests/xe_migrate.c
 +++ b/drivers/gpu/drm/xe/tests/xe_migrate.c
-@@ -83,7 +83,8 @@ static void test_copy(struct xe_migrate *m, struct xe_bo *bo,
+@@ -82,7 +82,8 @@ static void test_copy(struct xe_migrate *m, struct xe_bo *bo,
  						   bo->size,
  						   ttm_bo_type_kernel,
  						   region |
@@ -30,6 +31,28 @@ index 962f6438e219..bfdab83658a0 100644
  	if (IS_ERR(remote)) {
  		KUNIT_FAIL(test, "Failed to allocate remote bo for %s: %pe\n",
  			   str, remote);
+@@ -547,7 +548,9 @@ static void validate_ccs_test_run_tile(struct xe_device *xe, struct xe_tile *til
+ 
+ 	sys_bo = xe_bo_create_user(xe, NULL, NULL, SZ_4M,
+ 				   DRM_XE_GEM_CPU_CACHING_WC, ttm_bo_type_device,
+-				   XE_BO_FLAG_SYSTEM | XE_BO_FLAG_NEEDS_CPU_ACCESS);
++				   XE_BO_FLAG_SYSTEM |
++				   XE_BO_FLAG_NEEDS_CPU_ACCESS |
++				   XE_BO_FLAG_PINNED);
+ 
+ 	if (IS_ERR(sys_bo)) {
+ 		KUNIT_FAIL(test, "xe_bo_create() failed with err=%ld\n",
+@@ -570,7 +573,9 @@ static void validate_ccs_test_run_tile(struct xe_device *xe, struct xe_tile *til
+ 	xe_bo_unlock(sys_bo);
+ 
+ 	vram_bo = xe_bo_create_user(xe, NULL, NULL, SZ_4M, DRM_XE_GEM_CPU_CACHING_WC,
+-				    ttm_bo_type_device, bo_flags | XE_BO_FLAG_NEEDS_CPU_ACCESS);
++				    ttm_bo_type_device, bo_flags |
++				    XE_BO_FLAG_NEEDS_CPU_ACCESS |
++				    XE_BO_FLAG_PINNED);
+ 	if (IS_ERR(vram_bo)) {
+ 		KUNIT_FAIL(test, "xe_bo_create() failed with err=%ld\n",
+ 			   PTR_ERR(vram_bo));
 -- 
-2.25.1
+2.34.1
 

--- a/backport/patches/features/eu-debug/0001-drm-xe-display-Update-intel_bo_read_from_page-to-use.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-display-Update-intel_bo_read_from_page-to-use.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Tue, 26 Nov 2024 09:46:12 -0800
+Subject: drm/xe/display: Update intel_bo_read_from_page to use ttm_bo_access
+
+Don't open code vmap of a BO, use ttm_bo_access helper which is safe for
+non-contiguous BOs and non-visible BOs.
+
+Suggested-by: Matthew Auld <matthew.auld@intel.com>
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20241126174615.2665852-6-matthew.brost@intel.com
+(cherry picked from commit b6308aaa24a7ad3dfc6157b6afc550b9ab7e8945 linux-next)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ drivers/gpu/drm/xe/display/intel_bo.c | 25 +------------------------
+ 1 file changed, 1 insertion(+), 24 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/display/intel_bo.c b/drivers/gpu/drm/xe/display/intel_bo.c
+index 9f54fad0f1c0..43141964f6f2 100644
+--- a/drivers/gpu/drm/xe/display/intel_bo.c
++++ b/drivers/gpu/drm/xe/display/intel_bo.c
+@@ -40,31 +40,8 @@ int intel_bo_fb_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma)
+ int intel_bo_read_from_page(struct drm_gem_object *obj, u64 offset, void *dst, int size)
+ {
+ 	struct xe_bo *bo = gem_to_xe_bo(obj);
+-	struct ttm_bo_kmap_obj map;
+-	void *src;
+-	bool is_iomem;
+-	int ret;
+ 
+-	ret = xe_bo_lock(bo, true);
+-	if (ret)
+-		return ret;
+-
+-	ret = ttm_bo_kmap(&bo->ttm, offset >> PAGE_SHIFT, 1, &map);
+-	if (ret)
+-		goto out_unlock;
+-
+-	offset &= ~PAGE_MASK;
+-	src = ttm_kmap_obj_virtual(&map, &is_iomem);
+-	src += offset;
+-	if (is_iomem)
+-		memcpy_fromio(dst, (void __iomem *)src, size);
+-	else
+-		memcpy(dst, src, size);
+-
+-	ttm_bo_kunmap(&map);
+-out_unlock:
+-	xe_bo_unlock(bo);
+-	return ret;
++	return ttm_bo_access(&bo->ttm, offset, dst, size, 0);
+ }
+ 
+ struct intel_frontbuffer *intel_bo_get_frontbuffer(struct drm_gem_object *obj)
+-- 
+2.34.1
+


### PR DESCRIPTION
While executing the xe_migrate test getting the kernel taint. Hence
backporting the patches which are required.

Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>