### PR TITLE
patches/base: Add a patch to report OUT-OF-MEMORY to UMD

### DIFF
--- a/backport/patches/base/0001-drm-xe-Avoid-evicting-object-of-the-same-vm-in-none-.patch
+++ b/backport/patches/base/0001-drm-xe-Avoid-evicting-object-of-the-same-vm-in-none-.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Oak Zeng <oak.zeng@intel.com>
+Date: Mon, 2 Dec 2024 21:19:29 -0500
+Subject: [PATCH] drm/xe: Avoid evicting object of the same vm in none
+ fault mode
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+BO validation during vm_bind could trigger memory eviction when
+system runs under memory pressure. Right now we blindly evict
+BOs of all VMs. This scheme has a problem when system runs in
+none recoverable page fault mode: even though the vm_bind could
+be successful by evicting BOs, the later the rebinding of the
+evicted BOs would fail. So it is better to report an out-of-
+memory failure at vm_bind time than at time of rebinding where
+xekmd currently doesn't have a good mechanism to report error
+to user space.
+
+This patch implemented a scheme to only evict objects of other
+VMs during vm_bind time. Object of the same VM will skip eviction.
+If we failed to find enough memory for vm_bind, we report error
+to user space at vm_bind time.
+
+This scheme is not needed for recoverable page fault mode under
+what we can dynamically fault-in pages on demand.
+
+v1: Use xe_vm_in_preempt_fence_mode instead of stack variable (Thomas)
+
+Signed-off-by: Oak Zeng <oak.zeng@intel.com>
+Suggested-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20241203021929.1919730-1-oak.zeng@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry picked from commit 774b5fa509a97017715801739111a42fdc23d590 drm-tip)
+Signed-off-by: Ayaz A Siddiqui <ayaz.siddiqui@intel.com>
+---
+ drivers/gpu/drm/xe/xe_vm.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 183ec8f7698a..74d684708b00 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -2360,13 +2360,15 @@ static int vma_lock_and_validate(struct drm_exec *exec, struct xe_vma *vma,
+ 				 bool validate)
+ {
+ 	struct xe_bo *bo = xe_vma_bo(vma);
++	struct xe_vm *vm = xe_vma_vm(vma);
+ 	int err = 0;
+ 
+ 	if (bo) {
+ 		if (!bo->vm)
+ 			err = drm_exec_lock_obj(exec, &bo->ttm.base);
+ 		if (!err && validate)
+-			err = xe_bo_validate(bo, xe_vma_vm(vma), true);
++			err = xe_bo_validate(bo, vm,
++					     !xe_vm_in_preempt_fence_mode(vm));
+ 	}
+ 
+ 	return err;
+-- 
+2.25.1
+

--- a/backport/patches/base/0001-drm-xe-Reject-BO-eviction-if-BO-is-bound-to-current-.patch
+++ b/backport/patches/base/0001-drm-xe-Reject-BO-eviction-if-BO-is-bound-to-current-.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Oak Zeng <oak.zeng@intel.com>
+Date: Fri, 10 Jan 2025 16:01:37 -0500
+Subject: [PATCH] drm/xe: Reject BO eviction if BO is bound to current VM
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is a follow up fix for
+https://patchwork.freedesktop.org/patch/msgid/20241203021929.1919730-1-oak.zeng@intel.com
+The overall goal is to fail vm_bind when there is memory pressure. See more
+details in the commit message of above patch. Abbove patch fixes the issue
+when user pass in a vm_id parameter during gem_create. If user doesn't pass
+in a vm_id during gem_create, above patch doesn't help.
+
+This patch further reject BO eviction (which could be triggered by bo validation)
+if BO is bound to the current VM. vm_bind could fail due to the eviction failure.
+The BO to VM reverse mapping structure is used to determine whether BO is bound
+to VM.
+
+v2:
+Move vm_bo definition from function scope to if(evict) clause (Thomas)
+Further constraint the condition by adding ctx->resv (Thomas)
+Add a short comment describe the change.
+
+Suggested-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Signed-off-by: Oak Zeng <oak.zeng@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Signed-off-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250110210137.3181576-1-oak.zeng@intel.com
+(cherry picked from commit 0af944f0e3082ff517958b1cea76fb9b8cb379dd drm-tip)
+Signed-off-by: Ayaz A Siddiqui <ayaz.siddiqui@intel.com>
+---
+ drivers/gpu/drm/xe/xe_bo.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
+index 3f5391d416d4..4f077c11e8e2 100644
+--- a/drivers/gpu/drm/xe/xe_bo.c
++++ b/drivers/gpu/drm/xe/xe_bo.c
+@@ -713,6 +713,21 @@ static int xe_bo_move(struct ttm_buffer_object *ttm_bo, bool evict,
+ 		goto out;
+ 	}
+ 
++	/* Reject BO eviction if BO is bound to current VM. */
++	if (evict && ctx->resv) {
++		struct drm_gpuvm_bo *vm_bo;
++
++		drm_gem_for_each_gpuvm_bo(vm_bo, &bo->ttm.base) {
++			struct xe_vm *vm = gpuvm_to_vm(vm_bo->vm);
++
++			if (xe_vm_resv(vm) == ctx->resv &&
++			    xe_vm_in_preempt_fence_mode(vm)) {
++				ret = -EBUSY;
++				goto out;
++			}
++		}
++	}
++
+ 	/*
+ 	 * Failed multi-hop where the old_mem is still marked as
+ 	 * TTM_PL_FLAG_TEMPORARY, should just be a dummy move.
+-- 
+2.25.1
+

--- a/series
+++ b/series
@@ -93,6 +93,8 @@ backport/patches/base/0001-drm-xe-Don-t-keep-stale-pointer-to-bo-ggtt_node.patch
 backport/patches/base/0001-drm-xe-guc-Fix-GUC_-SUBMIT-FIRMWARE-_VER-helper-macr.patch
 backport/patches/base/0001-drm-xe-Fix-memory-leak-when-aborting-binds.patch
 backport/patches/base/0001-drm-xe-Fix-xe_pt_abort_unbind.patch
+backport/patches/base/0001-drm-xe-Avoid-evicting-object-of-the-same-vm-in-none-.patch
+backport/patches/base/0001-drm-xe-Reject-BO-eviction-if-BO-is-bound-to-current-.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-drm-xe-Use-the-filelist-from-drm-for-ccs_mode-change.patch
 backport/patches/features/eu-debug/0001-drm-xe-Export-xe_hw_engine-s-mmio-accessors.patch


### PR DESCRIPTION
Adding a patch to ensure that KMD returns failing return code when
it can't bind requested allocations, or provide correct API for UMD
to know when it should unbind unused allocations.

Signed-off-by: Ayaz A Siddiqui <ayaz.siddiqui@intel.com>