### PR TITLE
patches/base: Introduces new PCI IDs for BMG

### DIFF
--- a/backport/patches/base/0001-drm-xe-bmg-Add-new-PCI-IDs.patch
+++ b/backport/patches/base/0001-drm-xe-bmg-Add-new-PCI-IDs.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Date: Tue, 28 Jan 2025 21:50:15 +0530
+Subject: [PATCH] drm/xe/bmg: Add new PCI IDs
+
+Add 3 new PCI IDs for BMG.
+
+v2: Fix typo -> Replace '.' with ','
+
+Signed-off-by: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Reviewed-by: Clint Taylor <Clinton.A.Taylor@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250128162015.3288675-1-shekhar.chauhan@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit fa8ffaae1b15236b8afb0fbbc04117ff7c900a83 linux-next)
+Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
+---
+ include/drm/intel/xe_pciids.h | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/include/drm/intel/xe_pciids.h b/include/drm/intel/xe_pciids.h
+index 644872a35..3f7cff6c3 100644
+--- a/include/drm/intel/xe_pciids.h
++++ b/include/drm/intel/xe_pciids.h
+@@ -197,6 +197,9 @@
+ 	MACRO__(0xE20B, ## __VA_ARGS__), \
+ 	MACRO__(0xE20C, ## __VA_ARGS__), \
+ 	MACRO__(0xE20D, ## __VA_ARGS__), \
+-	MACRO__(0xE212, ## __VA_ARGS__)
++	MACRO__(0xE210, ## __VA_ARGS__), \
++	MACRO__(0xE212, ## __VA_ARGS__), \
++	MACRO__(0xE215, ## __VA_ARGS__), \
++	MACRO__(0xE216, ## __VA_ARGS__)
+ 
+ #endif
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -96,6 +96,7 @@ backport/patches/base/0001-drm-xe-Fix-xe_pt_abort_unbind.patch
 backport/patches/base/0001-drm-xe-Avoid-evicting-object-of-the-same-vm-in-none-.patch
 backport/patches/base/0001-drm-xe-Reject-BO-eviction-if-BO-is-bound-to-current-.patch
 backport/patches/base/0001-drm-xe-Mark-ComputeCS-read-mode-as-UC-on-iGPU.patch
+backport/patches/base/0001-drm-xe-bmg-Add-new-PCI-IDs.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-drm-xe-Use-the-filelist-from-drm-for-ccs_mode-change.patch
 backport/patches/features/eu-debug/0001-drm-xe-Export-xe_hw_engine-s-mmio-accessors.patch


### PR DESCRIPTION
This patch introduces new PCI IDs for platform BMG.

Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>