### PR TITLE
drm/xe: Enable fault injection infrastructure and helpers

### DIFF
--- a/backport/patches/base/0001-drm-xe-Add-fault-injection-for-xe_oa_alloc_regs.patch
+++ b/backport/patches/base/0001-drm-xe-Add-fault-injection-for-xe_oa_alloc_regs.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nakshtra Goyal <nakshtra.goyal@intel.com>
+Date: Thu, 27 Feb 2025 15:53:39 +0530
+Subject: drm/xe: Add fault injection for xe_oa_alloc_regs
+
+Add fault injection for xe_oa_alloc_regs to allow it to fail while
+executing xe_oa_add_config_ioctl().
+This need to be added as it cannot be reached by injecting error through
+IOCTL arguments.
+
+Signed-off-by: Nakshtra Goyal <nakshtra.goyal@intel.com>
+Reviewed-by: Francois Dugast <francois.dugast@intel.com>
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Link: https://lore.kernel.org/r/20250227102339.2859726-1-nakshtra.goyal@intel.com
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+(cherry picked from commit 6fe653f82402fafecb913375e74f386f52c10938 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_oa.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index 9ede7b3b15eb..c16d89940462 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -2233,6 +2233,7 @@ xe_oa_alloc_regs(struct xe_oa *oa, bool (*is_valid)(struct xe_oa *oa, u32 addr),
+ 	kfree(oa_regs);
+ 	return ERR_PTR(err);
+ }
++ALLOW_ERROR_INJECTION(xe_oa_alloc_regs, ERRNO);
+ 
+ static ssize_t show_dynamic_id(struct kobject *kobj,
+ 			       struct kobj_attribute *attr,
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Add-fault-injection-for-xe_sync_entry_parse.patch
+++ b/backport/patches/base/0001-drm-xe-Add-fault-injection-for-xe_sync_entry_parse.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Priyanka Dandamudi <priyanka.dandamudi@intel.com>
+Date: Wed, 12 Feb 2025 09:32:12 +0000
+Subject: drm/xe: Add fault injection for xe_sync_entry_parse
+
+Add fault injection for xe_sync_entry_parse to allow it to fail while
+executing xe_vm_bind_ioctl(). This needs to be added as it cannot be
+reached by injecting error through IOCTL arguments.
+
+Signed-off-by: Priyanka Dandamudi <priyanka.dandamudi@intel.com>
+Reviewed-by: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250212093212.3069356-1-priyanka.dandamudi@intel.com
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+(cherry picked from commit 70c7273778bf7f18f2e46a41638f6ff38fb9fa51 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_sync.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
+index 180ec778584f..fbd31970d615 100644
+--- a/drivers/gpu/drm/xe/xe_sync.c
++++ b/drivers/gpu/drm/xe/xe_sync.c
+@@ -223,6 +223,7 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 
+ 	return 0;
+ }
++ALLOW_ERROR_INJECTION(xe_sync_entry_parse, ERRNO);
+ 
+ int xe_sync_entry_add_deps(struct xe_sync_entry *sync, struct xe_sched_job *job)
+ {
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Add-helper-function-to-inject-fault-into-ct_d.patch
+++ b/backport/patches/base/0001-drm-xe-Add-helper-function-to-inject-fault-into-ct_d.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Date: Thu, 12 Jun 2025 13:34:02 +0530
+Subject: drm/xe: Add helper function to inject fault into
+ ct_dead_capture()
+
+When injecting fault to xe_guc_ct_send_recv() & xe_guc_mmio_send_recv()
+functions, the CI test systems are going out of space and crashing. To
+avoid this issue, a new helper function is created and when fault is
+injected into this xe_is_injection_active() helper function, ct dead
+capture is avoided which suppresses ct dumps in the log.
+
+Signed-off-by: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Suggested-by: John Harrison <John.C.Harrison@Intel.com>
+Reviewed-by: John Harrison <John.C.Harrison@Intel.com>
+Cc: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Cc: Jani Nikula <jani.nikula@intel.com>
+Signed-off-by: John Harrison <John.C.Harrison@Intel.com>
+Link: https://lore.kernel.org/r/20250612080402.22011-1-satyanarayana.k.v.p@intel.com
+(cherry picked from commit 87c648c31322459ed1284ee18ab9c256cb076fd0 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.h |  2 ++
+ drivers/gpu/drm/xe/xe_guc_ct.c | 24 ++++++++++++++++++++++++
+ 2 files changed, 26 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.h b/drivers/gpu/drm/xe/xe_device.h
+index 129fc6660062..7867b17b9b92 100644
+--- a/drivers/gpu/drm/xe/xe_device.h
++++ b/drivers/gpu/drm/xe/xe_device.h
+@@ -191,6 +191,8 @@ void xe_device_declare_wedged(struct xe_device *xe);
+ struct xe_file *xe_file_get(struct xe_file *xef);
+ void xe_file_put(struct xe_file *xef);
+ 
++int xe_is_injection_active(void);
++
+ /*
+  * Occasionally it is seen that the G2H worker starts running after a delay of more than
+  * a second even after being queued and activated by the Linux workqueue subsystem. This
+diff --git a/drivers/gpu/drm/xe/xe_guc_ct.c b/drivers/gpu/drm/xe/xe_guc_ct.c
+index 5a020fea997f..2f14933f039b 100644
+--- a/drivers/gpu/drm/xe/xe_guc_ct.c
++++ b/drivers/gpu/drm/xe/xe_guc_ct.c
+@@ -1769,6 +1769,24 @@ void xe_guc_ct_print(struct xe_guc_ct *ct, struct drm_printer *p, bool want_ctb)
+ }
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_DEBUG)
++
++#ifdef CONFIG_FUNCTION_ERROR_INJECTION
++/*
++ * This is a helper function which assists the driver in identifying if a fault
++ * injection test is currently active, allowing it to reduce unnecessary debug
++ * output. Typically, the function returns zero, but the fault injection
++ * framework can alter this to return an error. Since faults are injected
++ * through this function, it's important to ensure the compiler doesn't optimize
++ * it into an inline function. To avoid such optimization, the 'noinline'
++ * attribute is applied. Compiler optimizes the static function defined in the
++ * header file as an inline function.
++ */
++noinline int xe_is_injection_active(void) { return 0; }
++ALLOW_ERROR_INJECTION(xe_is_injection_active, ERRNO);
++#else
++int xe_is_injection_active(void) { return 0; }
++#endif
++
+ static void ct_dead_capture(struct xe_guc_ct *ct, struct guc_ctb *ctb, u32 reason_code)
+ {
+ 	struct xe_guc_log_snapshot *snapshot_log;
+@@ -1779,6 +1797,12 @@ static void ct_dead_capture(struct xe_guc_ct *ct, struct guc_ctb *ctb, u32 reaso
+ 
+ 	if (ctb)
+ 		ctb->info.broken = true;
++	/*
++	 * Huge dump is getting generated when injecting error for guc CT/MMIO
++	 * functions. So, let us suppress the dump when fault is injected.
++	 */
++	if (xe_is_injection_active())
++		return;
+ 
+ 	/* Ignore further errors after the first dump until a reset */
+ 	if (ct->dead.reported)
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Add-xe_mmio_init-initialization-function.patch
+++ b/backport/patches/base/0001-drm-xe-Add-xe_mmio_init-initialization-function.patch
@@ -1,0 +1,165 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ilia Levi <ilia.levi@intel.com>
+Date: Thu, 13 Feb 2025 11:35:59 +0200
+Subject: drm/xe: Add xe_mmio_init() initialization function
+
+Add a convenience function for minimal initialization of struct xe_mmio.
+This function also validates that the entirety of the provided mmio region
+is usable with struct xe_reg.
+
+v2: Modify commit message, add kernel doc, refactor assert (Michal)
+v3: Fix off-by-one bug, add clarifying macro (Michal)
+v4: Derive bitfield width from size (Michal)
+
+Signed-off-by: Ilia Levi <ilia.levi@intel.com>
+Reviewed-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250213093559.204652-1-ilia.levi@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit eb79d71e506a1caeb0dedd1bab0e6899e8e74f5b linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_reg_defs.h | 14 +++++++++++-
+ drivers/gpu/drm/xe/xe_gt.c            |  7 +++---
+ drivers/gpu/drm/xe/xe_mmio.c          | 32 ++++++++++++++++++---------
+ drivers/gpu/drm/xe/xe_mmio.h          |  2 ++
+ 4 files changed, 39 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_reg_defs.h b/drivers/gpu/drm/xe/regs/xe_reg_defs.h
+index 0eedd6c26b1b..3d359cab578e 100644
+--- a/drivers/gpu/drm/xe/regs/xe_reg_defs.h
++++ b/drivers/gpu/drm/xe/regs/xe_reg_defs.h
+@@ -7,9 +7,21 @@
+ #define _XE_REG_DEFS_H_
+ 
+ #include <linux/build_bug.h>
++#include <linux/log2.h>
++#include <linux/sizes.h>
+ 
+ #include "compat-i915-headers/i915_reg_defs.h"
+ 
++/**
++ * XE_REG_ADDR_MAX - The upper limit on MMIO register address
++ *
++ * This macro specifies the upper limit (not inclusive) on MMIO register offset
++ * supported by struct xe_reg and functions based on struct xe_mmio.
++ *
++ * Currently this is defined as 4 MiB.
++ */
++#define XE_REG_ADDR_MAX	SZ_4M
++
+ /**
+  * struct xe_reg - Register definition
+  *
+@@ -21,7 +33,7 @@ struct xe_reg {
+ 	union {
+ 		struct {
+ 			/** @addr: address */
+-			u32 addr:28;
++			u32 addr:const_ilog2(XE_REG_ADDR_MAX);
+ 			/**
+ 			 * @masked: register is "masked", with upper 16bits used
+ 			 * to identify the bits that are updated on the lower
+diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
+index 6b4b9eca2c38..8be2d31d0ad9 100644
+--- a/drivers/gpu/drm/xe/xe_gt.c
++++ b/drivers/gpu/drm/xe/xe_gt.c
+@@ -642,10 +642,9 @@ int xe_gt_init(struct xe_gt *gt)
+ void xe_gt_mmio_init(struct xe_gt *gt)
+ {
+ 	struct xe_tile *tile = gt_to_tile(gt);
++	struct xe_device *xe = tile_to_xe(tile);
+ 
+-	gt->mmio.regs = tile->mmio.regs;
+-	gt->mmio.regs_size = tile->mmio.regs_size;
+-	gt->mmio.tile = tile;
++	xe_mmio_init(&gt->mmio, tile, tile->mmio.regs, tile->mmio.regs_size);
+ 
+ 	if (gt->info.type == XE_GT_TYPE_MEDIA) {
+ 		gt->mmio.adj_offset = MEDIA_GT_GSI_OFFSET;
+@@ -655,7 +654,7 @@ void xe_gt_mmio_init(struct xe_gt *gt)
+ 		gt->mmio.adj_limit = 0;
+ 	}
+ 
+-	if (IS_SRIOV_VF(gt_to_xe(gt)))
++	if (IS_SRIOV_VF(xe))
+ 		gt->mmio.sriov_vf_gt = gt;
+ }
+ 
+diff --git a/drivers/gpu/drm/xe/xe_mmio.c b/drivers/gpu/drm/xe/xe_mmio.c
+index 9c2f60ce0c94..c83141e91a3b 100644
+--- a/drivers/gpu/drm/xe/xe_mmio.c
++++ b/drivers/gpu/drm/xe/xe_mmio.c
+@@ -55,7 +55,6 @@ static void tiles_fini(void *arg)
+ static void mmio_multi_tile_setup(struct xe_device *xe, size_t tile_mmio_size)
+ {
+ 	struct xe_tile *tile;
+-	void __iomem *regs;
+ 	u8 id;
+ 
+ 	/*
+@@ -94,13 +93,8 @@ static void mmio_multi_tile_setup(struct xe_device *xe, size_t tile_mmio_size)
+ 		}
+ 	}
+ 
+-	regs = xe->mmio.regs;
+-	for_each_tile(tile, xe, id) {
+-		tile->mmio.regs_size = SZ_4M;
+-		tile->mmio.regs = regs;
+-		tile->mmio.tile = tile;
+-		regs += tile_mmio_size;
+-	}
++	for_each_remote_tile(tile, xe, id)
++		xe_mmio_init(&tile->mmio, tile, xe->mmio.regs + id * tile_mmio_size, SZ_4M);
+ }
+ 
+ /*
+@@ -179,13 +173,29 @@ int xe_mmio_init(struct xe_device *xe)
+ 	}
+ 
+ 	/* Setup first tile; other tiles (if present) will be setup later. */
+-	root_tile->mmio.regs_size = SZ_4M;
+-	root_tile->mmio.regs = xe->mmio.regs;
+-	root_tile->mmio.tile = root_tile;
++	xe_mmio_init(&root_tile->mmio, root_tile, xe->mmio.regs, SZ_4M);
+ 
+ 	return devm_add_action_or_reset(xe->drm.dev, mmio_fini, xe);
+ }
+ 
++/**
++ * xe_mmio_init() - Initialize an MMIO instance
++ * @mmio: Pointer to the MMIO instance to initialize
++ * @tile: The tile to which the MMIO region belongs
++ * @ptr: Pointer to the start of the MMIO region
++ * @size: The size of the MMIO region in bytes
++ *
++ * This is a convenience function for minimal initialization of struct xe_mmio.
++ */
++void xe_mmio_init(struct xe_mmio *mmio, struct xe_tile *tile, void __iomem *ptr, u32 size)
++{
++	xe_tile_assert(tile, size <= XE_REG_ADDR_MAX);
++
++	mmio->regs = ptr;
++	mmio->regs_size = size;
++	mmio->tile = tile;
++}
++
+ static void mmio_flush_pending_writes(struct xe_mmio *mmio)
+ {
+ #define DUMMY_REG_OFFSET	0x130030
+diff --git a/drivers/gpu/drm/xe/xe_mmio.h b/drivers/gpu/drm/xe/xe_mmio.h
+index 8a46f4006a84..6c58f2d6422d 100644
+--- a/drivers/gpu/drm/xe/xe_mmio.h
++++ b/drivers/gpu/drm/xe/xe_mmio.h
+@@ -14,6 +14,8 @@ struct xe_reg;
+ int xe_mmio_init(struct xe_device *xe);
+ int xe_mmio_probe_tiles(struct xe_device *xe);
+ 
++void xe_mmio_init(struct xe_mmio *mmio, struct xe_tile *tile, void __iomem *ptr, u32 size);
++
+ u8 xe_mmio_read8(struct xe_mmio *mmio, struct xe_reg reg);
+ u16 xe_mmio_read16(struct xe_mmio *mmio, struct xe_reg reg);
+ void xe_mmio_write32(struct xe_mmio *mmio, struct xe_reg reg, u32 val);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Allow-fault-injection-in-exec-queue-IOCTLs.patch
+++ b/backport/patches/base/0001-drm-xe-Allow-fault-injection-in-exec-queue-IOCTLs.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Francois Dugast <francois.dugast@intel.com>
+Date: Wed, 5 Mar 2025 16:06:59 +0100
+Subject: drm/xe: Allow fault injection in exec queue IOCTLs
+
+Use fault injection infrastructure to allow specific functions to
+be configured over debugfs for failing during the execution of
+xe_exec_queue_create_ioctl(). xe_exec_queue_destroy_ioctl() and
+xe_exec_queue_get_property_ioctl() are not considered as there is
+no unwinding code to test with fault injection.
+
+This allows more thorough testing from user space by going through
+code paths for error handling and unwinding which cannot be reached
+by simply injecting errors in IOCTL arguments. This can help
+increase code robustness.
+
+The corresponding IGT series is:
+https://patchwork.freedesktop.org/series/144138/
+
+Reviewed-by: Sai Teja Pottumuttu <sai.teja.pottumuttu@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250305150659.46276-1-francois.dugast@intel.com
+Signed-off-by: Francois Dugast <francois.dugast@intel.com>
+(cherry picked from commit 5148da09dcd3f00913ddfc5d03901c4de56b61e3 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_exec_queue.c      | 1 +
+ drivers/gpu/drm/xe/xe_hw_engine_group.c | 1 +
+ drivers/gpu/drm/xe/xe_vm.c              | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index e5d4e8af2337..cd19a729d84c 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -173,6 +173,7 @@ struct xe_exec_queue *xe_exec_queue_create(struct xe_device *xe, struct xe_vm *v
+ 	__xe_exec_queue_free(q);
+ 	return ERR_PTR(err);
+ }
++ALLOW_ERROR_INJECTION(xe_exec_queue_create, ERRNO);
+ 
+ struct xe_exec_queue *xe_exec_queue_create_class(struct xe_device *xe, struct xe_gt *gt,
+ 						 struct xe_vm *vm,
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine_group.c b/drivers/gpu/drm/xe/xe_hw_engine_group.c
+index 82750520a90a..2d68c5b5262a 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine_group.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine_group.c
+@@ -178,6 +178,7 @@ int xe_hw_engine_group_add_exec_queue(struct xe_hw_engine_group *group, struct x
+ 	up_write(&group->mode_sem);
+ 	return err;
+ }
++ALLOW_ERROR_INJECTION(xe_hw_engine_group_add_exec_queue, ERRNO);
+ 
+ /**
+  * xe_hw_engine_group_del_exec_queue() - Delete an exec queue from a hw engine group
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 8516ae4bf881..6ddfb5cb1ed8 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -272,6 +272,7 @@ int xe_vm_add_compute_exec_queue(struct xe_vm *vm, struct xe_exec_queue *q)
+ 
+ 	return err;
+ }
++ALLOW_ERROR_INJECTION(xe_vm_add_compute_exec_queue, ERRNO);
+ 
+ /**
+  * xe_vm_remove_compute_exec_queue() - Remove compute exec queue from VM
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Allow-to-inject-error-in-early-probe.patch
+++ b/backport/patches/base/0001-drm-xe-Allow-to-inject-error-in-early-probe.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Fri, 14 Mar 2025 06:54:27 -0700
+Subject: drm/xe: Allow to inject error in early probe
+
+Allow to test if driver behaves correctly when xe_pcode_probe_early()
+fails. Note that this is not sufficient for testing survivability mode
+as it's still required to read the hw to check for errors, which doesn't
+happen on an injected failure.
+
+To complete the early probe coverage, allow injection in the other
+functions as well: xe_mmio_probe_early() and xe_device_probe_early().
+
+Reviewed-by: Francois Dugast <francois.dugast@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250314-fix-survivability-v5-3-fdb3559ea965@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit 676da6ba5bdc1997910ac1cc901cbf16bc6f6d97 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c | 1 +
+ drivers/gpu/drm/xe/xe_mmio.c   | 2 +-
+ drivers/gpu/drm/xe/xe_pcode.c  | 2 ++
+ 3 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index a98f477d377f..0d4ebe575a3d 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -600,6 +600,7 @@ int xe_device_probe_early(struct xe_device *xe)
+ 
+ 	return 0;
+ }
++ALLOW_ERROR_INJECTION(xe_device_probe_early, ERRNO); /* See xe_pci_probe() */
+ 
+ static int probe_has_flat_ccs(struct xe_device *xe)
+ {
+diff --git a/drivers/gpu/drm/xe/xe_mmio.c b/drivers/gpu/drm/xe/xe_mmio.c
+index dd167c84bf32..ad39c54f2eec 100644
+--- a/drivers/gpu/drm/xe/xe_mmio.c
++++ b/drivers/gpu/drm/xe/xe_mmio.c
+@@ -177,7 +177,7 @@ int xe_mmio_probe_early(struct xe_device *xe)
+ 
+ 	return devm_add_action_or_reset(xe->drm.dev, mmio_fini, xe);
+ }
+-
++ALLOW_ERROR_INJECTION(xe_mmio_probe_early, ERRNO); /* See xe_pci_probe() */
+ /**
+  * xe_mmio_init() - Initialize an MMIO instance
+  * @mmio: Pointer to the MMIO instance to initialize
+diff --git a/drivers/gpu/drm/xe/xe_pcode.c b/drivers/gpu/drm/xe/xe_pcode.c
+index 5ff2d0e45ab7..9189117fe825 100644
+--- a/drivers/gpu/drm/xe/xe_pcode.c
++++ b/drivers/gpu/drm/xe/xe_pcode.c
+@@ -7,6 +7,7 @@
+ 
+ #include <linux/delay.h>
+ #include <linux/errno.h>
++#include <linux/error-injection.h>
+ 
+ #include <drm/drm_managed.h>
+ 
+@@ -334,3 +335,4 @@ int xe_pcode_probe_early(struct xe_device *xe)
+ {
+ 	return xe_pcode_ready(xe, false);
+ }
++ALLOW_ERROR_INJECTION(xe_pcode_probe_early, ERRNO); /* See xe_pci_probe */
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Introduce-fault-injection-for-guc-CTB-send-re.patch
+++ b/backport/patches/base/0001-drm-xe-Introduce-fault-injection-for-guc-CTB-send-re.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Date: Thu, 3 Apr 2025 17:36:41 +0530
+Subject: drm/xe: Introduce fault injection for guc CTB send/recv
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fault can be injected with below steps.
+
+FAILTYPE=fail_function
+FAILFUNC=xe_guc_ct_send_recv
+
+echo > /sys/kernel/debug/$FAILTYPE/inject
+echo $FAILFUNC > /sys/kernel/debug/$FAILTYPE/inject
+printf %#x -19 > /sys/kernel/debug/$FAILTYPE/$FAILFUNC/retval
+
+echo N > /sys/kernel/debug/$FAILTYPE/task-filter
+echo 10 > /sys/kernel/debug/$FAILTYPE/probability
+echo 0 > /sys/kernel/debug/$FAILTYPE/interval
+echo -1 > /sys/kernel/debug/$FAILTYPE/times
+echo 0 > /sys/kernel/debug/$FAILTYPE/space
+echo 1 > /sys/kernel/debug/$FAILTYPE/verbose
+
+Signed-off-by: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Michał Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://lore.kernel.org/r/20250403120641.7258-3-satyanarayana.k.v.p@intel.com
+(cherry picked from commit 104080e33937aad54b4fbbe847bba750847abfdb linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc_ct.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc_ct.c b/drivers/gpu/drm/xe/xe_guc_ct.c
+index 72ad576fc18e..5a020fea997f 100644
+--- a/drivers/gpu/drm/xe/xe_guc_ct.c
++++ b/drivers/gpu/drm/xe/xe_guc_ct.c
+@@ -1088,6 +1088,7 @@ int xe_guc_ct_send_recv(struct xe_guc_ct *ct, const u32 *action, u32 len,
+ 	KUNIT_STATIC_STUB_REDIRECT(xe_guc_ct_send_recv, ct, action, len, response_buffer);
+ 	return guc_ct_send_recv(ct, action, len, response_buffer, false);
+ }
++ALLOW_ERROR_INJECTION(xe_guc_ct_send_recv, ERRNO);
+ 
+ int xe_guc_ct_send_recv_no_fail(struct xe_guc_ct *ct, const u32 *action,
+ 				u32 len, u32 *response_buffer)
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Introduce-fault-injection-for-guc-mmio-send-r.patch
+++ b/backport/patches/base/0001-drm-xe-Introduce-fault-injection-for-guc-mmio-send-r.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Date: Thu, 3 Apr 2025 17:36:40 +0530
+Subject: drm/xe: Introduce fault injection for guc mmio send/recv.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fault can be injected with below steps.
+
+FAILTYPE=fail_function
+FAILFUNC=xe_guc_mmio_send_recv
+
+echo > /sys/kernel/debug/$FAILTYPE/inject
+echo $FAILFUNC > /sys/kernel/debug/$FAILTYPE/inject
+printf %#x -5 > /sys/kernel/debug/$FAILTYPE/$FAILFUNC/retval
+
+echo N > /sys/kernel/debug/$FAILTYPE/task-filter
+echo 10 > /sys/kernel/debug/$FAILTYPE/probability
+echo 0 > /sys/kernel/debug/$FAILTYPE/interval
+echo -1 > /sys/kernel/debug/$FAILTYPE/times
+echo 0 > /sys/kernel/debug/$FAILTYPE/space
+echo 1 > /sys/kernel/debug/$FAILTYPE/verbose
+
+Signed-off-by: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Michał Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://lore.kernel.org/r/20250403120641.7258-2-satyanarayana.k.v.p@intel.com
+(cherry picked from commit e9dea328e8392d01b21544587cbcf313e4fdbe26 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
+index f229745b78b9..352a53e0d7d0 100644
+--- a/drivers/gpu/drm/xe/xe_guc.c
++++ b/drivers/gpu/drm/xe/xe_guc.c
+@@ -1388,6 +1388,7 @@ int xe_guc_mmio_send_recv(struct xe_guc *guc, const u32 *request,
+ 	/* Use data from the GuC response as our return value */
+ 	return FIELD_GET(GUC_HXG_RESPONSE_MSG_0_DATA0, header);
+ }
++ALLOW_ERROR_INJECTION(xe_guc_mmio_send_recv, ERRNO);
+ 
+ int xe_guc_mmio_send(struct xe_guc *guc, const u32 *request, u32 len)
+ {
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-hw_engine_class_sysfs-Allow-to-inject-error-d.patch
+++ b/backport/patches/base/0001-drm-xe-hw_engine_class_sysfs-Allow-to-inject-error-d.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Francois Dugast <francois.dugast@intel.com>
+Date: Fri, 14 Mar 2025 11:50:50 +0100
+Subject: drm/xe/hw_engine_class_sysfs: Allow to inject error during
+ probe
+
+Allow fault injection in a function used during initialization by
+xe_hw_engine_class_sysfs_init() so that its error handling can be
+tested.
+
+Signed-off-by: Francois Dugast <francois.dugast@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250314105050.636983-1-francois.dugast@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry picked from commit ac7759c74a602688c77519f056bd83ab657a73a3 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_hw_engine_class_sysfs.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine_class_sysfs.c b/drivers/gpu/drm/xe/xe_hw_engine_class_sysfs.c
+index a440442b4d72..640950172088 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine_class_sysfs.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine_class_sysfs.c
+@@ -605,6 +605,7 @@ static int xe_add_hw_engine_class_defaults(struct xe_device *xe,
+ 	kobject_put(kobj);
+ 	return err;
+ }
++ALLOW_ERROR_INJECTION(xe_add_hw_engine_class_defaults, ERRNO); /* See xe_pci_probe() */
+ 
+ 
+ static void hw_engine_class_sysfs_fini(void *arg)
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-s-xe_mmio_init-xe_mmio_probe_early.patch
+++ b/backport/patches/base/0001-drm-xe-s-xe_mmio_init-xe_mmio_probe_early.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ilia Levi <ilia.levi@intel.com>
+Date: Thu, 30 Jan 2025 12:50:56 +0200
+Subject: drm/xe: s/xe_mmio_init/xe_mmio_probe_early
+
+Rename so that xe_mmio_init() can be used in subsequent patches to
+initialize an instance of struct xe_mmio.
+
+Signed-off-by: Ilia Levi <ilia.levi@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250130105057.136586-1-ilia.levi@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c | 2 +-
+ drivers/gpu/drm/xe/xe_mmio.c   | 6 +++---
+ drivers/gpu/drm/xe/xe_mmio.h   | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 687289e3fdb2..a98f477d377f 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -580,7 +580,7 @@ int xe_device_probe_early(struct xe_device *xe)
+ {
+ 	int err;
+ 
+-	err = xe_mmio_init(xe);
++	err = xe_mmio_probe_early(xe);
+ 	if (err)
+ 		return err;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_mmio.c b/drivers/gpu/drm/xe/xe_mmio.c
+index c83141e91a3b..dd167c84bf32 100644
+--- a/drivers/gpu/drm/xe/xe_mmio.c
++++ b/drivers/gpu/drm/xe/xe_mmio.c
+@@ -59,7 +59,7 @@ static void mmio_multi_tile_setup(struct xe_device *xe, size_t tile_mmio_size)
+ 
+ 	/*
+ 	 * Nothing to be done as tile 0 has already been setup earlier with the
+-	 * entire BAR mapped - see xe_mmio_init()
++	 * entire BAR mapped - see xe_mmio_probe_early()
+ 	 */
+ 	if (xe->info.tile_count == 1)
+ 		return;
+@@ -73,7 +73,7 @@ static void mmio_multi_tile_setup(struct xe_device *xe, size_t tile_mmio_size)
+ 		/*
+ 		 * Although the per-tile mmio regs are not yet initialized, this
+ 		 * is fine as it's going to the root tile's mmio, that's
+-		 * guaranteed to be initialized earlier in xe_mmio_init()
++		 * guaranteed to be initialized earlier in xe_mmio_probe_early()
+ 		 */
+ 		mtcfg = xe_mmio_read32(mmio, XEHP_MTCFG_ADDR);
+ 		tile_count = REG_FIELD_GET(TILE_COUNT, mtcfg) + 1;
+@@ -155,7 +155,7 @@ static void mmio_fini(void *arg)
+ 	root_tile->mmio.regs = NULL;
+ }
+ 
+-int xe_mmio_init(struct xe_device *xe)
++int xe_mmio_probe_early(struct xe_device *xe)
+ {
+ 	struct xe_tile *root_tile = xe_device_get_root_tile(xe);
+ 	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+diff --git a/drivers/gpu/drm/xe/xe_mmio.h b/drivers/gpu/drm/xe/xe_mmio.h
+index 6c58f2d6422d..c151ba569003 100644
+--- a/drivers/gpu/drm/xe/xe_mmio.h
++++ b/drivers/gpu/drm/xe/xe_mmio.h
+@@ -11,7 +11,7 @@
+ struct xe_device;
+ struct xe_reg;
+ 
+-int xe_mmio_init(struct xe_device *xe);
++int xe_mmio_probe_early(struct xe_device *xe);
+ int xe_mmio_probe_tiles(struct xe_device *xe);
+ 
+ void xe_mmio_init(struct xe_mmio *mmio, struct xe_tile *tile, void __iomem *ptr, u32 size);
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -23,6 +23,16 @@ backport/patches/base/0001-drm-xe-hwmon-Read-energy-status-from-PMT.patch
 backport/patches/base/0001-drm-xe-hwmon-Expose-power-sysfs-entries-based-on-fir.patch
 backport/patches/base/0001-drm-xe-Default-auto_link_downgrade-status-to-false.patch
 backport/patches/base/0001-drm-xe-hwmon-Fix-xe_hwmon_power_max_write.patch
+backport/patches/base/0001-drm-xe-Add-xe_mmio_init-initialization-function.patch
+backport/patches/base/0001-drm-xe-s-xe_mmio_init-xe_mmio_probe_early.patch
+backport/patches/base/0001-drm-xe-Add-fault-injection-for-xe_sync_entry_parse.patch
+backport/patches/base/0001-drm-xe-Allow-fault-injection-in-exec-queue-IOCTLs.patch
+backport/patches/base/0001-drm-xe-Allow-to-inject-error-in-early-probe.patch
+backport/patches/base/0001-drm-xe-hw_engine_class_sysfs-Allow-to-inject-error-d.patch
+backport/patches/base/0001-drm-xe-Add-fault-injection-for-xe_oa_alloc_regs.patch
+backport/patches/base/0001-drm-xe-Introduce-fault-injection-for-guc-mmio-send-r.patch
+backport/patches/base/0001-drm-xe-Introduce-fault-injection-for-guc-CTB-send-re.patch
+backport/patches/base/0001-drm-xe-Add-helper-function-to-inject-fault-into-ct_d.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
This change introduces fault injection support across multiple
critical paths in the `drm/xe` driver to improve error-handling
coverage and exercise rarely triggered failure paths.

Issue: igt@xe_fault_injection@* failure

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>