### PR TITLE
features/eu-debug: Add DRM-managed cleanup support to avoid early release issues

### DIFF
--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-add-eudebug-drm-managed-finalize.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-add-eudebug-drm-managed-finalize.patch
@@ -1,0 +1,128 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Date: Mon, 9 Jun 2025 12:46:28 +0200
+Subject: [PATCH] drm/xe/eudebug: add eudebug drm managed finalize
+
+xe_eudebug_fini() can be called too early, that is before
+xe_eudebug_init() on some probe failures and this leads to
+errors/assert.
+
+xe_eudebug_fini() was called from xe_device_destroy() which is
+drm release managed function.
+Instead of being called from xe_device_destroy() it's better to add
+xe_eudebug_fini() as drm release managed function which is added only
+if xe_eudebug_init() was actually called.
+The advantage is that xe_eudebug_fini() will be called before
+xe_device_destroy().
+
+Reworked also sysfs init in the same way.
+
+Jira: VLK-73787
+
+Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
+Reviewed-by: Christoph Manszewski <christoph.manszewski@intel.com>
+(backported from commit 5ac85708cfba5a908bf24c0cb30a5d74faa29474 eudebug-dev)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/prelim/xe_eudebug.c | 39 +++++++++++++++++---------
+ drivers/gpu/drm/xe/prelim/xe_eudebug.h |  1 -
+ drivers/gpu/drm/xe/xe_device.c         |  2 --
+ 3 files changed, 25 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/prelim/xe_eudebug.c b/drivers/gpu/drm/xe/prelim/xe_eudebug.c
+index 638d59db3362..e2bebdb1f9fe 100644
+--- a/drivers/gpu/drm/xe/prelim/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.c
+@@ -2423,16 +2423,26 @@ static ssize_t prelim_enable_eudebug_store(struct device *dev, struct device_att
+ 
+ static DEVICE_ATTR_RW(prelim_enable_eudebug);
+ 
+-static void xe_eudebug_sysfs_fini(void *arg)
++static void prelim_xe_eudebug_sysfs_fini(struct drm_device *dev, void *__unused)
+ {
+-	struct xe_device *xe = arg;
++	struct xe_device *xe = to_xe_device(dev);
+ 
+ 	sysfs_remove_file(&xe->drm.dev->kobj, &dev_attr_prelim_enable_eudebug.attr);
+ }
+ 
++static void prelim_xe_eudebug_fini(struct drm_device *dev, void *__unused)
++{
++	struct xe_device *xe = to_xe_device(dev);
++
++	attention_scan_cancel(xe);
++	xe_assert(xe, list_empty_careful(&xe->eudebug.list));
++
++	if (xe->eudebug.ordered_wq)
++		destroy_workqueue(xe->eudebug.ordered_wq);
++}
++
+ void prelim_xe_eudebug_init(struct xe_device *xe)
+ {
+-	struct device *dev = xe->drm.dev;
+ 	int ret;
+ 
+ 	spin_lock_init(&xe->eudebug.lock);
+@@ -2449,22 +2459,23 @@ void prelim_xe_eudebug_init(struct xe_device *xe)
+ 	if (!xe->eudebug.available)
+ 		return;
+ 
++	ret = drmm_add_action_or_reset(&xe->drm, prelim_xe_eudebug_fini, NULL);
++	if (ret) {
++		drm_warn(&xe->drm, "eudebug initialization failed: %d, debugger unavailable\n", ret);
++		return;
++	}
++
+ 	ret = sysfs_create_file(&xe->drm.dev->kobj, &dev_attr_prelim_enable_eudebug.attr);
+ 	if (ret)
+ 		drm_warn(&xe->drm, "eudebug sysfs init failed: %d, debugger unavailable\n", ret);
+-	else
+-		devm_add_action_or_reset(dev, xe_eudebug_sysfs_fini, xe);
+ 
+-	xe->eudebug.available = ret == 0;
+-}
+-
+-void prelim_xe_eudebug_fini(struct xe_device *xe)
+-{
+-	attention_scan_cancel(xe);
+-	xe_assert(xe, list_empty_careful(&xe->eudebug.list));
++	ret = drmm_add_action_or_reset(&xe->drm, prelim_xe_eudebug_sysfs_fini, NULL);
++	if (ret) {
++		drm_warn(&xe->drm, "eudebug sysfs post-init failed: %d, debugger unavailable\n", ret);
++		return;
++	}
+ 
+-	if (xe->eudebug.ordered_wq)
+-		destroy_workqueue(xe->eudebug.ordered_wq);
++	xe->eudebug.available = ret == 0;
+ }
+ 
+ static int send_open_event(struct xe_eudebug *d, u32 flags, const u64 handle,
+diff --git a/drivers/gpu/drm/xe/prelim/xe_eudebug.h b/drivers/gpu/drm/xe/prelim/xe_eudebug.h
+index 6c442395228c..2cb5b083deb7 100644
+--- a/drivers/gpu/drm/xe/prelim/xe_eudebug.h
++++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.h
+@@ -28,7 +28,6 @@ int prelim_xe_eudebug_connect_ioctl(struct drm_device *dev,
+ 			     struct drm_file *file);
+ 
+ void prelim_xe_eudebug_init(struct xe_device *xe);
+-void prelim_xe_eudebug_fini(struct xe_device *xe);
+ 
+ void prelim_xe_eudebug_file_open(struct xe_file *xef);
+ void prelim_xe_eudebug_file_close(struct xe_file *xef);
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 7d493ed4b92e..899a93f76bce 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -307,8 +307,6 @@ static void xe_device_destroy(struct drm_device *dev, void *dummy)
+ {
+ 	struct xe_device *xe = to_xe_device(dev);
+ 
+-	prelim_xe_eudebug_fini(xe);
+-
+ 	if (xe->preempt_fence_wq)
+ 		destroy_workqueue(xe->preempt_fence_wq);
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -50,3 +50,4 @@ backport/patches/features/eu-debug/0001-drm-xe-eudebug-Enable-EU-pagefault-handl
 backport/patches/features/eu-debug/0001-drm-xe-Add-PRELIM-infrastructure.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-update-eudebug-prelim-flags.patch
+backport/patches/features/eu-debug/0001-drm-xe-eudebug-add-eudebug-drm-managed-finalize.patch


### PR DESCRIPTION
The cleanup logic was previously called unconditionally during device teardown.
However, in some probe failure cases, this could happen before initialization
was completed, leading to failure.
To avoid this, cleanup is now registered as a DRM-managed action, only if
initialization succeeds. This ensures proper cleanup ordering and avoids
premature access to uninitialized structures.
Sysfs setup and teardown are updated similarly to follow the same safe and
managed pattern.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>