### PR TITLE
Read the xkb tag and add it to generated tree

### DIFF
--- a/backport.sh
+++ b/backport.sh
@@ -19,6 +19,8 @@ OPTS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 
 flavor="features"
 is_existing_tree=0
+xkb_tag=""
+
 usage () {
           echo ""
           echo "Usage: $0 [-c|--create-tree] [-d|--delete-tree] [-r|--reset-tree]"
@@ -53,6 +55,7 @@ apply_patches() {
 		fi
 	done <$WORKING_DIR/series
 
+	git -C "$WORKING_DIR/kernel" tag "xkb-$xkb_tag"
 	echo "Tree created in the kernel folder, Now follow normal kernel build process"
 	exit;
 }
@@ -134,6 +137,7 @@ delete_kernel_tree () {
 	fi
 }
 
+xkb_tag=$(git -C $WORKING_DIR describe --always --tags)
 if [ ! $# -gt 0 ]; then
 	echo "No option provided, so proceeding with create-tree"
         create_kernel_tree

--- a/backport.sh
+++ b/backport.sh
@@ -72,30 +72,7 @@ create_kernel_tree () {
 
 	#check if tree is already created
 	if [ -d "kernel" ]; then
-		echo "Tree already exist"
-		base=$(git -C $SCRIPT_DIR"/kernel" log -1 --oneline | grep ${KERNEL_TAG/v} 2>&1)
-		if [ -n "$base" ]; then
-			echo "INFO: Tree already exists with given config, hence proceeding with it"
-			cd "kernel"
-			echo "$flavor backport"
-			apply_patches
-		else
-			echo "WARNING: Existing tree is not based on given config"
-			read -p "Do you want to reset it? (y/n)" yn
-			case $yn in
-				[yY] ) echo "resetting the existing tree";
-					rm -rf "kernel"
-					;;
-				[nN] ) echo "Storing the current tree to bkp_tree_$TIME_STAMP";
-					git -C "$WORKING_DIR/kernel" branch "bkp_tree_$TIME_STAMP"
-					base_sha=$(git -C "$WORKING_DIR/kernel" log --pretty=format:"%h" --reverse | head -1 2>&1)
-					git -C "$WORKING_DIR/kernel" reset --hard $base_sha
-					is_existing_tree=1
-					;;
-				* ) echo "Invalid option";
-					exit;;
-			esac
-		fi
+		rm -rf "kernel"
 	fi
 
 	# wget to download tarball


### PR DESCRIPTION
Adding the xkb tag to generated kernel tree by reading it from the
xekmd-backports tree to identify from which HEAD it has generated.

Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>