### PR TITLE
patches/base: Fix for xe_force_gt_reset failure

### DIFF
--- a/backport/patches/base/0001-drm-xe-Allow-to-trigger-GT-resets-using-debugfs-writ.patch
+++ b/backport/patches/base/0001-drm-xe-Allow-to-trigger-GT-resets-using-debugfs-writ.patch
@@ -1,0 +1,159 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Mon, 19 May 2025 22:09:14 +0200
+Subject: drm/xe: Allow to trigger GT resets using debugfs writes
+
+Today we allow to trigger GT resest by reading dedicated debugfs
+files "force_reset" and "force_reset_sync" that we are exposing
+using drm_info_list[] and drm_debugfs_create_files().
+
+To avoid triggering potentially disruptive actions during otherwise
+"safe" read operations, expose those two attributes using debugfs
+function where we can specify file permissions and provide custom
+"write" handler to trigger the GT resets also from there.
+
+This step would allow us to drop triggering GT resets during read
+operations, which we leave just to give users more time to switch.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Cc: Lucas De Marchi <lucas.demarchi@intel.com>
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://lore.kernel.org/r/20250519200914.216-1-michal.wajdeczko@intel.com
+(backported from commit 2cb38bb0add9b81f89ccdb2db88af89e99925880 linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_debugfs.c | 96 +++++++++++++++++++++++-------
+ 1 file changed, 76 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_debugfs.c b/drivers/gpu/drm/xe/xe_gt_debugfs.c
+index f7005a364..9303c6673 100644
+--- a/drivers/gpu/drm/xe/xe_gt_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_gt_debugfs.c
+@@ -122,24 +122,6 @@ static int powergate_info(struct xe_gt *gt, struct drm_printer *p)
+ 	return ret;
+ }
+ 
+-static int force_reset(struct xe_gt *gt, struct drm_printer *p)
+-{
+-	xe_pm_runtime_get(gt_to_xe(gt));
+-	xe_gt_reset_async(gt);
+-	xe_pm_runtime_put(gt_to_xe(gt));
+-
+-	return 0;
+-}
+-
+-static int force_reset_sync(struct xe_gt *gt, struct drm_printer *p)
+-{
+-	xe_pm_runtime_get(gt_to_xe(gt));
+-	xe_gt_reset(gt);
+-	xe_pm_runtime_put(gt_to_xe(gt));
+-
+-	return 0;
+-}
+-
+ static int sa_info(struct xe_gt *gt, struct drm_printer *p)
+ {
+ 	struct xe_tile *tile = gt_to_tile(gt);
+@@ -302,8 +284,6 @@ static int hwconfig(struct xe_gt *gt, struct drm_printer *p)
+ 
+ static const struct drm_info_list debugfs_list[] = {
+ 	{"hw_engines", .show = xe_gt_debugfs_simple_show, .data = hw_engines},
+-	{"force_reset", .show = xe_gt_debugfs_simple_show, .data = force_reset},
+-	{"force_reset_sync", .show = xe_gt_debugfs_simple_show, .data = force_reset_sync},
+ 	{"sa_info", .show = xe_gt_debugfs_simple_show, .data = sa_info},
+ 	{"topology", .show = xe_gt_debugfs_simple_show, .data = topology},
+ 	{"steering", .show = xe_gt_debugfs_simple_show, .data = steering},
+@@ -323,6 +303,78 @@ static const struct drm_info_list debugfs_list[] = {
+ 	{"hwconfig", .show = xe_gt_debugfs_simple_show, .data = hwconfig},
+ };
+ 
++static ssize_t write_to_gt_call(const char __user *userbuf, size_t count, loff_t *ppos,
++		void (*call)(struct xe_gt *), struct xe_gt *gt)
++{
++	bool yes;
++	int ret;
++
++	if (*ppos)
++		return -EINVAL;
++	ret = kstrtobool_from_user(userbuf, count, &yes);
++	if (ret < 0)
++		return ret;
++	if (yes)
++		call(gt);
++	return count;
++}
++
++static void force_reset(struct xe_gt *gt)
++{
++	struct xe_device *xe = gt_to_xe(gt);
++
++	xe_pm_runtime_get(xe);
++	xe_gt_reset_async(gt);
++	xe_pm_runtime_put(xe);
++}
++
++static ssize_t force_reset_write(struct file *file,
++		const char __user *userbuf,
++		size_t count, loff_t *ppos)
++{
++	struct seq_file *s = file->private_data;
++	struct xe_gt *gt = s->private;
++
++	return write_to_gt_call(userbuf, count, ppos, force_reset, gt);
++}
++
++static int force_reset_show(struct seq_file *s, void *unused)
++{
++	struct xe_gt *gt = s->private;
++
++	force_reset(gt); /* to be deprecated! */
++	return 0;
++}
++DEFINE_SHOW_STORE_ATTRIBUTE(force_reset);
++
++static void force_reset_sync(struct xe_gt *gt)
++{
++	struct xe_device *xe = gt_to_xe(gt);
++
++	xe_pm_runtime_get(xe);
++	xe_gt_reset(gt);
++	xe_pm_runtime_put(xe);
++}
++
++static ssize_t force_reset_sync_write(struct file *file,
++		const char __user *userbuf,
++		size_t count, loff_t *ppos)
++{
++	struct seq_file *s = file->private_data;
++	struct xe_gt *gt = s->private;
++
++	return write_to_gt_call(userbuf, count, ppos, force_reset_sync, gt);
++}
++
++static int force_reset_sync_show(struct seq_file *s, void *unused)
++{
++	struct xe_gt *gt = s->private;
++
++	force_reset_sync(gt); /* to be deprecated! */
++	return 0;
++}
++DEFINE_SHOW_STORE_ATTRIBUTE(force_reset_sync);
++
+ void xe_gt_debugfs_register(struct xe_gt *gt)
+ {
+ 	struct xe_device *xe = gt_to_xe(gt);
+@@ -346,6 +398,10 @@ void xe_gt_debugfs_register(struct xe_gt *gt)
+ 	 */
+ 	root->d_inode->i_private = gt;
+ 
++	/* VF safe */
++	debugfs_create_file("force_reset", 0600, root, gt, &force_reset_fops);
++	debugfs_create_file("force_reset_sync", 0600, root, gt, &force_reset_sync_fops);
++
+ 	drm_debugfs_create_files(debugfs_list,
+ 				 ARRAY_SIZE(debugfs_list),
+ 				 root, minor);
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -23,6 +23,7 @@ backport/patches/base/0001-drm-xe-hwmon-Read-energy-status-from-PMT.patch
 backport/patches/base/0001-drm-xe-hwmon-Expose-power-sysfs-entries-based-on-fir.patch
 backport/patches/base/0001-drm-xe-Default-auto_link_downgrade-status-to-false.patch
 backport/patches/base/0001-drm-xe-hwmon-Fix-xe_hwmon_power_max_write.patch
+backport/patches/base/0001-drm-xe-Allow-to-trigger-GT-resets-using-debugfs-writ.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
This patch enables triggering a forced GT reset via a write operation.
Previously, GT resets were triggered by reading
the dedicated debugfs files "force_reset" and "force_reset_sync".
With this patch, a custom write handler is provided,
allowing GT resets to be triggered from user space using a write operation as well.

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>