### PR TITLE
Enable Intel G31 platform Support 

### DIFF
--- a/backport/patches/base/0001-drm-xe-xe2_hpg-Add-PCI-IDs-for-xe2_hpg.patch
+++ b/backport/patches/base/0001-drm-xe-xe2_hpg-Add-PCI-IDs-for-xe2_hpg.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Date: Fri, 6 Jun 2025 00:38:02 +0530
+Subject: drm/xe/xe2_hpg: Add PCI IDs for xe2_hpg
+
+As per updated Bspec, Sync PCI IDs for BMG.
+
+Bspec: 68090
+Signed-off-by: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Signed-off-by: Dnyaneshwar Bhadane <dnyaneshwar.bhadane@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250605190804.1287289-2-dnyaneshwar.bhadane@intel.com
+(backported from commit 9b779ff0e1d1fa8a4e7d90405bcb902a1d5f4fe6 linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+
+---
+ include/drm/intel/pciids.h | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/include/drm/intel/pciids.h b/include/drm/intel/pciids.h
+index fa6d53734..0cd3adc94 100644
+--- a/include/drm/intel/pciids.h
++++ b/include/drm/intel/pciids.h
+@@ -812,7 +812,11 @@
+ 	MACRO__(0xE210, ## __VA_ARGS__), \
+ 	MACRO__(0xE211, ## __VA_ARGS__), \
+ 	MACRO__(0xE212, ## __VA_ARGS__), \
+-	MACRO__(0xE215, ## __VA_ARGS__), \
+-	MACRO__(0xE216, ## __VA_ARGS__)
++	MACRO__(0xE216, ## __VA_ARGS__), \
++	MACRO__(0xE220, ## __VA_ARGS__), \
++	MACRO__(0xE221, ## __VA_ARGS__), \
++	MACRO__(0xE222, ## __VA_ARGS__), \
++	MACRO__(0xE223, ## __VA_ARGS__)
++
+ 
+ #endif /* __PCIIDS_H__ */
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-xe2_hpg-Add-set-of-workarounds.patch
+++ b/backport/patches/base/0001-drm-xe-xe2_hpg-Add-set-of-workarounds.patch
@@ -1,0 +1,164 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Date: Fri, 6 Jun 2025 00:38:03 +0530
+Subject: drm/xe/xe2_hpg: Add set of workarounds
+
+Add set of workarounds for xe2_hpg.
+
+-v2: Fix xe2_hpg GMD version for some workarounds.
+-v3: Removed extra Workaround (Matt Roper)
+
+Signed-off-by: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Signed-off-by: Dnyaneshwar Bhadane <dnyaneshwar.bhadane@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250605190804.1287289-3-dnyaneshwar.bhadane@intel.com
+(backported from commit a5d221924e13a22c83b682410dcf72422d1c68db linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_wa.c         | 44 ++++++++++++++++++------------
+ drivers/gpu/drm/xe/xe_wa_oob.rules |  4 +--
+ 2 files changed, 28 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_wa.c b/drivers/gpu/drm/xe/xe_wa.c
+index 95b4b38fb..607fb0c0c 100644
+--- a/drivers/gpu/drm/xe/xe_wa.c
++++ b/drivers/gpu/drm/xe/xe_wa.c
+@@ -464,10 +464,6 @@ static const struct xe_rtp_entry_sr engine_was[] = {
+ 	  XE_RTP_RULES(GRAPHICS_VERSION(2004), FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(LSC_CHICKEN_BIT_0_UDW, ENABLE_SMP_LD_RENDER_SURFACE_CONTROL))
+ 	},
+-	{ XE_RTP_NAME("16018737384"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2004), FUNC(xe_rtp_match_first_render_or_compute)),
+-	  XE_RTP_ACTIONS(SET(ROW_CHICKEN, EARLY_EOT_DIS))
+-	},
+ 	/*
+ 	 * These two workarounds are the same, just applying to different
+ 	 * engines.  Although Wa_18032095049 (for the RCS) isn't required on
+@@ -494,31 +490,38 @@ static const struct xe_rtp_entry_sr engine_was[] = {
+ 	/* Xe2_HPG */
+ 
+ 	{ XE_RTP_NAME("16018712365"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), FUNC(xe_rtp_match_first_render_or_compute)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002),
++		       FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(LSC_CHICKEN_BIT_0_UDW, XE2_ALLOC_DPA_STARVE_FIX_DIS))
+ 	},
+ 	{ XE_RTP_NAME("16018737384"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), FUNC(xe_rtp_match_first_render_or_compute)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, XE_RTP_END_VERSION_UNDEFINED),
++		       FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(ROW_CHICKEN, EARLY_EOT_DIS))
+ 	},
+ 	{ XE_RTP_NAME("14019988906"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), FUNC(xe_rtp_match_first_render_or_compute)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002),
++		       FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(XEHP_PSS_CHICKEN, FLSH_IGNORES_PSD))
+ 	},
+ 	{ XE_RTP_NAME("14019877138"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), FUNC(xe_rtp_match_first_render_or_compute)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002),
++		       FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(XEHP_PSS_CHICKEN, FD_END_COLLECT))
+ 	},
+ 	{ XE_RTP_NAME("14020338487"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), FUNC(xe_rtp_match_first_render_or_compute)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002),
++		       FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(ROW_CHICKEN3, XE2_EUPEND_CHK_FLUSH_DIS))
+ 	},
+ 	{ XE_RTP_NAME("18032247524"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), FUNC(xe_rtp_match_first_render_or_compute)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002),
++		       FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(LSC_CHICKEN_BIT_0, SEQUENTIAL_ACCESS_UPGRADE_DISABLE))
+ 	},
+ 	{ XE_RTP_NAME("14018471104"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), FUNC(xe_rtp_match_first_render_or_compute)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002),
++		       FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(LSC_CHICKEN_BIT_0_UDW, ENABLE_SMP_LD_RENDER_SURFACE_CONTROL))
+ 	},
+ 	/*
+@@ -527,7 +530,7 @@ static const struct xe_rtp_entry_sr engine_was[] = {
+ 	 * apply this to all engines for simplicity.
+ 	 */
+ 	{ XE_RTP_NAME("16021639441"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002)),
+ 	  XE_RTP_ACTIONS(SET(CSFE_CHICKEN1(0),
+ 			     GHWSP_CSB_REPORT_DIS |
+ 			     PPHWSP_CSB_AND_TIMESTAMP_REPORT_DIS,
+@@ -539,11 +542,12 @@ static const struct xe_rtp_entry_sr engine_was[] = {
+ 	  XE_RTP_ACTIONS(SET(LSC_CHICKEN_BIT_0, WR_REQ_CHAINING_DIS))
+ 	},
+ 	{ XE_RTP_NAME("14021402888"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), ENGINE_CLASS(RENDER)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002), ENGINE_CLASS(RENDER)),
+ 	  XE_RTP_ACTIONS(SET(HALF_SLICE_CHICKEN7, CLEAR_OPTIMIZATION_DISABLE))
+ 	},
+-	{ XE_RTP_NAME("14021821874"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), FUNC(xe_rtp_match_first_render_or_compute)),
++	{ XE_RTP_NAME("14021821874, 14022954250"),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002),
++		       FUNC(xe_rtp_match_first_render_or_compute)),
+ 	  XE_RTP_ACTIONS(SET(TDL_TSL_CHICKEN, STK_ID_RESTRICT))
+ 	},
+ 
+@@ -688,7 +692,7 @@ static const struct xe_rtp_entry_sr lrc_was[] = {
+ 	  XE_RTP_ACTIONS(SET(INSTPM(RENDER_RING_BASE), ENABLE_SEMAPHORE_POLL_BIT))
+ 	},
+ 	{ XE_RTP_NAME("18033852989"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2004), ENGINE_CLASS(RENDER)),
++	  XE_RTP_RULES(GRAPHICS_VERSION(2004), ENGINE_CLASS(RENDER)),
+ 	  XE_RTP_ACTIONS(SET(COMMON_SLICE_CHICKEN1, DISABLE_BOTTOM_CLIP_RECTANGLE_TEST))
+ 	},
+ 	{ XE_RTP_NAME("14021567978"),
+@@ -721,7 +725,7 @@ static const struct xe_rtp_entry_sr lrc_was[] = {
+ 	  XE_RTP_ACTIONS(SET(CHICKEN_RASTER_1, DIS_SF_ROUND_NEAREST_EVEN))
+ 	},
+ 	{ XE_RTP_NAME("14019386621"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), ENGINE_CLASS(RENDER)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002), ENGINE_CLASS(RENDER)),
+ 	  XE_RTP_ACTIONS(SET(VF_SCRATCHPAD, XE2_VFG_TED_CREDIT_INTERFACE_DISABLE))
+ 	},
+ 	{ XE_RTP_NAME("14020756599"),
+@@ -738,13 +742,17 @@ static const struct xe_rtp_entry_sr lrc_was[] = {
+ 			     DIS_AUTOSTRIP))
+ 	},
+ 	{ XE_RTP_NAME("15016589081"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), ENGINE_CLASS(RENDER)),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002), ENGINE_CLASS(RENDER)),
+ 	  XE_RTP_ACTIONS(SET(CHICKEN_RASTER_1, DIS_CLIP_NEGATIVE_BOUNDING_BOX))
+ 	},
+ 	{ XE_RTP_NAME("22021007897"),
+ 		XE_RTP_RULES(GRAPHICS_VERSION(2001), ENGINE_CLASS(RENDER)),
+ 		XE_RTP_ACTIONS(SET(COMMON_SLICE_CHICKEN4, SBE_PUSH_CONSTANT_BEHIND_FIX_ENABLE))
+ 	},
++	{ XE_RTP_NAME("18033852989"),
++		XE_RTP_RULES(GRAPHICS_VERSION(2001), ENGINE_CLASS(RENDER)),
++		XE_RTP_ACTIONS(SET(COMMON_SLICE_CHICKEN1, DISABLE_BOTTOM_CLIP_RECTANGLE_TEST))
++	},
+ 
+ 	{}
+ };
+diff --git a/drivers/gpu/drm/xe/xe_wa_oob.rules b/drivers/gpu/drm/xe/xe_wa_oob.rules
+index da7d2c842..6a4f9bd0f 100644
+--- a/drivers/gpu/drm/xe/xe_wa_oob.rules
++++ b/drivers/gpu/drm/xe/xe_wa_oob.rules
+@@ -27,9 +27,9 @@
+ 16022287689	GRAPHICS_VERSION(2001)
+ 		GRAPHICS_VERSION(2004)
+ 13011645652	GRAPHICS_VERSION(2004)
+-14022293748	GRAPHICS_VERSION(2001)
++14022293748	GRAPHICS_VERSION_RANGE(2001, 2002)
+ 		GRAPHICS_VERSION(2004)
+-22019794406	GRAPHICS_VERSION(2001)
++22019794406	GRAPHICS_VERSION_RANGE(2001, 2002)
+ 		GRAPHICS_VERSION(2004)
+ 22019338487	MEDIA_VERSION(2000)
+ 		GRAPHICS_VERSION(2001)
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-xe2_hpg-Define-additional-Xe2_HPG-GMD_ID.patch
+++ b/backport/patches/base/0001-drm-xe-xe2_hpg-Define-additional-Xe2_HPG-GMD_ID.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Date: Fri, 6 Jun 2025 00:38:04 +0530
+Subject: drm/xe/xe2_hpg: Define additional Xe2_HPG GMD_ID
+
+Add another GMD_ID for Xe2_HPG
+
+Signed-off-by: Shekhar Chauhan <shekhar.chauhan@intel.com>
+Signed-off-by: James Ausmus <james.ausmus@intel.com>
+Signed-off-by: Dnyaneshwar Bhadane <dnyaneshwar.bhadane@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250605190804.1287289-4-dnyaneshwar.bhadane@intel.com
+(backported from commit 26ff87d2e776e10eb720138c5b5d334bceffc99f linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index 0a119d3ea..57fa58954 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -356,6 +356,7 @@ static const struct gmdid_map graphics_ip_map[] = {
+ 	{ 1271, &graphics_xelpg },
+ 	{ 1274, &graphics_xelpg },	/* Xe_LPG+ */
+ 	{ 2001, &graphics_xe2 },
++	{ 2002, &graphics_xe2 },
+ 	{ 2004, &graphics_xe2 },
+ };
+ 
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-xe2hpg-Add-Wa_22021007897.patch
+++ b/backport/patches/base/0001-drm-xe-xe2hpg-Add-Wa_22021007897.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aradhya Bhatia <aradhya.bhatia@intel.com>
+Date: Mon, 12 May 2025 06:50:04 +0000
+Subject: drm/xe/xe2hpg: Add Wa_22021007897
+
+Add Wa_22021007897 for the Xe2_HPG (graphics version: 20.01) IP. It is
+a permanent workaround, and applicable on all the steppings.
+
+Reviewed-by: Gustavo Sousa <gustavo.sousa@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Signed-off-by: Aradhya Bhatia <aradhya.bhatia@intel.com>
+Link: https://lore.kernel.org/r/20250512065004.2576-1-aradhya.bhatia@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(cherry picked from commit e5c13e2c505b73a8667ef9a0fd5cbd4227e483e6)
+Signed-ofif-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit b1f704107cf27906a9cea542b626b96019104663 linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h | 1 +
+ drivers/gpu/drm/xe/xe_wa.c           | 4 ++++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index 012e3961e..30c6eb0d6 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -157,6 +157,7 @@
+ #define XEHPG_SC_INSTDONE_EXTRA2		XE_REG_MCR(0x7108)
+ 
+ #define COMMON_SLICE_CHICKEN4			XE_REG(0x7300, XE_REG_OPTION_MASKED)
++#define   SBE_PUSH_CONSTANT_BEHIND_FIX_ENABLE	REG_BIT(12)
+ #define   DISABLE_TDC_LOAD_BALANCING_CALC	REG_BIT(6)
+ 
+ #define COMMON_SLICE_CHICKEN3				XE_REG(0x7304, XE_REG_OPTION_MASKED)
+diff --git a/drivers/gpu/drm/xe/xe_wa.c b/drivers/gpu/drm/xe/xe_wa.c
+index 28c514b2a..95b4b38fb 100644
+--- a/drivers/gpu/drm/xe/xe_wa.c
++++ b/drivers/gpu/drm/xe/xe_wa.c
+@@ -741,6 +741,10 @@ static const struct xe_rtp_entry_sr lrc_was[] = {
+ 	  XE_RTP_RULES(GRAPHICS_VERSION(2001), ENGINE_CLASS(RENDER)),
+ 	  XE_RTP_ACTIONS(SET(CHICKEN_RASTER_1, DIS_CLIP_NEGATIVE_BOUNDING_BOX))
+ 	},
++	{ XE_RTP_NAME("22021007897"),
++		XE_RTP_RULES(GRAPHICS_VERSION(2001), ENGINE_CLASS(RENDER)),
++		XE_RTP_ACTIONS(SET(COMMON_SLICE_CHICKEN4, SBE_PUSH_CONSTANT_BEHIND_FIX_ENABLE))
++	},
+ 
+ 	{}
+ };
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -105,6 +105,11 @@ backport/patches/base/0001-drm-xe-bmg-Add-one-additional-PCI-ID.patch
 backport/patches/base/0001-drm-i915-xe2hpd-Identify-the-memory-type-for-SKUs-wi.patch
 backport/patches/base/0001-drm-intel-pciids-rename-i915_pciids.h-to-just-pciids.patch
 backport/patches/base/0001-drm-xe-switch-to-common-PCI-ID-macros.patch
+backport/patches/base/0001-drm-xe-xe2_hpg-Add-PCI-IDs-for-xe2_hpg.patch
+backport/patches/base/0001-drm-xe-xe2hpg-Add-Wa_22021007897.patch
+backport/patches/base/0001-drm-xe-xe2_hpg-Add-set-of-workarounds.patch
+backport/patches/base/0001-drm-xe-xe2_hpg-Define-additional-Xe2_HPG-GMD_ID.patch
+
 # features/eu-debug
 backport/patches/features/eu-debug/0001-drm-xe-Use-the-filelist-from-drm-for-ccs_mode-change.patch
 backport/patches/features/eu-debug/0001-drm-xe-Export-xe_hw_engine-s-mmio-accessors.patch


### PR DESCRIPTION
Below changes enable proper detection and initialization of Xe2HPG devices.

- Add new PCI device IDs for Xe2HPG.
- Add Wa_22021007897 for Xe2HPG
- Implement required workarounds for Xe2HPG support.
- Add GMD_ID for Xe2HPG.

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>