### PR TITLE
Enable Intel G31 platform Support 

### DIFF
--- a/backport/patches/base/0001-drm-xe-xe2_hpg-Add-PCI-IDs-for-xe2_hpg.patch
+++ b/backport/patches/base/0001-drm-xe-xe2_hpg-Add-PCI-IDs-for-xe2_hpg.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Date: Fri, 6 Jun 2025 00:38:02 +0530
+Subject: drm/xe/xe2_hpg: Add PCI IDs for xe2_hpg
+
+As per updated Bspec, Sync PCI IDs for BMG.
+
+Bspec: 68090
+Signed-off-by: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Signed-off-by: Dnyaneshwar Bhadane <dnyaneshwar.bhadane@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250605190804.1287289-2-dnyaneshwar.bhadane@intel.com
+(cherry picked from commit 9b779ff0e1d1fa8a4e7d90405bcb902a1d5f4fe6 linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ include/drm/intel/pciids.h | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/include/drm/intel/pciids.h b/include/drm/intel/pciids.h
+index 750323e19..52adc556d 100644
+--- a/include/drm/intel/pciids.h
++++ b/include/drm/intel/pciids.h
+@@ -849,8 +849,11 @@
+ 	MACRO__(0xE210, ## __VA_ARGS__), \
+ 	MACRO__(0xE211, ## __VA_ARGS__), \
+ 	MACRO__(0xE212, ## __VA_ARGS__), \
+-	MACRO__(0xE215, ## __VA_ARGS__), \
+-	MACRO__(0xE216, ## __VA_ARGS__)
++	MACRO__(0xE216, ## __VA_ARGS__), \
++	MACRO__(0xE220, ## __VA_ARGS__), \
++	MACRO__(0xE221, ## __VA_ARGS__), \
++	MACRO__(0xE222, ## __VA_ARGS__), \
++	MACRO__(0xE223, ## __VA_ARGS__)
+ 
+ /* PTL */
+ #define INTEL_PTL_IDS(MACRO__, ...) \
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-xe2_hpg-Define-additional-Xe2_HPG-GMD_ID.patch
+++ b/backport/patches/base/0001-drm-xe-xe2_hpg-Define-additional-Xe2_HPG-GMD_ID.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Date: Fri, 6 Jun 2025 00:38:04 +0530
+Subject: drm/xe/xe2_hpg: Define additional Xe2_HPG GMD_ID
+
+Add another GMD_ID for Xe2_HPG
+
+Signed-off-by: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Signed-off-by: James Ausmus <james.ausmus@intel.com>
+Signed-off-by: Dnyaneshwar Bhadane <dnyaneshwar.bhadane@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250605190804.1287289-4-dnyaneshwar.bhadane@intel.com
+(cherry picked commit 26ff87d2e776e10eb720138c5b5d334bceffc99f linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index 71032ef27..efe4ea46d 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -356,6 +356,7 @@ static const struct gmdid_map graphics_ip_map[] = {
+ 	{ 1271, "Xe_LPG", &graphics_xelpg },
+ 	{ 1274, "Xe_LPG+", &graphics_xelpg },
+ 	{ 2001, "Xe2_HPG", &graphics_xe2 },
++	{ 2002, "Xe2_HPG", &graphics_xe2 },
+ 	{ 2004, "Xe2_LPG", &graphics_xe2 },
+ 	{ 3000, "Xe3_LPG", &graphics_xe2 },
+ 	{ 3001, "Xe3_LPG", &graphics_xe2 },
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -23,6 +23,8 @@ backport/patches/base/0001-drm-xe-hwmon-Read-energy-status-from-PMT.patch
 backport/patches/base/0001-drm-xe-hwmon-Expose-power-sysfs-entries-based-on-fir.patch
 backport/patches/base/0001-drm-xe-Default-auto_link_downgrade-status-to-false.patch
 backport/patches/base/0001-drm-xe-hwmon-Fix-xe_hwmon_power_max_write.patch
+backport/patches/base/0001-drm-xe-xe2_hpg-Add-PCI-IDs-for-xe2_hpg.patch
+backport/patches/base/0001-drm-xe-xe2_hpg-Define-additional-Xe2_HPG-GMD_ID.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Below changes enable proper detection and initialization of Xe2HPG devices.

Add PCI IDs, and GMD_ID for Xe2HPG.
Added changes to enable proper detection and initialization of Xe2HPG devices.

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>