### PR TITLE
patches/base: Merge pciids headers of xe and i915

### DIFF
--- a/backport/patches/base/0001-drm-intel-pciids-rename-i915_pciids.h-to-just-pciids.patch
+++ b/backport/patches/base/0001-drm-intel-pciids-rename-i915_pciids.h-to-just-pciids.patch
@@ -1,0 +1,107 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jani Nikula <jani.nikula@intel.com>
+Date: Tue, 22 Oct 2024 12:41:50 +0300
+Subject: drm/intel/pciids: rename i915_pciids.h to just pciids.h
+
+In preparation of sharing the PCI ID macros between i915 and xe, rename
+i915_pciids.h to pciids.h.
+
+Cc: Joonas Lahtinen <joonas.lahtinen@linux.intel.com>
+Cc: Lucas De Marchi <lucas.demarchi@intel.com>
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Cc: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Cc: Tvrtko Ursulin <tursulin@ursulin.net>
+Reviewed-by: Andi Shyti <andi.shyti@linux.intel.com>
+Acked-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/835143845faa5310e4bb58405a8a0848392bbf06.1729590029.git.jani.nikula@intel.com
+Signed-off-by: Jani Nikula <jani.nikula@intel.com>
+(backported from commit f719c2a2d1e7fb891d45998f241ff4273d7ae7e6 drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ arch/x86/kernel/early-quirks.c                      | 2 +-
+ drivers/gpu/drm/i915/display/intel_display_device.c | 2 +-
+ drivers/gpu/drm/i915/i915_pci.c                     | 2 +-
+ drivers/gpu/drm/i915/intel_device_info.c            | 2 +-
+ include/drm/intel/{i915_pciids.h => pciids.h}       | 6 +++---
+ 5 files changed, 7 insertions(+), 7 deletions(-)
+ rename include/drm/intel/{i915_pciids.h => pciids.h} (99%)
+
+diff --git a/arch/x86/kernel/early-quirks.c b/arch/x86/kernel/early-quirks.c
+index 29d1f9104..6b6f32f40 100644
+--- a/arch/x86/kernel/early-quirks.c
++++ b/arch/x86/kernel/early-quirks.c
+@@ -18,7 +18,7 @@
+ #include <linux/bcma/bcma_regs.h>
+ #include <linux/platform_data/x86/apple.h>
+ #include <drm/intel/i915_drm.h>
+-#include <drm/intel/i915_pciids.h>
++#include <drm/intel/pciids.h>
+ #include <asm/pci-direct.h>
+ #include <asm/dma.h>
+ #include <asm/io_apic.h>
+diff --git a/drivers/gpu/drm/i915/display/intel_display_device.c b/drivers/gpu/drm/i915/display/intel_display_device.c
+index 1c03aed4c..2c3ac8af6 100644
+--- a/drivers/gpu/drm/i915/display/intel_display_device.c
++++ b/drivers/gpu/drm/i915/display/intel_display_device.c
+@@ -3,7 +3,7 @@
+  * Copyright © 2023 Intel Corporation
+  */
+ 
+-#include <drm/intel/i915_pciids.h>
++#include <drm/intel/pciids.h>
+ #include <drm/drm_color_mgmt.h>
+ #include <linux/pci.h>
+ 
+diff --git a/drivers/gpu/drm/i915/i915_pci.c b/drivers/gpu/drm/i915/i915_pci.c
+index ce4dfd65f..c95839ece 100644
+--- a/drivers/gpu/drm/i915/i915_pci.c
++++ b/drivers/gpu/drm/i915/i915_pci.c
+@@ -24,7 +24,7 @@
+ 
+ #include <drm/drm_color_mgmt.h>
+ #include <drm/drm_drv.h>
+-#include <drm/intel/i915_pciids.h>
++#include <drm/intel/pciids.h>
+ 
+ #include "display/intel_display.h"
+ #include "display/intel_display_driver.h"
+diff --git a/drivers/gpu/drm/i915/intel_device_info.c b/drivers/gpu/drm/i915/intel_device_info.c
+index 1e88af96c..78556d96f 100644
+--- a/drivers/gpu/drm/i915/intel_device_info.c
++++ b/drivers/gpu/drm/i915/intel_device_info.c
+@@ -25,7 +25,7 @@
+ #include <linux/string_helpers.h>
+ 
+ #include <drm/drm_print.h>
+-#include <drm/intel/i915_pciids.h>
++#include <drm/intel/pciids.h>
+ 
+ #include "gt/intel_gt_regs.h"
+ #include "i915_drv.h"
+diff --git a/include/drm/intel/i915_pciids.h b/include/drm/intel/pciids.h
+similarity index 99%
+rename from include/drm/intel/i915_pciids.h
+rename to include/drm/intel/pciids.h
+index f35534522..38ba94ae5 100644
+--- a/include/drm/intel/i915_pciids.h
++++ b/include/drm/intel/pciids.h
+@@ -22,8 +22,8 @@
+  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  * DEALINGS IN THE SOFTWARE.
+  */
+-#ifndef _I915_PCIIDS_H
+-#define _I915_PCIIDS_H
++#ifndef __PCIIDS_H__
++#define __PCIIDS_H__
+ 
+ /*
+  * A pci_device_id struct {
+@@ -811,4 +811,4 @@
+ 	MACRO__(0xE20D, ## __VA_ARGS__), \
+ 	MACRO__(0xE212, ## __VA_ARGS__)
+ 
+-#endif /* _I915_PCIIDS_H */
++#endif /* __PCIIDS_H__ */
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-switch-to-common-PCI-ID-macros.patch
+++ b/backport/patches/base/0001-drm-xe-switch-to-common-PCI-ID-macros.patch
@@ -1,0 +1,352 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jani Nikula <jani.nikula@intel.com>
+Date: Tue, 22 Oct 2024 12:41:51 +0300
+Subject: drm/xe: switch to common PCI ID macros
+
+Switch to the shared PCI ID macros in drm/intel/pciids.h. Remove
+xe_pciids.h.
+
+Cc: Joonas Lahtinen <joonas.lahtinen@linux.intel.com>
+Cc: Lucas De Marchi <lucas.demarchi@intel.com>
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Cc: Thomas Hellstr_m <thomas.hellstrom@linux.intel.com>
+Cc: Tvrtko Ursulin <tursulin@ursulin.net>
+Reviewed-by: Andi Shyti <andi.shyti@linux.intel.com>
+Acked-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/84e08172184bdc6409cf6dd13f6c52971c647dbb.1729590029.git.jani.nikula@intel.com
+Signed-off-by: Jani Nikula <jani.nikula@intel.com>
+(backported from commit 493454445c9531051bd27a0305a61953780bd453 drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci.c   |  45 ++++----
+ include/drm/intel/pciids.h    |   6 +-
+ include/drm/intel/xe_pciids.h | 206 ----------------------------------
+ 3 files changed, 24 insertions(+), 233 deletions(-)
+ delete mode 100644 include/drm/intel/xe_pciids.h
+
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index 4727b5df9..0a119d3ea 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -13,7 +13,7 @@
+ 
+ #include <drm/drm_color_mgmt.h>
+ #include <drm/drm_drv.h>
+-#include <drm/intel/xe_pciids.h>
++#include <drm/intel/pciids.h>
+ 
+ #include "display/xe_display.h"
+ #include "regs/xe_gt_regs.h"
+@@ -234,7 +234,7 @@ static const struct xe_device_desc rkl_desc = {
+ 	.require_force_probe = true,
+ };
+ 
+-static const u16 adls_rpls_ids[] = { XE_RPLS_IDS(NOP), 0 };
++static const u16 adls_rpls_ids[] = { INTEL_RPLS_IDS(NOP), 0 };
+ 
+ static const struct xe_device_desc adl_s_desc = {
+ 	.graphics = &graphics_xelp,
+@@ -249,7 +249,7 @@ static const struct xe_device_desc adl_s_desc = {
+ 	},
+ };
+ 
+-static const u16 adlp_rplu_ids[] = { XE_RPLU_IDS(NOP), 0 };
++static const u16 adlp_rplu_ids[] = { INTEL_RPLU_IDS(NOP), 0 };
+ 
+ static const struct xe_device_desc adl_p_desc = {
+ 	.graphics = &graphics_xelp,
+@@ -286,9 +286,9 @@ static const struct xe_device_desc dg1_desc = {
+ 	.require_force_probe = true,
+ };
+ 
+-static const u16 dg2_g10_ids[] = { XE_DG2_G10_IDS(NOP), XE_ATS_M150_IDS(NOP), 0 };
+-static const u16 dg2_g11_ids[] = { XE_DG2_G11_IDS(NOP), XE_ATS_M75_IDS(NOP), 0 };
+-static const u16 dg2_g12_ids[] = { XE_DG2_G12_IDS(NOP), 0 };
++static const u16 dg2_g10_ids[] = { INTEL_DG2_G10_IDS(NOP), INTEL_ATS_M150_IDS(NOP), 0 };
++static const u16 dg2_g11_ids[] = { INTEL_DG2_G11_IDS(NOP), INTEL_ATS_M75_IDS(NOP), 0 };
++static const u16 dg2_g12_ids[] = { INTEL_DG2_G12_IDS(NOP), 0 };
+ 
+ #define DG2_FEATURES \
+ 	DGFX_FEATURES, \
+@@ -366,11 +366,6 @@ static const struct gmdid_map media_ip_map[] = {
+ 	{ 2000, &media_xe2 },
+ };
+ 
+-#define INTEL_VGA_DEVICE(id, info) {			\
+-	PCI_DEVICE(PCI_VENDOR_ID_INTEL, id),		\
+-	PCI_BASE_CLASS_DISPLAY << 16, 0xff << 16,	\
+-	(unsigned long) info }
+-
+ /*
+  * Make sure any device matches here are from most specific to most
+  * general.  For example, since the Quanta match is based on the subsystem
+@@ -378,25 +373,23 @@ static const struct gmdid_map media_ip_map[] = {
+  * PCI ID matches, otherwise we'll use the wrong info struct above.
+  */
+ static const struct pci_device_id pciidlist[] = {
+-	XE_TGL_IDS(INTEL_VGA_DEVICE, &tgl_desc),
+-	XE_RKL_IDS(INTEL_VGA_DEVICE, &rkl_desc),
+-	XE_ADLS_IDS(INTEL_VGA_DEVICE, &adl_s_desc),
+-	XE_ADLP_IDS(INTEL_VGA_DEVICE, &adl_p_desc),
+-	XE_ADLN_IDS(INTEL_VGA_DEVICE, &adl_n_desc),
+-	XE_RPLP_IDS(INTEL_VGA_DEVICE, &adl_p_desc),
+-	XE_RPLS_IDS(INTEL_VGA_DEVICE, &adl_s_desc),
+-	XE_DG1_IDS(INTEL_VGA_DEVICE, &dg1_desc),
+-	XE_ATS_M_IDS(INTEL_VGA_DEVICE, &ats_m_desc),
+-	XE_DG2_IDS(INTEL_VGA_DEVICE, &dg2_desc),
+-	XE_MTL_IDS(INTEL_VGA_DEVICE, &mtl_desc),
+-	XE_LNL_IDS(INTEL_VGA_DEVICE, &lnl_desc),
+-	XE_BMG_IDS(INTEL_VGA_DEVICE, &bmg_desc),
++	INTEL_TGL_IDS(INTEL_VGA_DEVICE, &tgl_desc),
++	INTEL_RKL_IDS(INTEL_VGA_DEVICE, &rkl_desc),
++	INTEL_ADLS_IDS(INTEL_VGA_DEVICE, &adl_s_desc),
++	INTEL_ADLP_IDS(INTEL_VGA_DEVICE, &adl_p_desc),
++	INTEL_ADLN_IDS(INTEL_VGA_DEVICE, &adl_n_desc),
++	INTEL_RPLP_IDS(INTEL_VGA_DEVICE, &adl_p_desc),
++	INTEL_RPLS_IDS(INTEL_VGA_DEVICE, &adl_s_desc),
++	INTEL_DG1_IDS(INTEL_VGA_DEVICE, &dg1_desc),
++	INTEL_ATS_M_IDS(INTEL_VGA_DEVICE, &ats_m_desc),
++	INTEL_DG2_IDS(INTEL_VGA_DEVICE, &dg2_desc),
++	INTEL_MTL_IDS(INTEL_VGA_DEVICE, &mtl_desc),
++	INTEL_LNL_IDS(INTEL_VGA_DEVICE, &lnl_desc),
++	INTEL_BMG_IDS(INTEL_VGA_DEVICE, &bmg_desc),
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(pci, pciidlist);
+ 
+-#undef INTEL_VGA_DEVICE
+-
+ /* is device_id present in comma separated list of ids */
+ static bool device_id_in_list(u16 device_id, const char *devices, bool negative)
+ {
+diff --git a/include/drm/intel/pciids.h b/include/drm/intel/pciids.h
+index 38ba94ae5..fa6d53734 100644
+--- a/include/drm/intel/pciids.h
++++ b/include/drm/intel/pciids.h
+@@ -809,6 +809,10 @@
+ 	MACRO__(0xE20B, ## __VA_ARGS__), \
+ 	MACRO__(0xE20C, ## __VA_ARGS__), \
+ 	MACRO__(0xE20D, ## __VA_ARGS__), \
+-	MACRO__(0xE212, ## __VA_ARGS__)
++	MACRO__(0xE210, ## __VA_ARGS__), \
++	MACRO__(0xE211, ## __VA_ARGS__), \
++	MACRO__(0xE212, ## __VA_ARGS__), \
++	MACRO__(0xE215, ## __VA_ARGS__), \
++	MACRO__(0xE216, ## __VA_ARGS__)
+ 
+ #endif /* __PCIIDS_H__ */
+diff --git a/include/drm/intel/xe_pciids.h b/include/drm/intel/xe_pciids.h
+deleted file mode 100644
+index f623fae8b..000000000
+--- a/include/drm/intel/xe_pciids.h
++++ /dev/null
+@@ -1,206 +0,0 @@
+-/* SPDX-License-Identifier: MIT */
+-/*
+- * Copyright © 2022 Intel Corporation
+- */
+-
+-#ifndef _XE_PCIIDS_H_
+-#define _XE_PCIIDS_H_
+-
+-/*
+- * Lists below can be turned into initializers for a struct pci_device_id
+- * by defining INTEL_VGA_DEVICE:
+- *
+- * #define INTEL_VGA_DEVICE(id, info) { \
+- *	0x8086, id,			\
+- *	~0, ~0,				\
+- *	0x030000, 0xff0000,		\
+- *	(unsigned long) info }
+- *
+- * And then calling like:
+- *
+- * XE_TGL_12_GT1_IDS(INTEL_VGA_DEVICE, ## __VA_ARGS__)
+- *
+- * To turn them into something else, just provide a different macro passed as
+- * first argument.
+- */
+-
+-/* TGL */
+-#define XE_TGL_GT1_IDS(MACRO__, ...)		\
+-	MACRO__(0x9A60, ## __VA_ARGS__),	\
+-	MACRO__(0x9A68, ## __VA_ARGS__),	\
+-	MACRO__(0x9A70, ## __VA_ARGS__)
+-
+-#define XE_TGL_GT2_IDS(MACRO__, ...)		\
+-	MACRO__(0x9A40, ## __VA_ARGS__),	\
+-	MACRO__(0x9A49, ## __VA_ARGS__),	\
+-	MACRO__(0x9A59, ## __VA_ARGS__),	\
+-	MACRO__(0x9A78, ## __VA_ARGS__),	\
+-	MACRO__(0x9AC0, ## __VA_ARGS__),	\
+-	MACRO__(0x9AC9, ## __VA_ARGS__),	\
+-	MACRO__(0x9AD9, ## __VA_ARGS__),	\
+-	MACRO__(0x9AF8, ## __VA_ARGS__)
+-
+-#define XE_TGL_IDS(MACRO__, ...)		\
+-	XE_TGL_GT1_IDS(MACRO__, ## __VA_ARGS__),\
+-	XE_TGL_GT2_IDS(MACRO__, ## __VA_ARGS__)
+-
+-/* RKL */
+-#define XE_RKL_IDS(MACRO__, ...)		\
+-	MACRO__(0x4C80, ## __VA_ARGS__),	\
+-	MACRO__(0x4C8A, ## __VA_ARGS__),	\
+-	MACRO__(0x4C8B, ## __VA_ARGS__),	\
+-	MACRO__(0x4C8C, ## __VA_ARGS__),	\
+-	MACRO__(0x4C90, ## __VA_ARGS__),	\
+-	MACRO__(0x4C9A, ## __VA_ARGS__)
+-
+-/* DG1 */
+-#define XE_DG1_IDS(MACRO__, ...)		\
+-	MACRO__(0x4905, ## __VA_ARGS__),	\
+-	MACRO__(0x4906, ## __VA_ARGS__),	\
+-	MACRO__(0x4907, ## __VA_ARGS__),	\
+-	MACRO__(0x4908, ## __VA_ARGS__),	\
+-	MACRO__(0x4909, ## __VA_ARGS__)
+-
+-/* ADL-S */
+-#define XE_ADLS_IDS(MACRO__, ...)		\
+-	MACRO__(0x4680, ## __VA_ARGS__),	\
+-	MACRO__(0x4682, ## __VA_ARGS__),	\
+-	MACRO__(0x4688, ## __VA_ARGS__),	\
+-	MACRO__(0x468A, ## __VA_ARGS__),	\
+-	MACRO__(0x468B, ## __VA_ARGS__),	\
+-	MACRO__(0x4690, ## __VA_ARGS__),	\
+-	MACRO__(0x4692, ## __VA_ARGS__),	\
+-	MACRO__(0x4693, ## __VA_ARGS__)
+-
+-/* ADL-P */
+-#define XE_ADLP_IDS(MACRO__, ...)		\
+-	MACRO__(0x46A0, ## __VA_ARGS__),	\
+-	MACRO__(0x46A1, ## __VA_ARGS__),	\
+-	MACRO__(0x46A2, ## __VA_ARGS__),	\
+-	MACRO__(0x46A3, ## __VA_ARGS__),	\
+-	MACRO__(0x46A6, ## __VA_ARGS__),	\
+-	MACRO__(0x46A8, ## __VA_ARGS__),	\
+-	MACRO__(0x46AA, ## __VA_ARGS__),	\
+-	MACRO__(0x462A, ## __VA_ARGS__),	\
+-	MACRO__(0x4626, ## __VA_ARGS__),	\
+-	MACRO__(0x4628, ## __VA_ARGS__),	\
+-	MACRO__(0x46B0, ## __VA_ARGS__),	\
+-	MACRO__(0x46B1, ## __VA_ARGS__),	\
+-	MACRO__(0x46B2, ## __VA_ARGS__),	\
+-	MACRO__(0x46B3, ## __VA_ARGS__),	\
+-	MACRO__(0x46C0, ## __VA_ARGS__),	\
+-	MACRO__(0x46C1, ## __VA_ARGS__),	\
+-	MACRO__(0x46C2, ## __VA_ARGS__),	\
+-	MACRO__(0x46C3, ## __VA_ARGS__)
+-
+-/* ADL-N */
+-#define XE_ADLN_IDS(MACRO__, ...)		\
+-	MACRO__(0x46D0, ## __VA_ARGS__),	\
+-	MACRO__(0x46D1, ## __VA_ARGS__),	\
+-	MACRO__(0x46D2, ## __VA_ARGS__)
+-
+-/* RPL-S */
+-#define XE_RPLS_IDS(MACRO__, ...)		\
+-	MACRO__(0xA780, ## __VA_ARGS__),	\
+-	MACRO__(0xA781, ## __VA_ARGS__),	\
+-	MACRO__(0xA782, ## __VA_ARGS__),	\
+-	MACRO__(0xA783, ## __VA_ARGS__),	\
+-	MACRO__(0xA788, ## __VA_ARGS__),	\
+-	MACRO__(0xA789, ## __VA_ARGS__),	\
+-	MACRO__(0xA78A, ## __VA_ARGS__),	\
+-	MACRO__(0xA78B, ## __VA_ARGS__)
+-
+-/* RPL-U */
+-#define XE_RPLU_IDS(MACRO__, ...)		\
+-	MACRO__(0xA721, ## __VA_ARGS__),	\
+-	MACRO__(0xA7A1, ## __VA_ARGS__),	\
+-	MACRO__(0xA7A9, ## __VA_ARGS__),	\
+-	MACRO__(0xA7AC, ## __VA_ARGS__),	\
+-	MACRO__(0xA7AD, ## __VA_ARGS__)
+-
+-/* RPL-P */
+-#define XE_RPLP_IDS(MACRO__, ...)		\
+-	XE_RPLU_IDS(MACRO__, ## __VA_ARGS__),	\
+-	MACRO__(0xA720, ## __VA_ARGS__),	\
+-	MACRO__(0xA7A0, ## __VA_ARGS__),	\
+-	MACRO__(0xA7A8, ## __VA_ARGS__),	\
+-	MACRO__(0xA7AA, ## __VA_ARGS__),	\
+-	MACRO__(0xA7AB, ## __VA_ARGS__)
+-
+-/* DG2 */
+-#define XE_DG2_G10_IDS(MACRO__, ...)		\
+-	MACRO__(0x5690, ## __VA_ARGS__),	\
+-	MACRO__(0x5691, ## __VA_ARGS__),	\
+-	MACRO__(0x5692, ## __VA_ARGS__),	\
+-	MACRO__(0x56A0, ## __VA_ARGS__),	\
+-	MACRO__(0x56A1, ## __VA_ARGS__),	\
+-	MACRO__(0x56A2, ## __VA_ARGS__),	\
+-	MACRO__(0x56BE, ## __VA_ARGS__),	\
+-	MACRO__(0x56BF, ## __VA_ARGS__)
+-
+-#define XE_DG2_G11_IDS(MACRO__, ...)		\
+-	MACRO__(0x5693, ## __VA_ARGS__),	\
+-	MACRO__(0x5694, ## __VA_ARGS__),	\
+-	MACRO__(0x5695, ## __VA_ARGS__),	\
+-	MACRO__(0x56A5, ## __VA_ARGS__),	\
+-	MACRO__(0x56A6, ## __VA_ARGS__),	\
+-	MACRO__(0x56B0, ## __VA_ARGS__),	\
+-	MACRO__(0x56B1, ## __VA_ARGS__),	\
+-	MACRO__(0x56BA, ## __VA_ARGS__),	\
+-	MACRO__(0x56BB, ## __VA_ARGS__),	\
+-	MACRO__(0x56BC, ## __VA_ARGS__),	\
+-	MACRO__(0x56BD, ## __VA_ARGS__)
+-
+-#define XE_DG2_G12_IDS(MACRO__, ...)		\
+-	MACRO__(0x5696, ## __VA_ARGS__),	\
+-	MACRO__(0x5697, ## __VA_ARGS__),	\
+-	MACRO__(0x56A3, ## __VA_ARGS__),	\
+-	MACRO__(0x56A4, ## __VA_ARGS__),	\
+-	MACRO__(0x56B2, ## __VA_ARGS__),	\
+-	MACRO__(0x56B3, ## __VA_ARGS__)
+-
+-#define XE_DG2_IDS(MACRO__, ...)		\
+-	XE_DG2_G10_IDS(MACRO__, ## __VA_ARGS__),\
+-	XE_DG2_G11_IDS(MACRO__, ## __VA_ARGS__),\
+-	XE_DG2_G12_IDS(MACRO__, ## __VA_ARGS__)
+-
+-#define XE_ATS_M150_IDS(MACRO__, ...)		\
+-	MACRO__(0x56C0, ## __VA_ARGS__),	\
+-	MACRO__(0x56C2, ## __VA_ARGS__)
+-
+-#define XE_ATS_M75_IDS(MACRO__, ...)		\
+-	MACRO__(0x56C1, ## __VA_ARGS__)
+-
+-#define XE_ATS_M_IDS(MACRO__, ...)		\
+-	XE_ATS_M150_IDS(MACRO__, ## __VA_ARGS__),\
+-	XE_ATS_M75_IDS(MACRO__, ## __VA_ARGS__)
+-
+-/* MTL / ARL */
+-#define XE_MTL_IDS(MACRO__, ...)		\
+-	MACRO__(0x7D40, ## __VA_ARGS__),	\
+-	MACRO__(0x7D41, ## __VA_ARGS__),	\
+-	MACRO__(0x7D45, ## __VA_ARGS__),	\
+-	MACRO__(0x7D51, ## __VA_ARGS__),        \
+-	MACRO__(0x7D55, ## __VA_ARGS__),	\
+-	MACRO__(0x7D60, ## __VA_ARGS__),	\
+-	MACRO__(0x7D67, ## __VA_ARGS__),	\
+-	MACRO__(0x7DD1, ## __VA_ARGS__),        \
+-	MACRO__(0x7DD5, ## __VA_ARGS__)
+-
+-#define XE_LNL_IDS(MACRO__, ...) \
+-	MACRO__(0x6420, ## __VA_ARGS__), \
+-	MACRO__(0x64A0, ## __VA_ARGS__), \
+-	MACRO__(0x64B0, ## __VA_ARGS__)
+-
+-#define XE_BMG_IDS(MACRO__, ...) \
+-	MACRO__(0xE202, ## __VA_ARGS__), \
+-	MACRO__(0xE20B, ## __VA_ARGS__), \
+-	MACRO__(0xE20C, ## __VA_ARGS__), \
+-	MACRO__(0xE20D, ## __VA_ARGS__), \
+-	MACRO__(0xE210, ## __VA_ARGS__), \
+-	MACRO__(0xE211, ## __VA_ARGS__), \
+-	MACRO__(0xE212, ## __VA_ARGS__), \
+-	MACRO__(0xE215, ## __VA_ARGS__), \
+-	MACRO__(0xE216, ## __VA_ARGS__)
+-
+-#endif
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -103,6 +103,8 @@ backport/patches/base/0001-drm-xe-prevent-potential-UAF-in-pf_provision_vf_ggtt.
 backport/patches/base/0001-drm-xe-client-bo-client-does-not-need-bos_lock.patch
 backport/patches/base/0001-drm-xe-bmg-Add-one-additional-PCI-ID.patch
 backport/patches/base/0001-drm-i915-xe2hpd-Identify-the-memory-type-for-SKUs-wi.patch
+backport/patches/base/0001-drm-intel-pciids-rename-i915_pciids.h-to-just-pciids.patch
+backport/patches/base/0001-drm-xe-switch-to-common-PCI-ID-macros.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-drm-xe-Use-the-filelist-from-drm-for-ccs_mode-change.patch
 backport/patches/features/eu-debug/0001-drm-xe-Export-xe_hw_engine-s-mmio-accessors.patch


### PR DESCRIPTION
In preparation of sharing the PCI ID macros between i915 and xe, rename
i915_pciids.h to pciids.h
Switch to the shared PCI ID macros in drm/intel/pciids.h. Remove
xe_pciids.h.

Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>