### PR TITLE
patches/base: Add support manage power limits through pcode mailboxes

### DIFF
--- a/backport/patches/base/0001-drm-xe-hwmon-Add-support-to-manage-PL2-though-mailbo.patch
+++ b/backport/patches/base/0001-drm-xe-hwmon-Add-support-to-manage-PL2-though-mailbo.patch
@@ -1,0 +1,378 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Karthik Poosa <karthik.poosa@intel.com>
+Date: Thu, 29 May 2025 22:04:55 +0530
+Subject: drm/xe/hwmon: Add support to manage PL2 though mailbox
+
+Add support to manage power limit PL2 (burst limit) through
+pcode mailbox commands.
+
+v2:
+ - Update power1_cap definition in hwmon documentation. (Badal)
+ - Clamp PL2 power limit to GPU firmware default value.
+
+v3:
+ - Activate the power label when either the PL1 or PL2 power
+   limit is enabled.
+
+v4:
+ - Update description of pl2_on_boot variable to fix kernel-doc
+   error.
+
+v5:
+ - Remove unnecessary drm_warn.
+ - Rectify powerX_label permission to read-only on platforms
+   without mailbox power limits support.
+ - Expose powerX_cap entries only on platforms with mailbox
+   support.
+
+v6:
+ - Improve commit message, refer to BIOS as GPU firmware.
+ - Refer to card firmware as GPU firmware in code.
+ - Remove unnecessary drm_dbg.
+ - Print supported and unsupported power limits. (Rodrigo)
+ - Enable powerN_cap/max_xxx entries only when power limits
+   supported in GPU firmware.
+
+Signed-off-by: Karthik Poosa <karthik.poosa@intel.com>
+Reviewed-by: Badal Nilawar <badal.nilawar@intel.com>
+Link: https://lore.kernel.org/r/20250529163458.2354509-4-karthik.poosa@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit c713b9a23c73f6ce9c0197369668f216ed0e04c9 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ .../ABI/testing/sysfs-driver-intel-xe-hwmon   |  30 +++++
+ drivers/gpu/drm/xe/xe_hwmon.c                 | 112 ++++++++++++------
+ 2 files changed, 109 insertions(+), 33 deletions(-)
+
+diff --git a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
+index ae842728c293..3ebb1d48e797 100644
+--- a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
++++ b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
+@@ -132,3 +132,33 @@ Contact:	intel-xe@lists.freedesktop.org
+ Description:	RO. Fan 3 speed in RPM.
+ 
+ 		Only supported for particular Intel Xe graphics platforms.
++
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/power1_cap
++Date:		May 2025
++KernelVersion:	6.15
++Contact:	intel-xe@lists.freedesktop.org
++Description:	RW. Card burst (PL2) power limit in microwatts.
++
++		The power controller will throttle the operating frequency
++		if the power averaged over a window (typically milli seconds)
++		exceeds this limit. A read value of 0 means that the PL2
++		power limit is disabled, writing 0 disables the	limit.
++		PL2 is greater than PL1 and its time window is lesser
++		compared to PL1.
++
++		Only supported for particular Intel Xe graphics platforms.
++
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/power2_cap
++Date:		May 2025
++KernelVersion:	6.15
++Contact:	intel-xe@lists.freedesktop.org
++Description:	RW. Package burst (PL2) power limit in microwatts.
++
++		The power controller will throttle the operating frequency
++		if the power averaged over a window (typically milli seconds)
++		exceeds this limit. A read value of 0 means that the PL2
++		power limit is disabled, writing 0 disables the	limit.
++		PL2 is greater than PL1 and its time window is lesser
++		compared to PL1.
++
++		Only supported for particular Intel Xe graphics platforms.
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index 178d0b7c3d01..384981b74632 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -48,6 +48,14 @@ enum xe_fan_channel {
+ 	FAN_MAX,
+ };
+ 
++/* Attribute index for powerX_xxx_interval sysfs entries */
++enum sensor_attr_power {
++	SENSOR_INDEX_PSYS_PL1,
++	SENSOR_INDEX_PKG_PL1,
++	SENSOR_INDEX_PSYS_PL2,
++	SENSOR_INDEX_PKG_PL2,
++};
++
+ /*
+  * For platforms that support mailbox commands for power limits, REG_PKG_POWER_SKU_UNIT is
+  * not supported and below are SKU units to be used.
+@@ -69,8 +77,9 @@ enum xe_fan_channel {
+  * PL*_HWMON_ATTR - mapping of hardware power limits to corresponding hwmon power attribute.
+  */
+ #define PL1_HWMON_ATTR	hwmon_power_max
++#define PL2_HWMON_ATTR	hwmon_power_cap
+ 
+-#define PWR_ATTR_TO_STR(attr)	(((attr) == hwmon_power_max) ? "PL1" : "Invalid")
++#define PWR_ATTR_TO_STR(attr)	(((attr) == hwmon_power_max) ? "PL1" : "PL2")
+ 
+ /*
+  * Timeout for power limit write mailbox command.
+@@ -121,6 +130,9 @@ struct xe_hwmon {
+ 	bool boot_power_limit_read;
+ 	/** @pl1_on_boot: power limit PL1 on boot */
+ 	u32 pl1_on_boot[CHANNEL_MAX];
++	/** @pl2_on_boot: power limit PL2 on boot */
++	u32 pl2_on_boot[CHANNEL_MAX];
++
+ };
+ 
+ static int xe_hwmon_pcode_read_power_limit(const struct xe_hwmon *hwmon, u32 attr, int channel,
+@@ -148,8 +160,10 @@ static int xe_hwmon_pcode_read_power_limit(const struct xe_hwmon *hwmon, u32 att
+ 	/* return the value only if limit is enabled */
+ 	if (attr == PL1_HWMON_ATTR)
+ 		*uval = (val0 & PWR_LIM_EN) ? val0 : 0;
++	else if (attr == PL2_HWMON_ATTR)
++		*uval = (val1 & PWR_LIM_EN) ? val1 : 0;
+ 	else if (attr == hwmon_power_label)
+-		*uval = (val0 & PWR_LIM_EN) ? 1 : 0;
++		*uval = (val0 & PWR_LIM_EN) ? 1 : (val1 & PWR_LIM_EN) ? 1 : 0;
+ 	else
+ 		*uval = 0;
+ 
+@@ -177,6 +191,8 @@ static int xe_hwmon_pcode_write_power_limit(const struct xe_hwmon *hwmon, u32 at
+ 
+ 	if (attr == PL1_HWMON_ATTR)
+ 		val0 = uval;
++	else if (attr == PL2_HWMON_ATTR)
++		val1 = uval;
+ 	else
+ 		return -EIO;
+ 
+@@ -257,7 +273,7 @@ static struct xe_reg xe_hwmon_get_reg(struct xe_hwmon *hwmon, enum xe_hwmon_reg
+  */
+ static void xe_hwmon_power_max_read(struct xe_hwmon *hwmon, u32 attr, int channel, long *value)
+ {
+-	u64 reg_val, min, max;
++	u64 reg_val = 0, min, max;
+ 	struct xe_device *xe = hwmon->xe;
+ 	struct xe_reg rapl_limit, pkg_power_sku;
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(xe);
+@@ -311,7 +327,7 @@ static int xe_hwmon_power_max_write(struct xe_hwmon *hwmon, u32 attr, int channe
+ {
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+ 	int ret = 0;
+-	u32 reg_val;
++	u32 reg_val, max;
+ 	struct xe_reg rapl_limit;
+ 
+ 	mutex_lock(&hwmon->hwmon_lock);
+@@ -339,20 +355,25 @@ static int xe_hwmon_power_max_write(struct xe_hwmon *hwmon, u32 attr, int channe
+ 
+ 	/* Computation in 64-bits to avoid overflow. Round to nearest. */
+ 	reg_val = DIV_ROUND_CLOSEST_ULL((u64)value << hwmon->scl_shift_power, SF_POWER);
+-	reg_val = PWR_LIM_EN | REG_FIELD_PREP(PWR_LIM_VAL, reg_val);
+ 
+ 	/*
+-	 * Clamp power limit to card-firmware default as maximum, as an additional protection to
++	 * Clamp power limit to GPU firmware default as maximum, as an additional protection to
+ 	 * pcode clamp.
+ 	 */
+ 	if (hwmon->xe->info.has_mbx_power_limits) {
+-		if (reg_val > REG_FIELD_GET(PWR_LIM_VAL, hwmon->pl1_on_boot[channel])) {
+-			reg_val = REG_FIELD_GET(PWR_LIM_VAL, hwmon->pl1_on_boot[channel]);
+-			drm_dbg(&hwmon->xe->drm, "Clamping power limit to firmware default 0x%x\n",
++		max = (attr == PL1_HWMON_ATTR) ?
++		       hwmon->pl1_on_boot[channel] : hwmon->pl2_on_boot[channel];
++		max = REG_FIELD_PREP(PWR_LIM_VAL, max);
++		if (reg_val > max) {
++			reg_val = max;
++			drm_dbg(&hwmon->xe->drm,
++				"Clamping power limit to GPU firmware default 0x%x\n",
+ 				reg_val);
+ 		}
+ 	}
+ 
++	reg_val = PWR_LIM_EN | REG_FIELD_PREP(PWR_LIM_VAL, reg_val);
++
+ 	if (hwmon->xe->info.has_mbx_power_limits)
+ 		ret = xe_hwmon_pcode_write_power_limit(hwmon, attr, channel, reg_val);
+ 	else
+@@ -436,8 +457,9 @@ xe_hwmon_power_max_interval_show(struct device *dev, struct device_attribute *at
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+ 	u32 x, y, x_w = 2; /* 2 bits */
+ 	u64 r, tau4, out;
+-	int channel = to_sensor_dev_attr(attr)->index;
++	int channel = (to_sensor_dev_attr(attr)->index % 2) ? CHANNEL_PKG : CHANNEL_CARD;
+ 	u32 power_attr = PL1_HWMON_ATTR;
++
+ 	int ret = 0;
+ 
+ 	xe_pm_runtime_get(hwmon->xe);
+@@ -490,9 +512,9 @@ xe_hwmon_power_max_interval_store(struct device *dev, struct device_attribute *a
+ 	u32 x, y, rxy, x_w = 2; /* 2 bits */
+ 	u64 tau4, r, max_win;
+ 	unsigned long val;
+-	int ret;
+-	int channel = to_sensor_dev_attr(attr)->index;
++	int channel = (to_sensor_dev_attr(attr)->index % 2) ? CHANNEL_PKG : CHANNEL_CARD;
+ 	u32 power_attr = PL1_HWMON_ATTR;
++	int ret;
+ 
+ 	ret = kstrtoul(buf, 0, &val);
+ 	if (ret)
+@@ -519,10 +541,8 @@ xe_hwmon_power_max_interval_store(struct device *dev, struct device_attribute *a
+ 	tau4 = (u64)((1 << x_w) | x) << y;
+ 	max_win = mul_u64_u32_shr(tau4, SF_TIME, hwmon->scl_shift_time + x_w);
+ 
+-	if (val > max_win) {
+-		drm_warn(&hwmon->xe->drm, "power_interval invalid val 0x%lx\n", val);
++	if (val > max_win)
+ 		return -EINVAL;
+-	}
+ 
+ 	/* val in hw units */
+ 	val = DIV_ROUND_CLOSEST_ULL((u64)val << hwmon->scl_shift_time, SF_TIME) + 1;
+@@ -566,11 +586,11 @@ xe_hwmon_power_max_interval_store(struct device *dev, struct device_attribute *a
+ /* PSYS PL1 */
+ static SENSOR_DEVICE_ATTR(power1_max_interval, 0664,
+ 			  xe_hwmon_power_max_interval_show,
+-			  xe_hwmon_power_max_interval_store, CHANNEL_CARD);
+-
++			  xe_hwmon_power_max_interval_store, SENSOR_INDEX_PSYS_PL1);
++/* PKG PL1 */
+ static SENSOR_DEVICE_ATTR(power2_max_interval, 0664,
+ 			  xe_hwmon_power_max_interval_show,
+-			  xe_hwmon_power_max_interval_store, CHANNEL_PKG);
++			  xe_hwmon_power_max_interval_store, SENSOR_INDEX_PKG_PL1);
+ 
+ static struct attribute *hwmon_attributes[] = {
+ 	&sensor_dev_attr_power1_max_interval.dev_attr.attr,
+@@ -584,7 +604,7 @@ static umode_t xe_hwmon_attributes_visible(struct kobject *kobj,
+ 	struct device *dev = kobj_to_dev(kobj);
+ 	struct xe_hwmon *hwmon = dev_get_drvdata(dev);
+ 	int ret = 0;
+-	int channel = index ? CHANNEL_PKG : CHANNEL_CARD;
++	int channel = (index % 2) ? CHANNEL_PKG : CHANNEL_CARD;
+ 	u32 power_attr = PL1_HWMON_ATTR;
+ 	u32 uval;
+ 
+@@ -593,7 +613,7 @@ static umode_t xe_hwmon_attributes_visible(struct kobject *kobj,
+ 	if (hwmon->xe->info.has_mbx_power_limits) {
+ 		xe_hwmon_pcode_read_power_limit(hwmon, power_attr, channel, &uval);
+ 		ret = (uval & PWR_LIM_EN) ? attr->mode : 0;
+-	} else {
++	} else if (power_attr != PL2_HWMON_ATTR) {
+ 		ret = xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT,
+ 						       channel)) ? attr->mode : 0;
+ 	}
+@@ -614,8 +634,9 @@ static const struct attribute_group *hwmon_groups[] = {
+ };
+ 
+ static const struct hwmon_channel_info * const hwmon_info[] = {
+-	HWMON_CHANNEL_INFO(power, HWMON_P_MAX | HWMON_P_RATED_MAX | HWMON_P_LABEL | HWMON_P_CRIT,
+-			   HWMON_P_MAX | HWMON_P_RATED_MAX | HWMON_P_LABEL),
++	HWMON_CHANNEL_INFO(power, HWMON_P_MAX | HWMON_P_RATED_MAX | HWMON_P_LABEL | HWMON_P_CRIT |
++			   HWMON_P_CAP,
++			   HWMON_P_MAX | HWMON_P_RATED_MAX | HWMON_P_LABEL | HWMON_P_CAP),
+ 	HWMON_CHANNEL_INFO(curr, HWMON_C_LABEL, HWMON_C_CRIT | HWMON_C_LABEL),
+ 	HWMON_CHANNEL_INFO(in, HWMON_I_INPUT | HWMON_I_LABEL, HWMON_I_INPUT | HWMON_I_LABEL),
+ 	HWMON_CHANNEL_INFO(energy, HWMON_E_INPUT | HWMON_E_LABEL, HWMON_E_INPUT | HWMON_E_LABEL),
+@@ -706,17 +727,32 @@ static void xe_hwmon_get_voltage(struct xe_hwmon *hwmon, int channel, long *valu
+ static umode_t
+ xe_hwmon_power_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
+ {
+-	u32 uval;
++	u32 uval = 0;
++	struct xe_reg rapl_limit;
++	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+ 
+ 	switch (attr) {
+ 	case hwmon_power_max:
++	case hwmon_power_cap:
++	case hwmon_power_label:
+ 		if (hwmon->xe->info.has_mbx_power_limits) {
+ 			xe_hwmon_pcode_read_power_limit(hwmon, attr, channel, &uval);
+-			return (uval) ? 0664 : 0;
+-		} else {
+-			return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT,
+-				       channel)) ? 0664 : 0;
++		} else if (attr != PL2_HWMON_ATTR) {
++			rapl_limit = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
++			if (xe_reg_is_valid(rapl_limit))
++				uval = xe_mmio_read32(mmio, rapl_limit);
++		}
++		if (uval & PWR_LIM_EN) {
++			if (attr == hwmon_power_label)
++				return 0444;
++
++			drm_info(&hwmon->xe->drm, "%s is supported on channel %d\n",
++				 PWR_ATTR_TO_STR(attr), channel);
++			return 0664;
+ 		}
++		drm_dbg(&hwmon->xe->drm, "%s is unsupported on channel %d\n",
++			PWR_ATTR_TO_STR(attr), channel);
++		return 0;
+ 	case hwmon_power_rated_max:
+ 		if (hwmon->xe->info.has_mbx_power_limits)
+ 			return 0;
+@@ -724,11 +760,9 @@ xe_hwmon_power_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
+ 			return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU,
+ 					       channel)) ? 0444 : 0;
+ 	case hwmon_power_crit:
+-	case hwmon_power_label:
+ 		if (channel == CHANNEL_CARD) {
+ 			xe_hwmon_pcode_read_i1(hwmon, &uval);
+-			return (uval & POWER_SETUP_I1_WATTS) ? (attr == hwmon_power_label) ?
+-				0444 : 0644 : 0;
++			return (uval & POWER_SETUP_I1_WATTS) ? 0644 : 0;
+ 		}
+ 		break;
+ 	default:
+@@ -742,6 +776,7 @@ xe_hwmon_power_read(struct xe_hwmon *hwmon, u32 attr, int channel, long *val)
+ {
+ 	switch (attr) {
+ 	case hwmon_power_max:
++	case hwmon_power_cap:
+ 		xe_hwmon_power_max_read(hwmon, attr, channel, val);
+ 		return 0;
+ 	case hwmon_power_rated_max:
+@@ -758,6 +793,7 @@ static int
+ xe_hwmon_power_write(struct xe_hwmon *hwmon, u32 attr, int channel, long val)
+ {
+ 	switch (attr) {
++	case hwmon_power_cap:
+ 	case hwmon_power_max:
+ 		return xe_hwmon_power_max_write(hwmon, attr, channel, val);
+ 	case hwmon_power_crit:
+@@ -1069,13 +1105,17 @@ xe_hwmon_get_preregistration_info(struct xe_device *xe)
+ 	struct xe_reg pkg_power_sku_unit;
+ 
+ 	if (hwmon->xe->info.has_mbx_power_limits) {
+-		/* Check if card firmware support mailbox power limits commands. */
++		/* Check if GPU firmware support mailbox power limits commands. */
+ 		if (xe_hwmon_pcode_read_power_limit(hwmon, PL1_HWMON_ATTR, CHANNEL_CARD,
+ 						    &hwmon->pl1_on_boot[CHANNEL_CARD]) |
+ 		    xe_hwmon_pcode_read_power_limit(hwmon, PL1_HWMON_ATTR, CHANNEL_PKG,
+-						    &hwmon->pl1_on_boot[CHANNEL_PKG])) {
++						    &hwmon->pl1_on_boot[CHANNEL_PKG]) |
++		    xe_hwmon_pcode_read_power_limit(hwmon, PL2_HWMON_ATTR, CHANNEL_CARD,
++						    &hwmon->pl2_on_boot[CHANNEL_CARD]) |
++		    xe_hwmon_pcode_read_power_limit(hwmon, PL1_HWMON_ATTR, CHANNEL_PKG,
++						    &hwmon->pl2_on_boot[CHANNEL_PKG])) {
+ 			drm_warn(&hwmon->xe->drm,
+-				 "Failed to read power limits, check card firmware !\n");
++				 "Failed to read power limits, check GPU firmware !\n");
+ 		} else {
+ 			drm_info(&hwmon->xe->drm, "Using mailbox commands for power limits\n");
+ 			/* Write default limits to read from pcode from now on. */
+@@ -1085,6 +1125,12 @@ xe_hwmon_get_preregistration_info(struct xe_device *xe)
+ 			xe_hwmon_pcode_write_power_limit(hwmon, PL1_HWMON_ATTR,
+ 							 CHANNEL_PKG,
+ 							 hwmon->pl1_on_boot[CHANNEL_PKG]);
++			xe_hwmon_pcode_write_power_limit(hwmon, PL2_HWMON_ATTR,
++							 CHANNEL_CARD,
++							 hwmon->pl2_on_boot[CHANNEL_CARD]);
++			xe_hwmon_pcode_write_power_limit(hwmon, PL2_HWMON_ATTR,
++							 CHANNEL_PKG,
++							 hwmon->pl2_on_boot[CHANNEL_PKG]);
+ 			hwmon->scl_shift_power = PWR_UNIT;
+ 			hwmon->scl_shift_energy = ENERGY_UNIT;
+ 			hwmon->scl_shift_time = TIME_UNIT;
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-hwmon-Add-support-to-manage-power-limits-thou.patch
+++ b/backport/patches/base/0001-drm-xe-hwmon-Add-support-to-manage-power-limits-thou.patch
@@ -1,0 +1,787 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Karthik Poosa <karthik.poosa@intel.com>
+Date: Thu, 29 May 2025 22:04:53 +0530
+Subject: drm/xe/hwmon: Add support to manage power limits though
+ mailbox
+
+Add support to manage power limits using pcode mailbox commands
+for supported platforms.
+
+v2:
+ - Address review comments. (Badal)
+ - Use mailbox commands instead of registers to manage power limits
+   for BMG.
+ - Clamp the maximum power limit to GPU firmware default value.
+
+v3:
+ - Clamp power limit in write also for platforms with mailbox support.
+
+v4:
+ - Remove unnecessary debug prints. (Badal)
+
+v5:
+ - Update description of variable pl1_on_boot to fix kernel-doc error.
+
+v6:
+ - Improve commit message, refer to BIOS as GPU firmware.
+ - Change macro READ_PL_FROM_BIOS to READ_PL_FROM_FW.
+ - Rectify drm_warn to drm_info.
+
+Signed-off-by: Karthik Poosa <karthik.poosa@intel.com>
+Fixes: e90f7a58e659 ("drm/xe/hwmon: Add HWMON support for BMG")
+Reviewed-by: Badal Nilawar <badal.nilawar@intel.com>
+Link: https://lore.kernel.org/r/20250529163458.2354509-2-karthik.poosa@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 7596d839f6228757fe17a810da2d1c5f3305078c linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_mchbar_regs.h |  10 +-
+ drivers/gpu/drm/xe/regs/xe_pcode_regs.h  |   4 -
+ drivers/gpu/drm/xe/xe_device_types.h     |   4 +
+ drivers/gpu/drm/xe/xe_hwmon.c            | 380 +++++++++++++++++------
+ drivers/gpu/drm/xe/xe_pci.c              |   5 +
+ drivers/gpu/drm/xe/xe_pcode.c            |  11 +
+ drivers/gpu/drm/xe/xe_pcode.h            |   3 +
+ drivers/gpu/drm/xe/xe_pcode_api.h        |   7 +
+ 8 files changed, 318 insertions(+), 106 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_mchbar_regs.h b/drivers/gpu/drm/xe/regs/xe_mchbar_regs.h
+index 519dd1067a19..5e8ce7bf78d3 100644
+--- a/drivers/gpu/drm/xe/regs/xe_mchbar_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_mchbar_regs.h
+@@ -35,10 +35,10 @@
+ #define PCU_CR_PACKAGE_ENERGY_STATUS		XE_REG(MCHBAR_MIRROR_BASE_SNB + 0x593c)
+ 
+ #define PCU_CR_PACKAGE_RAPL_LIMIT		XE_REG(MCHBAR_MIRROR_BASE_SNB + 0x59a0)
+-#define   PKG_PWR_LIM_1				REG_GENMASK(14, 0)
+-#define   PKG_PWR_LIM_1_EN			REG_BIT(15)
+-#define   PKG_PWR_LIM_1_TIME			REG_GENMASK(23, 17)
+-#define   PKG_PWR_LIM_1_TIME_X			REG_GENMASK(23, 22)
+-#define   PKG_PWR_LIM_1_TIME_Y			REG_GENMASK(21, 17)
++#define   PWR_LIM_VAL				REG_GENMASK(14, 0)
++#define   PWR_LIM_EN				REG_BIT(15)
++#define   PWR_LIM_TIME				REG_GENMASK(23, 17)
++#define   PWR_LIM_TIME_X			REG_GENMASK(23, 22)
++#define   PWR_LIM_TIME_Y			REG_GENMASK(21, 17)
+ 
+ #endif /* _XE_MCHBAR_REGS_H_ */
+diff --git a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
+index 254e15a90c49..db552b9fd1b1 100644
+--- a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
+@@ -18,14 +18,10 @@
+ #define PVC_GT0_PLATFORM_ENERGY_STATUS          XE_REG(0x28106c)
+ #define PVC_GT0_PACKAGE_POWER_SKU               XE_REG(0x281080)
+ 
+-#define BMG_PACKAGE_POWER_SKU			XE_REG(0x138098)
+-#define BMG_PACKAGE_POWER_SKU_UNIT		XE_REG(0x1380dc)
+ #define BMG_PACKAGE_ENERGY_STATUS		XE_REG(0x138120)
+ #define BMG_FAN_1_SPEED				XE_REG(0x138140)
+ #define BMG_FAN_2_SPEED				XE_REG(0x138170)
+ #define BMG_FAN_3_SPEED				XE_REG(0x1381a0)
+-#define BMG_PACKAGE_RAPL_LIMIT			XE_REG(0x138440)
+ #define BMG_PLATFORM_ENERGY_STATUS		XE_REG(0x138458)
+-#define BMG_PLATFORM_POWER_LIMIT		XE_REG(0x138460)
+ 
+ #endif /* _XE_PCODE_REGS_H_ */
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index e24ff5bdacaa..a7320bd97bd6 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -319,6 +319,10 @@ struct xe_device {
+ 		u8 has_llc:1;
+ 		/** @info.has_mmio_ext: Device has extra MMIO address range */
+ 		u8 has_mmio_ext:1;
++		/** @info.has_mbx_power_limits: Device has support to manage power limits using
++		 * pcode mailbox commands.
++		 */
++		u8 has_mbx_power_limits:1;
+ 		/** @info.has_range_tlb_invalidation: Has range based TLB invalidations */
+ 		u8 has_range_tlb_invalidation:1;
+ 		/** @info.has_sriov: Supports SR-IOV */
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index 708becaf4524..c3d0cebe3713 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -48,6 +48,14 @@ enum xe_fan_channel {
+ 	FAN_MAX,
+ };
+ 
++/*
++ * For platforms that support mailbox commands for power limits, REG_PKG_POWER_SKU_UNIT is
++ * not supported and below are SKU units to be used.
++ */
++#define PWR_UNIT	0x3
++#define ENERGY_UNIT	0xe
++#define TIME_UNIT	0xa
++
+ /*
+  * SF_* - scale factors for particular quantities according to hwmon spec.
+  */
+@@ -57,6 +65,18 @@ enum xe_fan_channel {
+ #define SF_ENERGY	1000000		/* microjoules */
+ #define SF_TIME		1000		/* milliseconds */
+ 
++/*
++ * PL*_HWMON_ATTR - mapping of hardware power limits to corresponding hwmon power attribute.
++ */
++#define PL1_HWMON_ATTR	hwmon_power_max
++
++#define PWR_ATTR_TO_STR(attr)	(((attr) == hwmon_power_max) ? "PL1" : "Invalid")
++
++/*
++ * Timeout for power limit write mailbox command.
++ */
++#define PL_WRITE_MBX_TIMEOUT_MS	(1)
++
+ /**
+  * struct xe_hwmon_energy_info - to accumulate energy
+  */
+@@ -97,8 +117,80 @@ struct xe_hwmon {
+ 	struct xe_hwmon_energy_info ei[CHANNEL_MAX];
+ 	/** @fi: Fan info for fanN_input */
+ 	struct xe_hwmon_fan_info fi[FAN_MAX];
++	/** @boot_power_limit_read: is boot power limits read */
++	bool boot_power_limit_read;
++	/** @pl1_on_boot: power limit PL1 on boot */
++	u32 pl1_on_boot[CHANNEL_MAX];
+ };
+ 
++static int xe_hwmon_pcode_read_power_limit(const struct xe_hwmon *hwmon, u32 attr, int channel,
++					   u32 *uval)
++{
++	struct xe_tile *root_tile = xe_device_get_root_tile(hwmon->xe);
++	u32 val0 = 0, val1 = 0;
++	int ret = 0;
++
++	ret = xe_pcode_read(root_tile, PCODE_MBOX(PCODE_POWER_SETUP,
++						  (channel == CHANNEL_CARD) ?
++						  READ_PSYSGPU_POWER_LIMIT :
++						  READ_PACKAGE_POWER_LIMIT,
++						  hwmon->boot_power_limit_read ?
++						  READ_PL_FROM_PCODE : READ_PL_FROM_FW),
++						  &val0, &val1);
++
++	if (ret) {
++		drm_dbg(&hwmon->xe->drm, "read failed ch %d val0 0x%08x, val1 0x%08x, ret %d\n",
++			channel, val0, val1, ret);
++		*uval = 0;
++		return ret;
++	}
++
++	/* return the value only if limit is enabled */
++	if (attr == PL1_HWMON_ATTR)
++		*uval = (val0 & PWR_LIM_EN) ? val0 : 0;
++	else if (attr == hwmon_power_label)
++		*uval = (val0 & PWR_LIM_EN) ? 1 : 0;
++	else
++		*uval = 0;
++
++	return ret;
++}
++
++static int xe_hwmon_pcode_write_power_limit(const struct xe_hwmon *hwmon, u32 attr, u8 channel,
++					    u32 uval)
++{
++	struct xe_tile *root_tile = xe_device_get_root_tile(hwmon->xe);
++	u32 val0, val1;
++	int ret = 0;
++
++	ret = xe_pcode_read(root_tile, PCODE_MBOX(PCODE_POWER_SETUP,
++						  (channel == CHANNEL_CARD) ?
++						  READ_PSYSGPU_POWER_LIMIT :
++						  READ_PACKAGE_POWER_LIMIT,
++						  hwmon->boot_power_limit_read ?
++						  READ_PL_FROM_PCODE : READ_PL_FROM_FW),
++						  &val0, &val1);
++
++	if (ret)
++		drm_dbg(&hwmon->xe->drm, "read failed ch %d val0 0x%08x, val1 0x%08x, ret %d\n",
++			channel, val0, val1, ret);
++
++	if (attr == PL1_HWMON_ATTR)
++		val0 = uval;
++	else
++		return -EIO;
++
++	ret = xe_pcode_write64_timeout(root_tile, PCODE_MBOX(PCODE_POWER_SETUP,
++							     (channel == CHANNEL_CARD) ?
++							     WRITE_PSYSGPU_POWER_LIMIT :
++							     WRITE_PACKAGE_POWER_LIMIT, 0),
++							     val0, val1, PL_WRITE_MBX_TIMEOUT_MS);
++	if (ret)
++		drm_dbg(&hwmon->xe->drm, "write failed ch %d val0 0x%08x, val1 0x%08x, ret %d\n",
++			channel, val0, val1, ret);
++	return ret;
++}
++
+ static struct xe_reg xe_hwmon_get_reg(struct xe_hwmon *hwmon, enum xe_hwmon_reg hwmon_reg,
+ 				      int channel)
+ {
+@@ -106,29 +198,19 @@ static struct xe_reg xe_hwmon_get_reg(struct xe_hwmon *hwmon, enum xe_hwmon_reg
+ 
+ 	switch (hwmon_reg) {
+ 	case REG_PKG_RAPL_LIMIT:
+-		if (xe->info.platform == XE_BATTLEMAGE) {
+-			if (channel == CHANNEL_PKG)
+-				return BMG_PACKAGE_RAPL_LIMIT;
+-			else
+-				return BMG_PLATFORM_POWER_LIMIT;
+-		} else if (xe->info.platform == XE_PVC && channel == CHANNEL_PKG) {
++		if (xe->info.platform == XE_PVC && channel == CHANNEL_PKG)
+ 			return PVC_GT0_PACKAGE_RAPL_LIMIT;
+-		} else if ((xe->info.platform == XE_DG2) && (channel == CHANNEL_PKG)) {
++		else if ((xe->info.platform == XE_DG2) && (channel == CHANNEL_PKG))
+ 			return PCU_CR_PACKAGE_RAPL_LIMIT;
+-		}
+ 		break;
+ 	case REG_PKG_POWER_SKU:
+-		if (xe->info.platform == XE_BATTLEMAGE)
+-			return BMG_PACKAGE_POWER_SKU;
+-		else if (xe->info.platform == XE_PVC && channel == CHANNEL_PKG)
++		if (xe->info.platform == XE_PVC && channel == CHANNEL_PKG)
+ 			return PVC_GT0_PACKAGE_POWER_SKU;
+ 		else if ((xe->info.platform == XE_DG2) && (channel == CHANNEL_PKG))
+ 			return PCU_CR_PACKAGE_POWER_SKU;
+ 		break;
+ 	case REG_PKG_POWER_SKU_UNIT:
+-		if (xe->info.platform == XE_BATTLEMAGE)
+-			return BMG_PACKAGE_POWER_SKU_UNIT;
+-		else if (xe->info.platform == XE_PVC)
++		if (xe->info.platform == XE_PVC)
+ 			return PVC_GT0_PACKAGE_POWER_SKU_UNIT;
+ 		else if (xe->info.platform == XE_DG2)
+ 			return PCU_CR_PACKAGE_POWER_SKU_UNIT;
+@@ -165,7 +247,7 @@ static struct xe_reg xe_hwmon_get_reg(struct xe_hwmon *hwmon, enum xe_hwmon_reg
+ 	return XE_REG(0);
+ }
+ 
+-#define PL1_DISABLE 0
++#define PL_DISABLE 0
+ 
+ /*
+  * HW allows arbitrary PL1 limits to be set but silently clamps these values to
+@@ -173,67 +255,83 @@ static struct xe_reg xe_hwmon_get_reg(struct xe_hwmon *hwmon, enum xe_hwmon_reg
+  * same pattern for sysfs, allow arbitrary PL1 limits to be set but display
+  * clamped values when read.
+  */
+-static void xe_hwmon_power_max_read(struct xe_hwmon *hwmon, int channel, long *value)
++static void xe_hwmon_power_max_read(struct xe_hwmon *hwmon, u32 attr, int channel, long *value)
+ {
+ 	u64 reg_val, min, max;
+ 	struct xe_device *xe = hwmon->xe;
+ 	struct xe_reg rapl_limit, pkg_power_sku;
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(xe);
+ 
+-	rapl_limit = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
+-	pkg_power_sku = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU, channel);
++	mutex_lock(&hwmon->hwmon_lock);
+ 
+-	/*
+-	 * Valid check of REG_PKG_RAPL_LIMIT is already done in xe_hwmon_power_is_visible.
+-	 * So not checking it again here.
+-	 */
+-	if (!xe_reg_is_valid(pkg_power_sku)) {
+-		drm_warn(&xe->drm, "pkg_power_sku invalid\n");
+-		*value = 0;
+-		return;
++	if (hwmon->xe->info.has_mbx_power_limits) {
++		xe_hwmon_pcode_read_power_limit(hwmon, attr, channel, (u32 *)&reg_val);
++	} else {
++		rapl_limit = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
++		pkg_power_sku = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU, channel);
++
++		/*
++		 * Valid check of REG_PKG_RAPL_LIMIT is already done in xe_hwmon_power_is_visible.
++		 * So not checking it again here.
++		 */
++		if (!xe_reg_is_valid(pkg_power_sku)) {
++			drm_warn(&xe->drm, "pkg_power_sku invalid\n");
++			*value = 0;
++			goto unlock;
++		}
++		reg_val = xe_mmio_read32(mmio, rapl_limit);
+ 	}
+ 
+-	mutex_lock(&hwmon->hwmon_lock);
+-
+-	reg_val = xe_mmio_read32(mmio, rapl_limit);
+-	/* Check if PL1 limit is disabled */
+-	if (!(reg_val & PKG_PWR_LIM_1_EN)) {
+-		*value = PL1_DISABLE;
++	/* Check if PL limits are disabled. */
++	if (!(reg_val & PWR_LIM_EN)) {
++		*value = PL_DISABLE;
++		drm_info(&hwmon->xe->drm, "%s disabled for channel %d, val 0x%016llx\n",
++			 PWR_ATTR_TO_STR(attr), channel, reg_val);
+ 		goto unlock;
+ 	}
+ 
+-	reg_val = REG_FIELD_GET(PKG_PWR_LIM_1, reg_val);
++	reg_val = REG_FIELD_GET(PWR_LIM_VAL, reg_val);
+ 	*value = mul_u64_u32_shr(reg_val, SF_POWER, hwmon->scl_shift_power);
+ 
+-	reg_val = xe_mmio_read64_2x32(mmio, pkg_power_sku);
+-	min = REG_FIELD_GET(PKG_MIN_PWR, reg_val);
+-	min = mul_u64_u32_shr(min, SF_POWER, hwmon->scl_shift_power);
+-	max = REG_FIELD_GET(PKG_MAX_PWR, reg_val);
+-	max = mul_u64_u32_shr(max, SF_POWER, hwmon->scl_shift_power);
+-
+-	if (min && max)
+-		*value = clamp_t(u64, *value, min, max);
++	/* For platforms with mailbox power limit support clamping would be done by pcode. */
++	if (!hwmon->xe->info.has_mbx_power_limits) {
++		reg_val = xe_mmio_read64_2x32(mmio, pkg_power_sku);
++		min = REG_FIELD_GET(PKG_MIN_PWR, reg_val);
++		max = REG_FIELD_GET(PKG_MAX_PWR, reg_val);
++		min = mul_u64_u32_shr(min, SF_POWER, hwmon->scl_shift_power);
++		max = mul_u64_u32_shr(max, SF_POWER, hwmon->scl_shift_power);
++		if (min && max)
++			*value = clamp_t(u64, *value, min, max);
++	}
+ unlock:
+ 	mutex_unlock(&hwmon->hwmon_lock);
+ }
+ 
+-static int xe_hwmon_power_max_write(struct xe_hwmon *hwmon, int channel, long value)
++static int xe_hwmon_power_max_write(struct xe_hwmon *hwmon, u32 attr, int channel, long value)
+ {
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+ 	int ret = 0;
+-	u64 reg_val;
++	u32 reg_val;
+ 	struct xe_reg rapl_limit;
+ 
++	mutex_lock(&hwmon->hwmon_lock);
++
+ 	rapl_limit = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
+ 
+-	mutex_lock(&hwmon->hwmon_lock);
++	/* Disable Power Limit and verify, as limit cannot be disabled on all platforms. */
++	if (value == PL_DISABLE) {
++		if (hwmon->xe->info.has_mbx_power_limits) {
++			drm_dbg(&hwmon->xe->drm, "disabling %s on channel %d\n",
++				PWR_ATTR_TO_STR(attr), channel);
++			xe_hwmon_pcode_write_power_limit(hwmon, attr, channel, 0);
++			xe_hwmon_pcode_read_power_limit(hwmon, attr, channel, &reg_val);
++		} else {
++			reg_val = xe_mmio_rmw32(mmio, rapl_limit, PWR_LIM_EN, 0);
++			reg_val = xe_mmio_read32(mmio, rapl_limit);
++		}
+ 
+-	/* Disable PL1 limit and verify, as limit cannot be disabled on all platforms */
+-	if (value == PL1_DISABLE) {
+-		reg_val = xe_mmio_rmw32(mmio, rapl_limit, PKG_PWR_LIM_1_EN, 0);
+-		reg_val = xe_mmio_read32(mmio, rapl_limit);
+-		if (reg_val & PKG_PWR_LIM_1_EN) {
+-			drm_warn(&hwmon->xe->drm, "PL1 disable is not supported!\n");
++		if (reg_val & PWR_LIM_EN) {
++			drm_warn(&hwmon->xe->drm, "Power limit disable is not supported!\n");
+ 			ret = -EOPNOTSUPP;
+ 		}
+ 		goto unlock;
+@@ -241,26 +339,50 @@ static int xe_hwmon_power_max_write(struct xe_hwmon *hwmon, int channel, long va
+ 
+ 	/* Computation in 64-bits to avoid overflow. Round to nearest. */
+ 	reg_val = DIV_ROUND_CLOSEST_ULL((u64)value << hwmon->scl_shift_power, SF_POWER);
+-	reg_val = PKG_PWR_LIM_1_EN | REG_FIELD_PREP(PKG_PWR_LIM_1, reg_val);
+-	reg_val = xe_mmio_rmw32(mmio, rapl_limit, PKG_PWR_LIM_1_EN | PKG_PWR_LIM_1, reg_val);
++	reg_val = PWR_LIM_EN | REG_FIELD_PREP(PWR_LIM_VAL, reg_val);
+ 
++	/*
++	 * Clamp power limit to card-firmware default as maximum, as an additional protection to
++	 * pcode clamp.
++	 */
++	if (hwmon->xe->info.has_mbx_power_limits) {
++		if (reg_val > REG_FIELD_GET(PWR_LIM_VAL, hwmon->pl1_on_boot[channel])) {
++			reg_val = REG_FIELD_GET(PWR_LIM_VAL, hwmon->pl1_on_boot[channel]);
++			drm_dbg(&hwmon->xe->drm, "Clamping power limit to firmware default 0x%x\n",
++				reg_val);
++		}
++	}
++
++	if (hwmon->xe->info.has_mbx_power_limits)
++		ret = xe_hwmon_pcode_write_power_limit(hwmon, attr, channel, reg_val);
++	else
++		reg_val = xe_mmio_rmw32(mmio, rapl_limit, PWR_LIM_EN | PWR_LIM_VAL,
++					reg_val);
+ unlock:
+ 	mutex_unlock(&hwmon->hwmon_lock);
+ 	return ret;
+ }
+ 
+-static void xe_hwmon_power_rated_max_read(struct xe_hwmon *hwmon, int channel, long *value)
++static void xe_hwmon_power_rated_max_read(struct xe_hwmon *hwmon, u32 attr, int channel,
++					  long *value)
+ {
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+-	struct xe_reg reg = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU, channel);
+-	u64 reg_val;
++	u32 reg_val;
++
++	if (hwmon->xe->info.has_mbx_power_limits) {
++		/* PL1 is rated max if supported. */
++		xe_hwmon_pcode_read_power_limit(hwmon, PL1_HWMON_ATTR, channel, &reg_val);
++	} else {
++		/*
++		 * This sysfs file won't be visible if REG_PKG_POWER_SKU is invalid, so valid check
++		 * for this register can be skipped.
++		 * See xe_hwmon_power_is_visible.
++		 */
++		struct xe_reg reg = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU, channel);
++
++		reg_val = xe_mmio_read32(mmio, reg);
++	}
+ 
+-	/*
+-	 * This sysfs file won't be visible if REG_PKG_POWER_SKU is invalid, so valid check
+-	 * for this register can be skipped.
+-	 * See xe_hwmon_power_is_visible.
+-	 */
+-	reg_val = xe_mmio_read32(mmio, reg);
+ 	reg_val = REG_FIELD_GET(PKG_TDP, reg_val);
+ 	*value = mul_u64_u32_shr(reg_val, SF_POWER, hwmon->scl_shift_power);
+ }
+@@ -314,23 +436,35 @@ xe_hwmon_power_max_interval_show(struct device *dev, struct device_attribute *at
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+ 	u32 x, y, x_w = 2; /* 2 bits */
+ 	u64 r, tau4, out;
+-	int sensor_index = to_sensor_dev_attr(attr)->index;
++	int channel = to_sensor_dev_attr(attr)->index;
++	u32 power_attr = PL1_HWMON_ATTR;
++	int ret = 0;
+ 
+ 	xe_pm_runtime_get(hwmon->xe);
+ 
+ 	mutex_lock(&hwmon->hwmon_lock);
+ 
+-	r = xe_mmio_read32(mmio, xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, sensor_index));
++	if (hwmon->xe->info.has_mbx_power_limits) {
++		ret = xe_hwmon_pcode_read_power_limit(hwmon, power_attr, channel, (u32 *)&r);
++		if (ret) {
++			drm_err(&hwmon->xe->drm,
++				"power interval read fail, ch %d, attr %d, r 0%llx, ret %d\n",
++				channel, power_attr, r, ret);
++			r = 0;
++		}
++	} else {
++		r = xe_mmio_read32(mmio, xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel));
++	}
+ 
+ 	mutex_unlock(&hwmon->hwmon_lock);
+ 
+ 	xe_pm_runtime_put(hwmon->xe);
+ 
+-	x = REG_FIELD_GET(PKG_PWR_LIM_1_TIME_X, r);
+-	y = REG_FIELD_GET(PKG_PWR_LIM_1_TIME_Y, r);
++	x = REG_FIELD_GET(PWR_LIM_TIME_X, r);
++	y = REG_FIELD_GET(PWR_LIM_TIME_Y, r);
+ 
+ 	/*
+-	 * tau = 1.x * power(2,y), x = bits(23:22), y = bits(21:17)
++	 * tau = (1 + (x / 4)) * power(2,y), x = bits(23:22), y = bits(21:17)
+ 	 *     = (4 | x) << (y - 2)
+ 	 *
+ 	 * Here (y - 2) ensures a 1.x fixed point representation of 1.x
+@@ -357,14 +491,15 @@ xe_hwmon_power_max_interval_store(struct device *dev, struct device_attribute *a
+ 	u64 tau4, r, max_win;
+ 	unsigned long val;
+ 	int ret;
+-	int sensor_index = to_sensor_dev_attr(attr)->index;
++	int channel = to_sensor_dev_attr(attr)->index;
++	u32 power_attr = PL1_HWMON_ATTR;
+ 
+ 	ret = kstrtoul(buf, 0, &val);
+ 	if (ret)
+ 		return ret;
+ 
+ 	/*
+-	 * Max HW supported tau in '1.x * power(2,y)' format, x = 0, y = 0x12.
++	 * Max HW supported tau in '(1 + (x / 4)) * power(2,y)' format, x = 0, y = 0x12.
+ 	 * The hwmon->scl_shift_time default of 0xa results in a max tau of 256 seconds.
+ 	 *
+ 	 * The ideal scenario is for PKG_MAX_WIN to be read from the PKG_PWR_SKU register.
+@@ -384,11 +519,13 @@ xe_hwmon_power_max_interval_store(struct device *dev, struct device_attribute *a
+ 	tau4 = (u64)((1 << x_w) | x) << y;
+ 	max_win = mul_u64_u32_shr(tau4, SF_TIME, hwmon->scl_shift_time + x_w);
+ 
+-	if (val > max_win)
++	if (val > max_win) {
++		drm_warn(&hwmon->xe->drm, "power_interval invalid val 0x%lx\n", val);
+ 		return -EINVAL;
++	}
+ 
+ 	/* val in hw units */
+-	val = DIV_ROUND_CLOSEST_ULL((u64)val << hwmon->scl_shift_time, SF_TIME);
++	val = DIV_ROUND_CLOSEST_ULL((u64)val << hwmon->scl_shift_time, SF_TIME) + 1;
+ 
+ 	/*
+ 	 * Convert val to 1.x * power(2,y)
+@@ -403,14 +540,21 @@ xe_hwmon_power_max_interval_store(struct device *dev, struct device_attribute *a
+ 		x = (val - (1ul << y)) << x_w >> y;
+ 	}
+ 
+-	rxy = REG_FIELD_PREP(PKG_PWR_LIM_1_TIME_X, x) | REG_FIELD_PREP(PKG_PWR_LIM_1_TIME_Y, y);
++	rxy = REG_FIELD_PREP(PWR_LIM_TIME_X, x) |
++			       REG_FIELD_PREP(PWR_LIM_TIME_Y, y);
+ 
+ 	xe_pm_runtime_get(hwmon->xe);
+ 
+ 	mutex_lock(&hwmon->hwmon_lock);
+ 
+-	r = xe_mmio_rmw32(mmio, xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, sensor_index),
+-			  PKG_PWR_LIM_1_TIME, rxy);
++	if (hwmon->xe->info.has_mbx_power_limits) {
++		ret = xe_hwmon_pcode_read_power_limit(hwmon, power_attr, channel, (u32 *)&r);
++		r = (r & ~PWR_LIM_TIME) | rxy;
++		xe_hwmon_pcode_write_power_limit(hwmon, power_attr, channel, r);
++	} else {
++		r = xe_mmio_rmw32(mmio, xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel),
++				  PWR_LIM_TIME, rxy);
++	}
+ 
+ 	mutex_unlock(&hwmon->hwmon_lock);
+ 
+@@ -419,6 +563,7 @@ xe_hwmon_power_max_interval_store(struct device *dev, struct device_attribute *a
+ 	return count;
+ }
+ 
++/* PSYS PL1 */
+ static SENSOR_DEVICE_ATTR(power1_max_interval, 0664,
+ 			  xe_hwmon_power_max_interval_show,
+ 			  xe_hwmon_power_max_interval_store, CHANNEL_CARD);
+@@ -439,10 +584,19 @@ static umode_t xe_hwmon_attributes_visible(struct kobject *kobj,
+ 	struct device *dev = kobj_to_dev(kobj);
+ 	struct xe_hwmon *hwmon = dev_get_drvdata(dev);
+ 	int ret = 0;
++	int channel = index ? CHANNEL_PKG : CHANNEL_CARD;
++	u32 power_attr = PL1_HWMON_ATTR;
++	u32 uval;
+ 
+ 	xe_pm_runtime_get(hwmon->xe);
+ 
+-	ret = xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, index)) ? attr->mode : 0;
++	if (hwmon->xe->info.has_mbx_power_limits) {
++		xe_hwmon_pcode_read_power_limit(hwmon, power_attr, channel, &uval);
++		ret = (uval & PWR_LIM_EN) ? attr->mode : 0;
++	} else {
++		ret = xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT,
++						       channel)) ? attr->mode : 0;
++	}
+ 
+ 	xe_pm_runtime_put(hwmon->xe);
+ 
+@@ -556,19 +710,27 @@ xe_hwmon_power_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
+ 
+ 	switch (attr) {
+ 	case hwmon_power_max:
+-		return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT,
++		if (hwmon->xe->info.has_mbx_power_limits) {
++			xe_hwmon_pcode_read_power_limit(hwmon, attr, channel, &uval);
++			return (uval) ? 0664 : 0;
++		} else {
++			return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT,
+ 				       channel)) ? 0664 : 0;
++		}
+ 	case hwmon_power_rated_max:
+-		return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU,
+-				       channel)) ? 0444 : 0;
++		if (hwmon->xe->info.has_mbx_power_limits)
++			return 0;
++		else
++			return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU,
++					       channel)) ? 0444 : 0;
+ 	case hwmon_power_crit:
+-		if (channel == CHANNEL_PKG)
+-			return (xe_hwmon_pcode_read_i1(hwmon, &uval) ||
+-				!(uval & POWER_SETUP_I1_WATTS)) ? 0 : 0644;
+-		break;
+ 	case hwmon_power_label:
+-		return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU_UNIT,
+-				       channel)) ? 0444 : 0;
++		if (channel == CHANNEL_PKG) {
++			xe_hwmon_pcode_read_i1(hwmon, &uval);
++			return (uval & POWER_SETUP_I1_WATTS) ? (attr == hwmon_power_label) ?
++				0444 : 0644 : 0;
++		}
++		break;
+ 	default:
+ 		return 0;
+ 	}
+@@ -580,10 +742,10 @@ xe_hwmon_power_read(struct xe_hwmon *hwmon, u32 attr, int channel, long *val)
+ {
+ 	switch (attr) {
+ 	case hwmon_power_max:
+-		xe_hwmon_power_max_read(hwmon, channel, val);
++		xe_hwmon_power_max_read(hwmon, attr, channel, val);
+ 		return 0;
+ 	case hwmon_power_rated_max:
+-		xe_hwmon_power_rated_max_read(hwmon, channel, val);
++		xe_hwmon_power_rated_max_read(hwmon, attr, channel, val);
+ 		return 0;
+ 	case hwmon_power_crit:
+ 		return xe_hwmon_power_curr_crit_read(hwmon, channel, val, SF_POWER);
+@@ -597,7 +759,7 @@ xe_hwmon_power_write(struct xe_hwmon *hwmon, u32 attr, int channel, long val)
+ {
+ 	switch (attr) {
+ 	case hwmon_power_max:
+-		return xe_hwmon_power_max_write(hwmon, channel, val);
++		return xe_hwmon_power_max_write(hwmon, attr, channel, val);
+ 	case hwmon_power_crit:
+ 		return xe_hwmon_power_curr_crit_write(hwmon, channel, val, SF_POWER);
+ 	default:
+@@ -906,18 +1068,42 @@ xe_hwmon_get_preregistration_info(struct xe_device *xe)
+ 	int channel;
+ 	struct xe_reg pkg_power_sku_unit;
+ 
+-	/*
+-	 * The contents of register PKG_POWER_SKU_UNIT do not change,
+-	 * so read it once and store the shift values.
+-	 */
+-	pkg_power_sku_unit = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU_UNIT, 0);
+-	if (xe_reg_is_valid(pkg_power_sku_unit)) {
+-		val_sku_unit = xe_mmio_read32(mmio, pkg_power_sku_unit);
+-		hwmon->scl_shift_power = REG_FIELD_GET(PKG_PWR_UNIT, val_sku_unit);
+-		hwmon->scl_shift_energy = REG_FIELD_GET(PKG_ENERGY_UNIT, val_sku_unit);
+-		hwmon->scl_shift_time = REG_FIELD_GET(PKG_TIME_UNIT, val_sku_unit);
++	if (hwmon->xe->info.has_mbx_power_limits) {
++		/* Check if card firmware support mailbox power limits commands. */
++		if (xe_hwmon_pcode_read_power_limit(hwmon, PL1_HWMON_ATTR, CHANNEL_CARD,
++						    &hwmon->pl1_on_boot[CHANNEL_CARD]) |
++		    xe_hwmon_pcode_read_power_limit(hwmon, PL1_HWMON_ATTR, CHANNEL_PKG,
++						    &hwmon->pl1_on_boot[CHANNEL_PKG])) {
++			drm_warn(&hwmon->xe->drm,
++				 "Failed to read power limits, check card firmware !\n");
++		} else {
++			drm_info(&hwmon->xe->drm, "Using mailbox commands for power limits\n");
++			/* Write default limits to read from pcode from now on. */
++			xe_hwmon_pcode_write_power_limit(hwmon, PL1_HWMON_ATTR,
++							 CHANNEL_CARD,
++							 hwmon->pl1_on_boot[CHANNEL_CARD]);
++			xe_hwmon_pcode_write_power_limit(hwmon, PL1_HWMON_ATTR,
++							 CHANNEL_PKG,
++							 hwmon->pl1_on_boot[CHANNEL_PKG]);
++			hwmon->scl_shift_power = PWR_UNIT;
++			hwmon->scl_shift_energy = ENERGY_UNIT;
++			hwmon->scl_shift_time = TIME_UNIT;
++			hwmon->boot_power_limit_read = true;
++		}
++	} else {
++		drm_info(&hwmon->xe->drm, "Using register for power limits\n");
++		/*
++		 * The contents of register PKG_POWER_SKU_UNIT do not change,
++		 * so read it once and store the shift values.
++		 */
++		pkg_power_sku_unit = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU_UNIT, 0);
++		if (xe_reg_is_valid(pkg_power_sku_unit)) {
++			val_sku_unit = xe_mmio_read32(mmio, pkg_power_sku_unit);
++			hwmon->scl_shift_power = REG_FIELD_GET(PKG_PWR_UNIT, val_sku_unit);
++			hwmon->scl_shift_energy = REG_FIELD_GET(PKG_ENERGY_UNIT, val_sku_unit);
++			hwmon->scl_shift_time = REG_FIELD_GET(PKG_TIME_UNIT, val_sku_unit);
++		}
+ 	}
+-
+ 	/*
+ 	 * Initialize 'struct xe_hwmon_energy_info', i.e. set fields to the
+ 	 * first value of the energy register read
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index e0971b3a24a5..362a79b8ef0a 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -63,6 +63,7 @@ struct xe_device_desc {
+ 	u8 has_heci_cscfi:1;
+ 	u8 has_llc:1;
+ 	u8 has_mmio_ext:1;
++	u8 has_mbx_power_limits:1;
+ 	u8 has_sriov:1;
+ 	u8 skip_guc_pc:1;
+ 	u8 skip_mtcfg:1;
+@@ -318,6 +319,7 @@ static const struct xe_device_desc dg2_desc = {
+ 	DG2_FEATURES,
+ 	.has_display = true,
+ 	.has_fan_control = true,
++	.has_mbx_power_limits = false,
+ };
+ 
+ static const __maybe_unused struct xe_device_desc pvc_desc = {
+@@ -327,6 +329,7 @@ static const __maybe_unused struct xe_device_desc pvc_desc = {
+ 	.has_display = false,
+ 	.has_heci_gscfi = 1,
+ 	.require_force_probe = true,
++	.has_mbx_power_limits = false,
+ };
+ 
+ static const struct xe_device_desc mtl_desc = {
+@@ -346,6 +349,7 @@ static const struct xe_device_desc bmg_desc = {
+ 	PLATFORM(BATTLEMAGE),
+ 	.has_display = true,
+ 	.has_fan_control = true,
++	.has_mbx_power_limits = true,
+ 	.has_heci_cscfi = 1,
+ };
+ 
+@@ -618,6 +622,7 @@ static int xe_info_init_early(struct xe_device *xe,
+ 
+ 	xe->info.is_dgfx = desc->is_dgfx;
+ 	xe->info.has_fan_control = desc->has_fan_control;
++	xe->info.has_mbx_power_limits = desc->has_mbx_power_limits;
+ 	xe->info.has_heci_gscfi = desc->has_heci_gscfi;
+ 	xe->info.has_heci_cscfi = desc->has_heci_cscfi;
+ 	xe->info.has_llc = desc->has_llc;
+diff --git a/drivers/gpu/drm/xe/xe_pcode.c b/drivers/gpu/drm/xe/xe_pcode.c
+index 9333ce776a6e..5ff2d0e45ab7 100644
+--- a/drivers/gpu/drm/xe/xe_pcode.c
++++ b/drivers/gpu/drm/xe/xe_pcode.c
+@@ -108,6 +108,17 @@ int xe_pcode_write_timeout(struct xe_tile *tile, u32 mbox, u32 data, int timeout
+ 	return err;
+ }
+ 
++int xe_pcode_write64_timeout(struct xe_tile *tile, u32 mbox, u32 data0, u32 data1, int timeout)
++{
++	int err;
++
++	mutex_lock(&tile->pcode.lock);
++	err = pcode_mailbox_rw(tile, mbox, &data0, &data1, timeout, false, false);
++	mutex_unlock(&tile->pcode.lock);
++
++	return err;
++}
++
+ int xe_pcode_read(struct xe_tile *tile, u32 mbox, u32 *val, u32 *val1)
+ {
+ 	int err;
+diff --git a/drivers/gpu/drm/xe/xe_pcode.h b/drivers/gpu/drm/xe/xe_pcode.h
+index ba33991d72a7..de38f44f3201 100644
+--- a/drivers/gpu/drm/xe/xe_pcode.h
++++ b/drivers/gpu/drm/xe/xe_pcode.h
+@@ -18,6 +18,9 @@ int xe_pcode_init_min_freq_table(struct xe_tile *tile, u32 min_gt_freq,
+ int xe_pcode_read(struct xe_tile *tile, u32 mbox, u32 *val, u32 *val1);
+ int xe_pcode_write_timeout(struct xe_tile *tile, u32 mbox, u32 val,
+ 			   int timeout_ms);
++int xe_pcode_write64_timeout(struct xe_tile *tile, u32 mbox, u32 data0,
++			     u32 data1, int timeout);
++
+ #define xe_pcode_write(tile, mbox, val) \
+ 	xe_pcode_write_timeout(tile, mbox, val, 1)
+ 
+diff --git a/drivers/gpu/drm/xe/xe_pcode_api.h b/drivers/gpu/drm/xe/xe_pcode_api.h
+index 0d737b780f88..9a5dd9c469fe 100644
+--- a/drivers/gpu/drm/xe/xe_pcode_api.h
++++ b/drivers/gpu/drm/xe/xe_pcode_api.h
+@@ -43,6 +43,13 @@
+ #define	    POWER_SETUP_I1_SHIFT		6	/* 10.6 fixed point format */
+ #define	    POWER_SETUP_I1_DATA_MASK		REG_GENMASK(15, 0)
+ 
++#define	READ_PSYSGPU_POWER_LIMIT		0x6
++#define	WRITE_PSYSGPU_POWER_LIMIT		0x7
++#define	READ_PACKAGE_POWER_LIMIT		0x8
++#define	WRITE_PACKAGE_POWER_LIMIT		0x9
++#define	READ_PL_FROM_FW				0x1
++#define	READ_PL_FROM_PCODE			0x0
++
+ #define   PCODE_FREQUENCY_CONFIG		0x6e
+ /* Frequency Config Sub Commands (param1) */
+ #define     PCODE_MBOX_FC_SC_READ_FUSED_P0	0x0
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-hwmon-Expose-power-sysfs-entries-based-on-fir.patch
+++ b/backport/patches/base/0001-drm-xe-hwmon-Expose-power-sysfs-entries-based-on-fir.patch
@@ -1,0 +1,145 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Karthik Poosa <karthik.poosa@intel.com>
+Date: Thu, 29 May 2025 22:04:58 +0530
+Subject: drm/xe/hwmon: Expose power sysfs entries based on firmware
+ support
+
+Enable hwmon sysfs entries (power_xxx) only when GPU firmware
+supports it.
+Previously, these entries were created if the MMIO register
+was present. Now, we enable based on the data in the register.
+
+v2: Remove a unnecessary comment. (Rodrigo)
+
+Signed-off-by: Karthik Poosa <karthik.poosa@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://lore.kernel.org/r/20250529163458.2354509-7-karthik.poosa@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry picked from commit 48a1126836cc3b7e63c31730dcd34df0d82176cd linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_hwmon.c | 63 ++++++++++++++++++++---------------
+ 1 file changed, 37 insertions(+), 26 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index 91052ca07a9c..4212b1a4a392 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -282,16 +282,6 @@ static void xe_hwmon_power_max_read(struct xe_hwmon *hwmon, u32 attr, int channe
+ 	} else {
+ 		rapl_limit = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
+ 		pkg_power_sku = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU, channel);
+-
+-		/*
+-		 * Valid check of REG_PKG_RAPL_LIMIT is already done in xe_hwmon_power_is_visible.
+-		 * So not checking it again here.
+-		 */
+-		if (!xe_reg_is_valid(pkg_power_sku)) {
+-			drm_warn(&xe->drm, "pkg_power_sku invalid\n");
+-			*value = 0;
+-			goto unlock;
+-		}
+ 		reg_val = xe_mmio_read32(mmio, rapl_limit);
+ 	}
+ 
+@@ -636,17 +626,20 @@ static umode_t xe_hwmon_attributes_visible(struct kobject *kobj,
+ 	int ret = 0;
+ 	int channel = (index % 2) ? CHANNEL_PKG : CHANNEL_CARD;
+ 	u32 power_attr = (index > 1) ? PL2_HWMON_ATTR : PL1_HWMON_ATTR;
+-	u32 uval;
++	u32 uval = 0;
++	struct xe_reg rapl_limit;
++	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+ 
+ 	xe_pm_runtime_get(hwmon->xe);
+ 
+ 	if (hwmon->xe->info.has_mbx_power_limits) {
+ 		xe_hwmon_pcode_read_power_limit(hwmon, power_attr, channel, &uval);
+-		ret = (uval & PWR_LIM_EN) ? attr->mode : 0;
+ 	} else if (power_attr != PL2_HWMON_ATTR) {
+-		ret = xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT,
+-						       channel)) ? attr->mode : 0;
++		rapl_limit = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
++		if (xe_reg_is_valid(rapl_limit))
++			uval = xe_mmio_read32(mmio, rapl_limit);
+ 	}
++	ret = (uval & PWR_LIM_EN) ? attr->mode : 0;
+ 
+ 	xe_pm_runtime_put(hwmon->xe);
+ 
+@@ -758,24 +751,20 @@ static umode_t
+ xe_hwmon_power_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
+ {
+ 	u32 uval = 0;
+-	struct xe_reg rapl_limit;
++	struct xe_reg reg;
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+ 
+ 	switch (attr) {
+ 	case hwmon_power_max:
+ 	case hwmon_power_cap:
+-	case hwmon_power_label:
+ 		if (hwmon->xe->info.has_mbx_power_limits) {
+ 			xe_hwmon_pcode_read_power_limit(hwmon, attr, channel, &uval);
+ 		} else if (attr != PL2_HWMON_ATTR) {
+-			rapl_limit = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
+-			if (xe_reg_is_valid(rapl_limit))
+-				uval = xe_mmio_read32(mmio, rapl_limit);
++			reg = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
++			if (xe_reg_is_valid(reg))
++				uval = xe_mmio_read32(mmio, reg);
+ 		}
+ 		if (uval & PWR_LIM_EN) {
+-			if (attr == hwmon_power_label)
+-				return 0444;
+-
+ 			drm_info(&hwmon->xe->drm, "%s is supported on channel %d\n",
+ 				 PWR_ATTR_TO_STR(attr), channel);
+ 			return 0664;
+@@ -784,17 +773,39 @@ xe_hwmon_power_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
+ 			PWR_ATTR_TO_STR(attr), channel);
+ 		return 0;
+ 	case hwmon_power_rated_max:
+-		if (hwmon->xe->info.has_mbx_power_limits)
++		if (hwmon->xe->info.has_mbx_power_limits) {
+ 			return 0;
+-		else
+-			return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU,
+-					       channel)) ? 0444 : 0;
++		} else {
++			reg = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU, channel);
++			if (xe_reg_is_valid(reg))
++				uval = xe_mmio_read32(mmio, reg);
++			return uval ? 0444 : 0;
++		}
+ 	case hwmon_power_crit:
+ 		if (channel == CHANNEL_CARD) {
+ 			xe_hwmon_pcode_read_i1(hwmon, &uval);
+ 			return (uval & POWER_SETUP_I1_WATTS) ? 0644 : 0;
+ 		}
+ 		break;
++	case hwmon_power_label:
++		if (hwmon->xe->info.has_mbx_power_limits) {
++			xe_hwmon_pcode_read_power_limit(hwmon, attr, channel, &uval);
++		} else {
++			reg = xe_hwmon_get_reg(hwmon, REG_PKG_POWER_SKU, channel);
++			if (xe_reg_is_valid(reg))
++				uval = xe_mmio_read32(mmio, reg);
++
++			if (!uval) {
++				reg = xe_hwmon_get_reg(hwmon, REG_PKG_RAPL_LIMIT, channel);
++				if (xe_reg_is_valid(reg))
++					uval = xe_mmio_read32(mmio, reg);
++			}
++		}
++		if ((!(uval & PWR_LIM_EN)) && channel == CHANNEL_CARD) {
++			xe_hwmon_pcode_read_i1(hwmon, &uval);
++			return (uval & POWER_SETUP_I1_WATTS) ? 0444 : 0;
++		}
++		return (uval) ? 0444 : 0;
+ 	default:
+ 		return 0;
+ 	}
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-hwmon-Expose-powerX_cap_interval.patch
+++ b/backport/patches/base/0001-drm-xe-hwmon-Expose-powerX_cap_interval.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Karthik Poosa <karthik.poosa@intel.com>
+Date: Thu, 29 May 2025 22:04:56 +0530
+Subject: drm/xe/hwmon: Expose powerX_cap_interval
+
+Expose powerX_cap_interval to manage burst power limit time window.
+
+Signed-off-by: Karthik Poosa <karthik.poosa@intel.com>
+Reviewed-by: Badal Nilawar <badal.nilawar@intel.com>
+Link: https://lore.kernel.org/r/20250529163458.2354509-5-karthik.poosa@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry picked from commit 719d8a59595287557352893478f0c4e0df32b107 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ .../ABI/testing/sysfs-driver-intel-xe-hwmon    | 18 ++++++++++++++++++
+ drivers/gpu/drm/xe/xe_hwmon.c                  | 16 +++++++++++++---
+ 2 files changed, 31 insertions(+), 3 deletions(-)
+
+diff --git a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
+index 3ebb1d48e797..e9f72147e3dd 100644
+--- a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
++++ b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
+@@ -162,3 +162,21 @@ Description:	RW. Package burst (PL2) power limit in microwatts.
+ 		compared to PL1.
+ 
+ 		Only supported for particular Intel Xe graphics platforms.
++
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/power1_cap_interval
++Date:		May 2025
++KernelVersion:	6.15
++Contact:	intel-xe@lists.freedesktop.org
++Description:	RW. Card burst power limit interval (Tau in PL2/Tau) in
++		milliseconds over which sustained power is averaged.
++
++		Only supported for particular Intel Xe graphics platforms.
++
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/power2_cap_interval
++Date:		May 2025
++KernelVersion:	6.15
++Contact:	intel-xe@lists.freedesktop.org
++Description:	RW. Package burst power limit interval (Tau in PL2/Tau) in
++		milliseconds over which sustained power is averaged.
++
++		Only supported for particular Intel Xe graphics platforms.
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index 384981b74632..451cea26a443 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -458,7 +458,7 @@ xe_hwmon_power_max_interval_show(struct device *dev, struct device_attribute *at
+ 	u32 x, y, x_w = 2; /* 2 bits */
+ 	u64 r, tau4, out;
+ 	int channel = (to_sensor_dev_attr(attr)->index % 2) ? CHANNEL_PKG : CHANNEL_CARD;
+-	u32 power_attr = PL1_HWMON_ATTR;
++	u32 power_attr = (to_sensor_dev_attr(attr)->index > 1) ? PL2_HWMON_ATTR : PL1_HWMON_ATTR;
+ 
+ 	int ret = 0;
+ 
+@@ -513,7 +513,7 @@ xe_hwmon_power_max_interval_store(struct device *dev, struct device_attribute *a
+ 	u64 tau4, r, max_win;
+ 	unsigned long val;
+ 	int channel = (to_sensor_dev_attr(attr)->index % 2) ? CHANNEL_PKG : CHANNEL_CARD;
+-	u32 power_attr = PL1_HWMON_ATTR;
++	u32 power_attr = (to_sensor_dev_attr(attr)->index > 1) ? PL2_HWMON_ATTR : PL1_HWMON_ATTR;
+ 	int ret;
+ 
+ 	ret = kstrtoul(buf, 0, &val);
+@@ -591,10 +591,20 @@ static SENSOR_DEVICE_ATTR(power1_max_interval, 0664,
+ static SENSOR_DEVICE_ATTR(power2_max_interval, 0664,
+ 			  xe_hwmon_power_max_interval_show,
+ 			  xe_hwmon_power_max_interval_store, SENSOR_INDEX_PKG_PL1);
++/* PSYS PL2 */
++static SENSOR_DEVICE_ATTR(power1_cap_interval, 0664,
++			  xe_hwmon_power_max_interval_show,
++			  xe_hwmon_power_max_interval_store, SENSOR_INDEX_PSYS_PL2);
++/* PKG PL2 */
++static SENSOR_DEVICE_ATTR(power2_cap_interval, 0664,
++			  xe_hwmon_power_max_interval_show,
++			  xe_hwmon_power_max_interval_store, SENSOR_INDEX_PKG_PL2);
+ 
+ static struct attribute *hwmon_attributes[] = {
+ 	&sensor_dev_attr_power1_max_interval.dev_attr.attr,
+ 	&sensor_dev_attr_power2_max_interval.dev_attr.attr,
++	&sensor_dev_attr_power1_cap_interval.dev_attr.attr,
++	&sensor_dev_attr_power2_cap_interval.dev_attr.attr,
+ 	NULL
+ };
+ 
+@@ -605,7 +615,7 @@ static umode_t xe_hwmon_attributes_visible(struct kobject *kobj,
+ 	struct xe_hwmon *hwmon = dev_get_drvdata(dev);
+ 	int ret = 0;
+ 	int channel = (index % 2) ? CHANNEL_PKG : CHANNEL_CARD;
+-	u32 power_attr = PL1_HWMON_ATTR;
++	u32 power_attr = (index > 1) ? PL2_HWMON_ATTR : PL1_HWMON_ATTR;
+ 	u32 uval;
+ 
+ 	xe_pm_runtime_get(hwmon->xe);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-hwmon-Move-card-reactive-critical-power-under.patch
+++ b/backport/patches/base/0001-drm-xe-hwmon-Move-card-reactive-critical-power-under.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Karthik Poosa <karthik.poosa@intel.com>
+Date: Thu, 29 May 2025 22:04:54 +0530
+Subject: drm/xe/hwmon: Move card reactive critical power under channel
+ card
+
+Move power2/curr2_crit to channel 1 i.e power1/curr1_crit as this
+represents the entire card critical power/current.
+
+v2: Update the date of curr1_crit also in hwmon documentation.
+
+Signed-off-by: Karthik Poosa <karthik.poosa@intel.com>
+Fixes: 345dadc4f68b ("drm/xe/hwmon: Add infra to support card power and energy attributes")
+Reviewed-by: Badal Nilawar <badal.nilawar@intel.com>
+Link: https://lore.kernel.org/r/20250529163458.2354509-3-karthik.poosa@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 25e963a09e059ffdb15c09cc79cfded855b43668 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ .../ABI/testing/sysfs-driver-intel-xe-hwmon   | 20 +++++++++----------
+ drivers/gpu/drm/xe/xe_hwmon.c                 |  6 +++---
+ 2 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
+index 149e4adbfdac..ae842728c293 100644
+--- a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
++++ b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
+@@ -60,26 +60,26 @@ Description:	RO. Package default power limit (default TDP setting).
+ 
+ 		Only supported for particular Intel Xe graphics platforms.
+ 
+-What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/power2_crit
+-Date:		February 2024
+-KernelVersion:	6.8
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/power1_crit
++Date:		May 2025
++KernelVersion:	6.15
+ Contact:	intel-xe@lists.freedesktop.org
+-Description:	RW. Package reactive critical (I1) power limit in microwatts.
++Description:	RW. Card reactive critical (I1) power limit in microwatts.
+ 
+-		Package reactive critical (I1) power limit in microwatts is exposed
++		Card reactive critical (I1) power limit in microwatts is exposed
+ 		for client products. The power controller will throttle the
+ 		operating frequency if the power averaged over a window exceeds
+ 		this limit.
+ 
+ 		Only supported for particular Intel Xe graphics platforms.
+ 
+-What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/curr2_crit
+-Date:		February 2024
+-KernelVersion:	6.8
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/curr1_crit
++Date:		May 2025
++KernelVersion:	6.15
+ Contact:	intel-xe@lists.freedesktop.org
+-Description:	RW. Package reactive critical (I1) power limit in milliamperes.
++Description:	RW. Card reactive critical (I1) power limit in milliamperes.
+ 
+-		Package reactive critical (I1) power limit in milliamperes is
++		Card reactive critical (I1) power limit in milliamperes is
+ 		exposed for server products. The power controller will throttle
+ 		the operating frequency if the power averaged over a window
+ 		exceeds this limit.
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index c3d0cebe3713..178d0b7c3d01 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -614,8 +614,8 @@ static const struct attribute_group *hwmon_groups[] = {
+ };
+ 
+ static const struct hwmon_channel_info * const hwmon_info[] = {
+-	HWMON_CHANNEL_INFO(power, HWMON_P_MAX | HWMON_P_RATED_MAX | HWMON_P_LABEL,
+-			   HWMON_P_MAX | HWMON_P_RATED_MAX | HWMON_P_CRIT | HWMON_P_LABEL),
++	HWMON_CHANNEL_INFO(power, HWMON_P_MAX | HWMON_P_RATED_MAX | HWMON_P_LABEL | HWMON_P_CRIT,
++			   HWMON_P_MAX | HWMON_P_RATED_MAX | HWMON_P_LABEL),
+ 	HWMON_CHANNEL_INFO(curr, HWMON_C_LABEL, HWMON_C_CRIT | HWMON_C_LABEL),
+ 	HWMON_CHANNEL_INFO(in, HWMON_I_INPUT | HWMON_I_LABEL, HWMON_I_INPUT | HWMON_I_LABEL),
+ 	HWMON_CHANNEL_INFO(energy, HWMON_E_INPUT | HWMON_E_LABEL, HWMON_E_INPUT | HWMON_E_LABEL),
+@@ -725,7 +725,7 @@ xe_hwmon_power_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
+ 					       channel)) ? 0444 : 0;
+ 	case hwmon_power_crit:
+ 	case hwmon_power_label:
+-		if (channel == CHANNEL_PKG) {
++		if (channel == CHANNEL_CARD) {
+ 			xe_hwmon_pcode_read_i1(hwmon, &uval);
+ 			return (uval & POWER_SETUP_I1_WATTS) ? (attr == hwmon_power_label) ?
+ 				0444 : 0644 : 0;
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-hwmon-Read-energy-status-from-PMT.patch
+++ b/backport/patches/base/0001-drm-xe-hwmon-Read-energy-status-from-PMT.patch
@@ -1,0 +1,193 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Karthik Poosa <karthik.poosa@intel.com>
+Date: Thu, 29 May 2025 22:04:57 +0530
+Subject: drm/xe/hwmon: Read energy status from PMT
+
+Read card and package energy status using pmt apis instead
+of xe_mmio for supported platforms.
+Enable Battlemage to read energy from PMT.
+
+v2:
+ - Remove unused has_pmt_energy field. (Badal)
+ - Use GENMASK to extract energy data. (Badal)
+
+v3:
+ - Move PMT energy register offset and GENMASK to xe_pmt.h
+ - Address review comments. (Jani)
+
+v4:
+ - Remove unnecessary debug print. (Badal)
+
+v5:
+ - Resolve an unused variable warning.
+ - Add a return value check.
+
+Signed-off-by: Karthik Poosa <karthik.poosa@intel.com>
+Reviewed-by: Badal Nilawar <badal.nilawar@intel.com>
+Link: https://lore.kernel.org/r/20250529163458.2354509-6-karthik.poosa@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 0c5405d3aa4ad871837bb1261f4128de09680c83 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_pcode_regs.h |  2 -
+ drivers/gpu/drm/xe/regs/xe_pmt.h        |  5 +++
+ drivers/gpu/drm/xe/xe_hwmon.c           | 49 +++++++++++++++++++------
+ drivers/gpu/drm/xe/xe_vsec.c            |  4 +-
+ drivers/gpu/drm/xe/xe_vsec.h            |  4 ++
+ 5 files changed, 49 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
+index db552b9fd1b1..a60f7f447a26 100644
+--- a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
+@@ -18,10 +18,8 @@
+ #define PVC_GT0_PLATFORM_ENERGY_STATUS          XE_REG(0x28106c)
+ #define PVC_GT0_PACKAGE_POWER_SKU               XE_REG(0x281080)
+ 
+-#define BMG_PACKAGE_ENERGY_STATUS		XE_REG(0x138120)
+ #define BMG_FAN_1_SPEED				XE_REG(0x138140)
+ #define BMG_FAN_2_SPEED				XE_REG(0x138170)
+ #define BMG_FAN_3_SPEED				XE_REG(0x1381a0)
+-#define BMG_PLATFORM_ENERGY_STATUS		XE_REG(0x138458)
+ 
+ #endif /* _XE_PCODE_REGS_H_ */
+diff --git a/drivers/gpu/drm/xe/regs/xe_pmt.h b/drivers/gpu/drm/xe/regs/xe_pmt.h
+index f45abcd96ba8..b0efd9b48d1e 100644
+--- a/drivers/gpu/drm/xe/regs/xe_pmt.h
++++ b/drivers/gpu/drm/xe/regs/xe_pmt.h
+@@ -10,6 +10,11 @@
+ #define BMG_PMT_BASE_OFFSET		0xDB000
+ #define BMG_DISCOVERY_OFFSET		(SOC_BASE + BMG_PMT_BASE_OFFSET)
+ 
++#define PUNIT_TELEMETRY_GUID		XE_REG(BMG_DISCOVERY_OFFSET + 0x4)
++#define BMG_ENERGY_STATUS_PMT_OFFSET	(0x30)
++#define	ENERGY_PKG			REG_GENMASK64(31, 0)
++#define	ENERGY_CARD			REG_GENMASK64(63, 32)
++
+ #define BMG_TELEMETRY_BASE_OFFSET	0xE0000
+ #define BMG_TELEMETRY_OFFSET		(SOC_BASE + BMG_TELEMETRY_BASE_OFFSET)
+ 
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index 451cea26a443..91052ca07a9c 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -19,6 +19,8 @@
+ #include "xe_pcode_api.h"
+ #include "xe_sriov.h"
+ #include "xe_pm.h"
++#include "xe_vsec.h"
++#include "regs/xe_pmt.h"
+ 
+ enum xe_hwmon_reg {
+ 	REG_PKG_RAPL_LIMIT,
+@@ -236,12 +238,7 @@ static struct xe_reg xe_hwmon_get_reg(struct xe_hwmon *hwmon, enum xe_hwmon_reg
+ 			return GT_PERF_STATUS;
+ 		break;
+ 	case REG_PKG_ENERGY_STATUS:
+-		if (xe->info.platform == XE_BATTLEMAGE) {
+-			if (channel == CHANNEL_PKG)
+-				return BMG_PACKAGE_ENERGY_STATUS;
+-			else
+-				return BMG_PLATFORM_ENERGY_STATUS;
+-		} else if (xe->info.platform == XE_PVC && channel == CHANNEL_PKG) {
++		if (xe->info.platform == XE_PVC && channel == CHANNEL_PKG) {
+ 			return PVC_GT0_PLATFORM_ENERGY_STATUS;
+ 		} else if ((xe->info.platform == XE_DG2) && (channel == CHANNEL_PKG)) {
+ 			return PCU_CR_PACKAGE_ENERGY_STATUS;
+@@ -434,9 +431,32 @@ xe_hwmon_energy_get(struct xe_hwmon *hwmon, int channel, long *energy)
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
+ 	struct xe_hwmon_energy_info *ei = &hwmon->ei[channel];
+ 	u64 reg_val;
++	int ret = 0;
++
++	/* Energy is supported only for card and pkg */
++	if (channel > CHANNEL_PKG) {
++		*energy = 0;
++		return;
++	}
+ 
+-	reg_val = xe_mmio_read32(mmio, xe_hwmon_get_reg(hwmon, REG_PKG_ENERGY_STATUS,
+-							channel));
++	if (hwmon->xe->info.platform == XE_BATTLEMAGE) {
++		ret = xe_pmt_telem_read(to_pci_dev(hwmon->xe->drm.dev),
++					xe_mmio_read32(mmio, PUNIT_TELEMETRY_GUID),
++					&reg_val, BMG_ENERGY_STATUS_PMT_OFFSET,	sizeof(reg_val));
++		if (ret != sizeof(reg_val)) {
++			drm_warn(&hwmon->xe->drm, "energy read from pmt failed, ret %d\n", ret);
++			*energy = 0;
++			return;
++		}
++
++		if (channel == CHANNEL_PKG)
++			reg_val = REG_FIELD_GET64(ENERGY_PKG, reg_val);
++		else
++			reg_val = REG_FIELD_GET64(ENERGY_CARD, reg_val);
++	} else {
++		reg_val = xe_mmio_read32(mmio, xe_hwmon_get_reg(hwmon, REG_PKG_ENERGY_STATUS,
++								channel));
++	}
+ 
+ 	if (reg_val >= ei->reg_val_prev)
+ 		ei->accum_energy += reg_val - ei->reg_val_prev;
+@@ -886,11 +906,18 @@ xe_hwmon_in_read(struct xe_hwmon *hwmon, u32 attr, int channel, long *val)
+ static umode_t
+ xe_hwmon_energy_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
+ {
++	long energy = 0;
++
+ 	switch (attr) {
+ 	case hwmon_energy_input:
+ 	case hwmon_energy_label:
+-		return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_ENERGY_STATUS,
+-				       channel)) ? 0444 : 0;
++		if (hwmon->xe->info.platform == XE_BATTLEMAGE) {
++			xe_hwmon_energy_get(hwmon, channel, &energy);
++			return energy ? 0444 : 0;
++		} else {
++			return xe_reg_is_valid(xe_hwmon_get_reg(hwmon, REG_PKG_ENERGY_STATUS,
++					       channel)) ? 0444 : 0;
++		}
+ 	default:
+ 		return 0;
+ 	}
+@@ -1222,4 +1249,4 @@ void xe_hwmon_register(struct xe_device *xe)
+ 		return;
+ 	}
+ }
+-
++MODULE_IMPORT_NS("INTEL_PMT_TELEMETRY");
+diff --git a/drivers/gpu/drm/xe/xe_vsec.c b/drivers/gpu/drm/xe/xe_vsec.c
+index b378848d3b7b..3e573b0b7ebd 100644
+--- a/drivers/gpu/drm/xe/xe_vsec.c
++++ b/drivers/gpu/drm/xe/xe_vsec.c
+@@ -149,8 +149,8 @@ static int xe_guid_decode(u32 guid, int *index, u32 *offset)
+ 	return 0;
+ }
+ 
+-static int xe_pmt_telem_read(struct pci_dev *pdev, u32 guid, u64 *data, loff_t user_offset,
+-			     u32 count)
++int xe_pmt_telem_read(struct pci_dev *pdev, u32 guid, u64 *data, loff_t user_offset,
++		      u32 count)
+ {
+ 	struct xe_device *xe = pdev_to_xe_device(pdev);
+ 	void __iomem *telem_addr = xe->mmio.regs + BMG_TELEMETRY_OFFSET;
+diff --git a/drivers/gpu/drm/xe/xe_vsec.h b/drivers/gpu/drm/xe/xe_vsec.h
+index 5777c53faec2..dabfb4e02d70 100644
+--- a/drivers/gpu/drm/xe/xe_vsec.h
++++ b/drivers/gpu/drm/xe/xe_vsec.h
+@@ -4,8 +4,12 @@
+ #ifndef _XE_VSEC_H_
+ #define _XE_VSEC_H_
+ 
++#include <linux/types.h>
++
++struct pci_dev;
+ struct xe_device;
+ 
+ void xe_vsec_init(struct xe_device *xe);
++int xe_pmt_telem_read(struct pci_dev *pdev, u32 guid, u64 *data, loff_t user_offset, u32 count);
+ 
+ #endif
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-hwmon-expose-fan-speed.patch
+++ b/backport/patches/base/0001-drm-xe-hwmon-expose-fan-speed.patch
@@ -1,0 +1,360 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Wed, 12 Mar 2025 14:29:09 +0530
+Subject: drm/xe/hwmon: expose fan speed
+
+Add hwmon support for fan1_input, fan2_input and fan3_input attributes,
+which will expose fan speed of respective channels in RPM when supported
+by hardware. With this in place we can monitor fan speed using lm-sensors
+tool.
+
+v2: Rely on platform checks instead of mailbox error (Aravind, Rodrigo)
+v3: Introduce has_fan_control flag (Rodrigo)
+
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Andi Shyti <andi.shyti@linux.intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250312085909.755073-1-raag.jadav@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 28f79ac609de2797cccdd5fa6c4d5ec8bcef92b4 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ .../ABI/testing/sysfs-driver-intel-xe-hwmon   |  24 ++++
+ drivers/gpu/drm/xe/regs/xe_pcode_regs.h       |   3 +
+ drivers/gpu/drm/xe/xe_device_types.h          |   2 +
+ drivers/gpu/drm/xe/xe_hwmon.c                 | 125 +++++++++++++++++-
+ drivers/gpu/drm/xe/xe_pci.c                   |   4 +
+ drivers/gpu/drm/xe/xe_pcode_api.h             |   3 +
+ 6 files changed, 160 insertions(+), 1 deletion(-)
+
+diff --git a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
+index d792a56f59ac..149e4adbfdac 100644
+--- a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
++++ b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
+@@ -108,3 +108,27 @@ Contact:	intel-xe@lists.freedesktop.org
+ Description:	RO. Package current voltage in millivolt.
+ 
+ 		Only supported for particular Intel Xe graphics platforms.
++
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan1_input
++Date:		March 2025
++KernelVersion:	6.14
++Contact:	intel-xe@lists.freedesktop.org
++Description:	RO. Fan 1 speed in RPM.
++
++		Only supported for particular Intel Xe graphics platforms.
++
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan2_input
++Date:		March 2025
++KernelVersion:	6.14
++Contact:	intel-xe@lists.freedesktop.org
++Description:	RO. Fan 2 speed in RPM.
++
++		Only supported for particular Intel Xe graphics platforms.
++
++What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan3_input
++Date:		March 2025
++KernelVersion:	6.14
++Contact:	intel-xe@lists.freedesktop.org
++Description:	RO. Fan 3 speed in RPM.
++
++		Only supported for particular Intel Xe graphics platforms.
+diff --git a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
+index 0b0b49d850ae..254e15a90c49 100644
+--- a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
+@@ -21,6 +21,9 @@
+ #define BMG_PACKAGE_POWER_SKU			XE_REG(0x138098)
+ #define BMG_PACKAGE_POWER_SKU_UNIT		XE_REG(0x1380dc)
+ #define BMG_PACKAGE_ENERGY_STATUS		XE_REG(0x138120)
++#define BMG_FAN_1_SPEED				XE_REG(0x138140)
++#define BMG_FAN_2_SPEED				XE_REG(0x138170)
++#define BMG_FAN_3_SPEED				XE_REG(0x1381a0)
+ #define BMG_PACKAGE_RAPL_LIMIT			XE_REG(0x138440)
+ #define BMG_PLATFORM_ENERGY_STATUS		XE_REG(0x138458)
+ #define BMG_PLATFORM_POWER_LIMIT		XE_REG(0x138460)
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index 230c3b17a572..e24ff5bdacaa 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -307,6 +307,8 @@ struct xe_device {
+ 		u8 has_atomic_enable_pte_bit:1;
+ 		/** @info.has_device_atomics_on_smem: Supports device atomics on SMEM */
+ 		u8 has_device_atomics_on_smem:1;
++		/** @info.has_fan_control: Device supports fan control */
++		u8 has_fan_control:1;
+ 		/** @info.has_flat_ccs: Whether flat CCS metadata is used */
+ 		u8 has_flat_ccs:1;
+ 		/** @info.has_heci_cscfi: device has heci cscfi */
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index fde56dad3ab7..708becaf4524 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -5,6 +5,7 @@
+ 
+ #include <linux/hwmon-sysfs.h>
+ #include <linux/hwmon.h>
++#include <linux/jiffies.h>
+ #include <linux/types.h>
+ 
+ #include <drm/drm_managed.h>
+@@ -25,6 +26,7 @@ enum xe_hwmon_reg {
+ 	REG_PKG_POWER_SKU_UNIT,
+ 	REG_GT_PERF_STATUS,
+ 	REG_PKG_ENERGY_STATUS,
++	REG_FAN_SPEED,
+ };
+ 
+ enum xe_hwmon_reg_operation {
+@@ -39,6 +41,13 @@ enum xe_hwmon_channel {
+ 	CHANNEL_MAX,
+ };
+ 
++enum xe_fan_channel {
++	FAN_1,
++	FAN_2,
++	FAN_3,
++	FAN_MAX,
++};
++
+ /*
+  * SF_* - scale factors for particular quantities according to hwmon spec.
+  */
+@@ -58,6 +67,16 @@ struct xe_hwmon_energy_info {
+ 	long accum_energy;
+ };
+ 
++/**
++ * struct xe_hwmon_fan_info - to cache previous fan reading
++ */
++struct xe_hwmon_fan_info {
++	/** @reg_val_prev: previous fan reg val */
++	u32 reg_val_prev;
++	/** @time_prev: previous timestamp */
++	u64 time_prev;
++};
++
+ /**
+  * struct xe_hwmon - xe hwmon data structure
+  */
+@@ -76,6 +95,8 @@ struct xe_hwmon {
+ 	int scl_shift_time;
+ 	/** @ei: Energy info for energyN_input */
+ 	struct xe_hwmon_energy_info ei[CHANNEL_MAX];
++	/** @fi: Fan info for fanN_input */
++	struct xe_hwmon_fan_info fi[FAN_MAX];
+ };
+ 
+ static struct xe_reg xe_hwmon_get_reg(struct xe_hwmon *hwmon, enum xe_hwmon_reg hwmon_reg,
+@@ -128,6 +149,14 @@ static struct xe_reg xe_hwmon_get_reg(struct xe_hwmon *hwmon, enum xe_hwmon_reg
+ 			return PCU_CR_PACKAGE_ENERGY_STATUS;
+ 		}
+ 		break;
++	case REG_FAN_SPEED:
++		if (channel == FAN_1)
++			return BMG_FAN_1_SPEED;
++		else if (channel == FAN_2)
++			return BMG_FAN_2_SPEED;
++		else if (channel == FAN_3)
++			return BMG_FAN_3_SPEED;
++		break;
+ 	default:
+ 		drm_warn(&xe->drm, "Unknown xe hwmon reg id: %d\n", hwmon_reg);
+ 		break;
+@@ -436,6 +465,7 @@ static const struct hwmon_channel_info * const hwmon_info[] = {
+ 	HWMON_CHANNEL_INFO(curr, HWMON_C_LABEL, HWMON_C_CRIT | HWMON_C_LABEL),
+ 	HWMON_CHANNEL_INFO(in, HWMON_I_INPUT | HWMON_I_LABEL, HWMON_I_INPUT | HWMON_I_LABEL),
+ 	HWMON_CHANNEL_INFO(energy, HWMON_E_INPUT | HWMON_E_LABEL, HWMON_E_INPUT | HWMON_E_LABEL),
++	HWMON_CHANNEL_INFO(fan, HWMON_F_INPUT, HWMON_F_INPUT, HWMON_F_INPUT),
+ 	NULL
+ };
+ 
+@@ -462,6 +492,19 @@ static int xe_hwmon_pcode_write_i1(const struct xe_hwmon *hwmon, u32 uval)
+ 			      (uval & POWER_SETUP_I1_DATA_MASK));
+ }
+ 
++static int xe_hwmon_pcode_read_fan_control(const struct xe_hwmon *hwmon, u32 subcmd, u32 *uval)
++{
++	struct xe_tile *root_tile = xe_device_get_root_tile(hwmon->xe);
++
++	/* Platforms that don't return correct value */
++	if (hwmon->xe->info.platform == XE_DG2 && subcmd == FSC_READ_NUM_FANS) {
++		*uval = 2;
++		return 0;
++	}
++
++	return xe_pcode_read(root_tile, PCODE_MBOX(FAN_SPEED_CONTROL, subcmd, 0), uval, NULL);
++}
++
+ static int xe_hwmon_power_curr_crit_read(struct xe_hwmon *hwmon, int channel,
+ 					 long *value, u32 scale_factor)
+ {
+@@ -657,6 +700,75 @@ xe_hwmon_energy_read(struct xe_hwmon *hwmon, u32 attr, int channel, long *val)
+ 	}
+ }
+ 
++static umode_t
++xe_hwmon_fan_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
++{
++	u32 uval;
++
++	if (!hwmon->xe->info.has_fan_control)
++		return 0;
++
++	switch (attr) {
++	case hwmon_fan_input:
++		if (xe_hwmon_pcode_read_fan_control(hwmon, FSC_READ_NUM_FANS, &uval))
++			return 0;
++
++		return channel < uval ? 0444 : 0;
++	default:
++		return 0;
++	}
++}
++
++static int
++xe_hwmon_fan_input_read(struct xe_hwmon *hwmon, int channel, long *val)
++{
++	struct xe_mmio *mmio = xe_root_tile_mmio(hwmon->xe);
++	struct xe_hwmon_fan_info *fi = &hwmon->fi[channel];
++	u64 rotations, time_now, time;
++	u32 reg_val;
++	int ret = 0;
++
++	mutex_lock(&hwmon->hwmon_lock);
++
++	reg_val = xe_mmio_read32(mmio, xe_hwmon_get_reg(hwmon, REG_FAN_SPEED, channel));
++	time_now = get_jiffies_64();
++
++	/*
++	 * HW register value is accumulated count of pulses from PWM fan with the scale
++	 * of 2 pulses per rotation.
++	 */
++	rotations = (reg_val - fi->reg_val_prev) / 2;
++
++	time = jiffies_delta_to_msecs(time_now - fi->time_prev);
++	if (unlikely(!time)) {
++		ret = -EAGAIN;
++		goto unlock;
++	}
++
++	/*
++	 * Calculate fan speed in RPM by time averaging two subsequent readings in minutes.
++	 * RPM = number of rotations * msecs per minute / time in msecs
++	 */
++	*val = DIV_ROUND_UP_ULL(rotations * (MSEC_PER_SEC * 60), time);
++
++	fi->reg_val_prev = reg_val;
++	fi->time_prev = time_now;
++unlock:
++	mutex_unlock(&hwmon->hwmon_lock);
++	return ret;
++}
++
++static int
++xe_hwmon_fan_read(struct xe_hwmon *hwmon, u32 attr, int channel, long *val)
++{
++	switch (attr) {
++	case hwmon_fan_input:
++		return xe_hwmon_fan_input_read(hwmon, channel, val);
++	default:
++		return -EOPNOTSUPP;
++	}
++}
++
+ static umode_t
+ xe_hwmon_is_visible(const void *drvdata, enum hwmon_sensor_types type,
+ 		    u32 attr, int channel)
+@@ -679,6 +791,9 @@ xe_hwmon_is_visible(const void *drvdata, enum hwmon_sensor_types type,
+ 	case hwmon_energy:
+ 		ret = xe_hwmon_energy_is_visible(hwmon, attr, channel);
+ 		break;
++	case hwmon_fan:
++		ret = xe_hwmon_fan_is_visible(hwmon, attr, channel);
++		break;
+ 	default:
+ 		ret = 0;
+ 		break;
+@@ -711,6 +826,9 @@ xe_hwmon_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
+ 	case hwmon_energy:
+ 		ret = xe_hwmon_energy_read(hwmon, attr, channel, val);
+ 		break;
++	case hwmon_fan:
++		ret = xe_hwmon_fan_read(hwmon, attr, channel, val);
++		break;
+ 	default:
+ 		ret = -EOPNOTSUPP;
+ 		break;
+@@ -783,7 +901,7 @@ xe_hwmon_get_preregistration_info(struct xe_device *xe)
+ {
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(xe);
+ 	struct xe_hwmon *hwmon = xe->hwmon;
+-	long energy;
++	long energy, fan_speed;
+ 	u64 val_sku_unit = 0;
+ 	int channel;
+ 	struct xe_reg pkg_power_sku_unit;
+@@ -807,6 +925,11 @@ xe_hwmon_get_preregistration_info(struct xe_device *xe)
+ 	for (channel = 0; channel < CHANNEL_MAX; channel++)
+ 		if (xe_hwmon_is_visible(hwmon, hwmon_energy, hwmon_energy_input, channel))
+ 			xe_hwmon_energy_get(hwmon, channel, &energy);
++
++	/* Initialize 'struct xe_hwmon_fan_info' with initial fan register reading. */
++	for (channel = 0; channel < FAN_MAX; channel++)
++		if (xe_hwmon_is_visible(hwmon, hwmon_fan, hwmon_fan_input, channel))
++			xe_hwmon_fan_input_read(hwmon, channel, &fan_speed);
+ }
+ 
+ static void xe_hwmon_mutex_destroy(void *arg)
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index 39be74848e44..e0971b3a24a5 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -58,6 +58,7 @@ struct xe_device_desc {
+ 	u8 is_dgfx:1;
+ 
+ 	u8 has_display:1;
++	u8 has_fan_control:1;
+ 	u8 has_heci_gscfi:1;
+ 	u8 has_heci_cscfi:1;
+ 	u8 has_llc:1;
+@@ -316,6 +317,7 @@ static const struct xe_device_desc dg2_desc = {
+ 
+ 	DG2_FEATURES,
+ 	.has_display = true,
++	.has_fan_control = true,
+ };
+ 
+ static const __maybe_unused struct xe_device_desc pvc_desc = {
+@@ -343,6 +345,7 @@ static const struct xe_device_desc bmg_desc = {
+ 	DGFX_FEATURES,
+ 	PLATFORM(BATTLEMAGE),
+ 	.has_display = true,
++	.has_fan_control = true,
+ 	.has_heci_cscfi = 1,
+ };
+ 
+@@ -614,6 +617,7 @@ static int xe_info_init_early(struct xe_device *xe,
+ 		subplatform_desc->subplatform : XE_SUBPLATFORM_NONE;
+ 
+ 	xe->info.is_dgfx = desc->is_dgfx;
++	xe->info.has_fan_control = desc->has_fan_control;
+ 	xe->info.has_heci_gscfi = desc->has_heci_gscfi;
+ 	xe->info.has_heci_cscfi = desc->has_heci_cscfi;
+ 	xe->info.has_llc = desc->has_llc;
+diff --git a/drivers/gpu/drm/xe/xe_pcode_api.h b/drivers/gpu/drm/xe/xe_pcode_api.h
+index e52f240635d9..0d737b780f88 100644
+--- a/drivers/gpu/drm/xe/xe_pcode_api.h
++++ b/drivers/gpu/drm/xe/xe_pcode_api.h
+@@ -54,6 +54,9 @@
+ #define   LINK_DOWNGRADE               REG_GENMASK(1, 0)
+ #define     DOWNGRADE_CAPABLE          2
+ 
++#define   FAN_SPEED_CONTROL			0x7D
++#define     FSC_READ_NUM_FANS			0x4
++
+ struct pcode_err_decode {
+ 	int errno;
+ 	const char *str;
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -15,6 +15,13 @@ backport/patches/base/0001-drm-xe-xe_pmu-Add-PMU-support-for-engine-activity.pat
 backport/patches/base/0001-drm-xe-xe_pmu-Acquire-forcewake-on-event-init-for-en.patch
 backport/patches/base/0001-drm-xe-Add-locks-in-gtidle-code.patch
 backport/patches/base/0001-drm-xe-pmu-Add-GT-frequency-events.patch
+backport/patches/base/0001-drm-xe-hwmon-expose-fan-speed.patch
+backport/patches/base/0001-drm-xe-hwmon-Add-support-to-manage-power-limits-thou.patch
+backport/patches/base/0001-drm-xe-hwmon-Move-card-reactive-critical-power-under.patch
+backport/patches/base/0001-drm-xe-hwmon-Add-support-to-manage-PL2-though-mailbo.patch
+backport/patches/base/0001-drm-xe-hwmon-Expose-powerX_cap_interval.patch
+backport/patches/base/0001-drm-xe-hwmon-Read-energy-status-from-PMT.patch
+backport/patches/base/0001-drm-xe-hwmon-Expose-power-sysfs-entries-based-on-fir.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Enable PL2 support through powerX_cap.
Expose PL2 interval through powerX_cap_interval.
Read energy status from PMT instead of MMIO.
Move power2_crit to power1_crit.

JIRA : VLK-72278

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>