### PR TITLE
xekmd-backports: enable eu-debug feature on top kv6.14.

### DIFF
--- a/backport/patches/base/0001-drm-i915-xe2hpd-Identify-the-memory-type-for-SKUs-wi.patch
+++ b/backport/patches/base/0001-drm-i915-xe2hpd-Identify-the-memory-type-for-SKUs-wi.patch
@@ -1,0 +1,116 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vivek Kasireddy <vivek.kasireddy@intel.com>
+Date: Mon, 24 Mar 2025 10:22:33 -0700
+Subject: [PATCH] drm/i915/xe2hpd: Identify the memory type for SKUs with GDDR
+ + ECC
+
+Some SKUs of Xe2_HPD platforms (such as BMG) have GDDR memory type
+with ECC enabled. We need to identify this scenario and add a new
+case in xelpdp_get_dram_info() to handle it. In addition, the
+derating value needs to be adjusted accordingly to compensate for
+the limited bandwidth.
+
+Bspec: 64602
+Cc: Matt Roper <matthew.d.roper@intel.com>
+Fixes: 3adcf970dc7e ("drm/xe/bmg: Drop force_probe requirement")
+Cc: stable@vger.kernel.org
+Signed-off-by: Vivek Kasireddy <vivek.kasireddy@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Acked-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250324-tip-v2-1-38397de319f8@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit 327e30123cafcb45c0fc5843da0367b90332999d drm-tip)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/i915/display/intel_bw.c | 12 ++++++++++++
+ drivers/gpu/drm/i915/i915_drv.h         |  1 +
+ drivers/gpu/drm/i915/soc/intel_dram.c   |  4 ++++
+ drivers/gpu/drm/xe/xe_device_types.h    |  1 +
+ 4 files changed, 18 insertions(+)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_bw.c b/drivers/gpu/drm/i915/display/intel_bw.c
+index 47036d4ab..ec63a2abd 100644
+--- a/drivers/gpu/drm/i915/display/intel_bw.c
++++ b/drivers/gpu/drm/i915/display/intel_bw.c
+@@ -244,6 +244,7 @@ static int icl_get_qgv_points(struct drm_i915_private *dev_priv,
+ 			qi->deinterleave = 4;
+ 			break;
+ 		case INTEL_DRAM_GDDR:
++		case INTEL_DRAM_GDDR_ECC:
+ 			qi->channel_width = 32;
+ 			break;
+ 		default:
+@@ -398,6 +399,12 @@ static const struct intel_sa_info xe2_hpd_sa_info = {
+ 	/* Other values not used by simplified algorithm */
+ };
+ 
++static const struct intel_sa_info xe2_hpd_ecc_sa_info = {
++	.derating = 45,
++	.deprogbwlimit = 53,
++	/* Other values not used by simplified algorithm */
++};
++
+ static int icl_get_bw_info(struct drm_i915_private *dev_priv, const struct intel_sa_info *sa)
+ {
+ 	struct intel_qgv_info qi = {};
+@@ -740,6 +747,8 @@ static unsigned int icl_qgv_bw(struct drm_i915_private *i915,
+ 
+ void intel_bw_init_hw(struct drm_i915_private *dev_priv)
+ {
++	const struct dram_info *dram_info = &dev_priv->dram_info;
++
+ 	if (!HAS_DISPLAY(dev_priv))
+ 		return;
+ 
+@@ -747,6 +756,9 @@ void intel_bw_init_hw(struct drm_i915_private *dev_priv)
+ 		xe2_hpd_get_bw_info(dev_priv, &xe2_hpd_sa_info);
+ 	else if (DISPLAY_VER(dev_priv) >= 14)
+ 		tgl_get_bw_info(dev_priv, &mtl_sa_info);
++	else if (DISPLAY_VERx100(dev_priv) >= 1401 && IS_DGFX(dev_priv) &&
++		dram_info->type == INTEL_DRAM_GDDR_ECC)
++		xe2_hpd_get_bw_info(dev_priv, &xe2_hpd_ecc_sa_info);
+ 	else if (IS_DG2(dev_priv))
+ 		dg2_get_bw_info(dev_priv);
+ 	else if (IS_ALDERLAKE_P(dev_priv))
+diff --git a/drivers/gpu/drm/i915/i915_drv.h b/drivers/gpu/drm/i915/i915_drv.h
+index 718b2bfe6..0cacb270a 100644
+--- a/drivers/gpu/drm/i915/i915_drv.h
++++ b/drivers/gpu/drm/i915/i915_drv.h
+@@ -306,6 +306,7 @@ struct drm_i915_private {
+ 			INTEL_DRAM_DDR5,
+ 			INTEL_DRAM_LPDDR5,
+ 			INTEL_DRAM_GDDR,
++			INTEL_DRAM_GDDR_ECC,
+ 		} type;
+ 		u8 num_qgv_points;
+ 		u8 num_psf_gv_points;
+diff --git a/drivers/gpu/drm/i915/soc/intel_dram.c b/drivers/gpu/drm/i915/soc/intel_dram.c
+index 4aba47bcc..a9f7b2280 100644
+--- a/drivers/gpu/drm/i915/soc/intel_dram.c
++++ b/drivers/gpu/drm/i915/soc/intel_dram.c
+@@ -687,6 +687,10 @@ static int xelpdp_get_dram_info(struct drm_i915_private *i915)
+ 		drm_WARN_ON(&i915->drm, !IS_DGFX(i915));
+ 		dram_info->type = INTEL_DRAM_GDDR;
+ 		break;
++	case 9:
++		drm_WARN_ON(&i915->drm, !IS_DGFX(i915));
++		dram_info->type = INTEL_DRAM_GDDR_ECC;
++		break;
+ 	default:
+ 		MISSING_CASE(val);
+ 		return -EINVAL;
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index b091a949b..4cf3bb0eb 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -548,6 +548,7 @@ struct xe_device {
+ 			INTEL_DRAM_DDR5,
+ 			INTEL_DRAM_LPDDR5,
+ 			INTEL_DRAM_GDDR,
++			INTEL_DRAM_GDDR_ECC,
+ 		} type;
+ 		u8 num_qgv_points;
+ 		u8 num_psf_gv_points;
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-bmg-Add-one-additional-PCI-ID.patch
+++ b/backport/patches/base/0001-drm-xe-bmg-Add-one-additional-PCI-ID.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Roper <matthew.d.roper@intel.com>
+Date: Tue, 25 Mar 2025 15:47:10 -0700
+Subject: [PATCH] drm/xe/bmg: Add one additional PCI ID
+
+One additional BMG PCI ID has been added to the spec; make sure our
+driver recognizes devices with this ID properly.
+
+Bspec: 68090
+Cc: stable@vger.kernel.org # v6.12+
+Reviewed-by: Clint Taylor <Clinton.A.Taylor@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://lore.kernel.org/r/20250325224709.4073080-2-matthew.d.roper@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(cherry picked from commit cca9734ebe55f6af11ce8d57ca1afdc4d158c808 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ include/drm/intel/pciids.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/drm/intel/pciids.h b/include/drm/intel/pciids.h
+index 4736ea525048..d212848d07f3 100644
+--- a/include/drm/intel/pciids.h
++++ b/include/drm/intel/pciids.h
+@@ -850,6 +850,7 @@
+ 	MACRO__(0xE20C, ## __VA_ARGS__), \
+ 	MACRO__(0xE20D, ## __VA_ARGS__), \
+ 	MACRO__(0xE210, ## __VA_ARGS__), \
++	MACRO__(0xE211, ## __VA_ARGS__), \
+ 	MACRO__(0xE212, ## __VA_ARGS__), \
+ 	MACRO__(0xE215, ## __VA_ARGS__), \
+ 	MACRO__(0xE216, ## __VA_ARGS__)
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -1,5 +1,7 @@
 # base
 backport/patches/base/0001-drm-xe-bmg-Add-new-PCI-IDs.patch
+backport/patches/base/0001-drm-xe-bmg-Add-one-additional-PCI-ID.patch
+backport/patches/base/0001-drm-i915-xe2hpd-Identify-the-memory-type-for-SKUs-wi.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
 Now we need to only apply EU debug patches as BMG/LNL patches
 are merged in kv6.14

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
Signed-off-by: Ayaz A Siddiqui <ayaz.siddiqui@intel.com>