### PR TITLE
patches/base: update drm-cycles-* values for active contexts

### DIFF
--- a/backport/patches/base/0001-drm-xe-Add-WA-BB-to-capture-active-context-utilizati.patch
+++ b/backport/patches/base/0001-drm-xe-Add-WA-BB-to-capture-active-context-utilizati.patch
@@ -1,0 +1,576 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Date: Fri, 9 May 2025 09:12:03 -0700
+Subject: drm/xe: Add WA BB to capture active context utilization
+
+Context Timestamp (CTX_TIMESTAMP) in the LRC accumulates the run ticks
+of the context, but only gets updated when the context switches out. In
+order to check how long a context has been active before it switches
+out, two things are required:
+
+(1) Determine if the context is running:
+
+To do so, we program the WA BB to set an initial value for CTX_TIMESTAMP
+in the LRC. The value chosen is 1 since 0 is the initial value when the
+LRC is initialized. During a query, we just check for this value to
+determine if the context is active. If the context switched out, it
+would overwrite this location with the actual CTX_TIMESTAMP MMIO value.
+Note that WA BB runs as the last part of the context restore, so reusing
+this LRC location will not clobber anything.
+
+(2) Calculate the time that the context has been active for:
+
+The CTX_TIMESTAMP ticks only when the context is active. If a context is
+active, we just use the CTX_TIMESTAMP MMIO as the new value of
+utilization. While doing so, we need to read the CTX_TIMESTAMP MMIO
+for the specific engine instance. Since we do not know which instance
+the context is running on until it is scheduled, we also read the
+ENGINE_ID MMIO in the WA BB and store it in the PPHSWP.
+
+Using the above 2 instructions in a WA BB, capture active context
+utilization.
+
+v2: (Matt Brost)
+- This breaks TDR, fix it by saving the CTX_TIMESTAMP register
+  "drm/xe: Save CTX_TIMESTAMP mmio value instead of LRC value"
+- Drop tile from LRC if using gt
+  "drm/xe: Save the gt pointer in LRC and drop the tile"
+
+v3:
+- Remove helpers for bb_per_ctx_ptr (Matt)
+- Add define for context active value (Matt)
+- Use 64 bit CTX TIMESTAMP for platforms that support it. For platforms
+  that don't, live with the rare race. (Matt, Lucas)
+- Convert engine id to hwe and get the MMIO value (Lucas)
+- Correct commit message on when WA BB runs (Lucas)
+
+v4:
+- s/GRAPHICS_VER(...)/xe->info.has_64bit_timestamp/ (Matt)
+- Drop support for active utilization on a VF (CI failure)
+- In xe_lrc_init ensure the lrc value is 0 to begin with (CI regression)
+
+v5:
+- Minor checkpatch fix
+- Squash into previous commit and make TDR use 32-bit time
+- Update code comment to match commit msg
+
+Closes: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues/4532
+Suggested-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Signed-off-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://lore.kernel.org/r/20250509161159.2173069-8-umesh.nerlige.ramappa@intel.com
+(backported from commit 617d824c5323b8474b3665ae6c410c98b839e0b0 linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_engine_regs.h |   5 +
+ drivers/gpu/drm/xe/regs/xe_lrc_layout.h  |   2 +
+ drivers/gpu/drm/xe/xe_device_types.h     |   2 +
+ drivers/gpu/drm/xe/xe_exec_queue.c       |   2 +-
+ drivers/gpu/drm/xe/xe_guc_submit.c       |   2 +-
+ drivers/gpu/drm/xe/xe_lrc.c              | 188 ++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_lrc.h              |   5 +-
+ drivers/gpu/drm/xe/xe_lrc_types.h        |   5 +-
+ drivers/gpu/drm/xe/xe_pci.c              |   2 +
+ drivers/gpu/drm/xe/xe_pci_types.h        |   1 +
+ drivers/gpu/drm/xe/xe_trace_lrc.h        |   8 +-
+ 11 files changed, 206 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
+index b732c8981..db2d7bd7e 100644
+--- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
+@@ -43,6 +43,10 @@
+ #define XEHPC_BCS8_RING_BASE			0x3ee000
+ #define GSCCS_RING_BASE				0x11a000
+ 
++#define ENGINE_ID(base)				XE_REG((base) + 0x8c)
++#define   ENGINE_INSTANCE_ID			REG_GENMASK(9, 4)
++#define   ENGINE_CLASS_ID			REG_GENMASK(2, 0)
++
+ #define RING_TAIL(base)				XE_REG((base) + 0x30)
+ #define   TAIL_ADDR				REG_GENMASK(20, 3)
+ 
+@@ -149,6 +153,7 @@
+ #define   STOP_RING				REG_BIT(8)
+ 
+ #define RING_CTX_TIMESTAMP(base)		XE_REG((base) + 0x3a8)
++#define RING_CTX_TIMESTAMP_UDW(base)		XE_REG((base) + 0x3ac)
+ #define CSBE_DEBUG_STATUS(base)			XE_REG((base) + 0x3fc)
+ 
+ #define RING_FORCE_TO_NONPRIV(base, i)		XE_REG(((base) + 0x4d0) + (i) * 4)
+diff --git a/drivers/gpu/drm/xe/regs/xe_lrc_layout.h b/drivers/gpu/drm/xe/regs/xe_lrc_layout.h
+index 57944f90b..994af591a 100644
+--- a/drivers/gpu/drm/xe/regs/xe_lrc_layout.h
++++ b/drivers/gpu/drm/xe/regs/xe_lrc_layout.h
+@@ -11,7 +11,9 @@
+ #define CTX_RING_TAIL			(0x06 + 1)
+ #define CTX_RING_START			(0x08 + 1)
+ #define CTX_RING_CTL			(0x0a + 1)
++#define CTX_BB_PER_CTX_PTR		(0x12 + 1)
+ #define CTX_TIMESTAMP			(0x22 + 1)
++#define CTX_TIMESTAMP_UDW		(0x24 + 1)
+ #define CTX_INDIRECT_RING_STATE		(0x26 + 1)
+ #define CTX_PDP0_UDW			(0x30 + 1)
+ #define CTX_PDP0_LDW			(0x32 + 1)
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index a7320bd97..bcb3f8fef 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -329,6 +329,8 @@ struct xe_device {
+ 		u8 has_sriov:1;
+ 		/** @info.has_usm: Device has unified shared memory support */
+ 		u8 has_usm:1;
++		/** @info.has_64bit_timestamp: Device supports 64-bit timestamps */
++		u8 has_64bit_timestamp:1;
+ 		/** @info.is_dgfx: is discrete device */
+ 		u8 is_dgfx:1;
+ 		/**
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index 7e1abbbfb..42ca0e549 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -771,7 +771,7 @@ void xe_exec_queue_update_run_ticks(struct xe_exec_queue *q)
+ {
+ 	struct xe_device *xe = gt_to_xe(q->gt);
+ 	struct xe_lrc *lrc;
+-	u32 old_ts, new_ts;
++	u64 old_ts, new_ts;
+ 	int idx;
+ 
+ 	/*
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index 1a5fe4822..21a24ae4c 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -933,7 +933,7 @@ static bool check_timeout(struct xe_exec_queue *q, struct xe_sched_job *job)
+ 		return xe_sched_invalidate_job(job, 2);
+ 	}
+ 
+-	ctx_timestamp = xe_lrc_ctx_timestamp(q->lrc[0]);
++	ctx_timestamp = lower_32_bits(xe_lrc_ctx_timestamp(q->lrc[0]));
+ 	ctx_job_timestamp = xe_lrc_ctx_job_timestamp(q->lrc[0]);
+ 
+ 	/*
+diff --git a/drivers/gpu/drm/xe/xe_lrc.c b/drivers/gpu/drm/xe/xe_lrc.c
+index 5d7629bb6..e43f53fe7 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.c
++++ b/drivers/gpu/drm/xe/xe_lrc.c
+@@ -24,6 +24,7 @@
+ #include "xe_hw_fence.h"
+ #include "xe_map.h"
+ #include "xe_memirq.h"
++#include "xe_mmio.h"
+ #include "xe_sriov.h"
+ #include "xe_trace_lrc.h"
+ #include "xe_vm.h"
+@@ -650,6 +651,7 @@ u32 xe_lrc_pphwsp_offset(struct xe_lrc *lrc)
+ #define LRC_START_SEQNO_PPHWSP_OFFSET (LRC_SEQNO_PPHWSP_OFFSET + 8)
+ #define LRC_CTX_JOB_TIMESTAMP_OFFSET (LRC_START_SEQNO_PPHWSP_OFFSET + 8)
+ #define LRC_PARALLEL_PPHWSP_OFFSET 2048
++#define LRC_ENGINE_ID_PPHWSP_OFFSET 2096
+ #define LRC_PPHWSP_SIZE SZ_4K
+ 
+ u32 xe_lrc_regs_offset(struct xe_lrc *lrc)
+@@ -694,11 +696,21 @@ static inline u32 __xe_lrc_parallel_offset(struct xe_lrc *lrc)
+ 	return xe_lrc_pphwsp_offset(lrc) + LRC_PARALLEL_PPHWSP_OFFSET;
+ }
+ 
++static inline u32 __xe_lrc_engine_id_offset(struct xe_lrc *lrc)
++{
++	return xe_lrc_pphwsp_offset(lrc) + LRC_ENGINE_ID_PPHWSP_OFFSET;
++}
++
+ static u32 __xe_lrc_ctx_timestamp_offset(struct xe_lrc *lrc)
+ {
+ 	return __xe_lrc_regs_offset(lrc) + CTX_TIMESTAMP * sizeof(u32);
+ }
+ 
++static u32 __xe_lrc_ctx_timestamp_udw_offset(struct xe_lrc *lrc)
++{
++	return __xe_lrc_regs_offset(lrc) + CTX_TIMESTAMP_UDW * sizeof(u32);
++}
++
+ static inline u32 __xe_lrc_indirect_ring_offset(struct xe_lrc *lrc)
+ {
+ 	/* Indirect ring state page is at the very end of LRC */
+@@ -726,8 +738,10 @@ DECL_MAP_ADDR_HELPERS(regs)
+ DECL_MAP_ADDR_HELPERS(start_seqno)
+ DECL_MAP_ADDR_HELPERS(ctx_job_timestamp)
+ DECL_MAP_ADDR_HELPERS(ctx_timestamp)
++DECL_MAP_ADDR_HELPERS(ctx_timestamp_udw)
+ DECL_MAP_ADDR_HELPERS(parallel)
+ DECL_MAP_ADDR_HELPERS(indirect_ring)
++DECL_MAP_ADDR_HELPERS(engine_id)
+ 
+ #undef DECL_MAP_ADDR_HELPERS
+ 
+@@ -742,19 +756,38 @@ u32 xe_lrc_ctx_timestamp_ggtt_addr(struct xe_lrc *lrc)
+ 	return __xe_lrc_ctx_timestamp_ggtt_addr(lrc);
+ }
+ 
++/**
++ * xe_lrc_ctx_timestamp_udw_ggtt_addr() - Get ctx timestamp udw GGTT address
++ * @lrc: Pointer to the lrc.
++ *
++ * Returns: ctx timestamp udw GGTT address
++ */
++u32 xe_lrc_ctx_timestamp_udw_ggtt_addr(struct xe_lrc *lrc)
++{
++	return __xe_lrc_ctx_timestamp_udw_ggtt_addr(lrc);
++}
++
+ /**
+  * xe_lrc_ctx_timestamp() - Read ctx timestamp value
+  * @lrc: Pointer to the lrc.
+  *
+  * Returns: ctx timestamp value
+  */
+-u32 xe_lrc_ctx_timestamp(struct xe_lrc *lrc)
++u64 xe_lrc_ctx_timestamp(struct xe_lrc *lrc)
+ {
+ 	struct xe_device *xe = lrc_to_xe(lrc);
+ 	struct iosys_map map;
++	u32 ldw, udw = 0;
+ 
+ 	map = __xe_lrc_ctx_timestamp_map(lrc);
+-	return xe_map_read32(xe, &map);
++	ldw = xe_map_read32(xe, &map);
++
++	if (xe->info.has_64bit_timestamp) {
++		map = __xe_lrc_ctx_timestamp_udw_map(lrc);
++		udw = xe_map_read32(xe, &map);
++	}
++
++	return (u64)udw << 32 | ldw;
+ }
+ 
+ /**
+@@ -877,6 +910,65 @@ static void xe_lrc_finish(struct xe_lrc *lrc)
+ 	xe_bo_unpin(lrc->bo);
+ 	xe_bo_unlock(lrc->bo);
+ 	xe_bo_put(lrc->bo);
++	xe_bo_unpin_map_no_vm(lrc->bb_per_ctx_bo);
++}
++
++/*
++ * xe_lrc_setup_utilization() - Setup wa bb to assist in calculating active
++ * context run ticks.
++ * @lrc: Pointer to the lrc.
++ *
++ * Context Timestamp (CTX_TIMESTAMP) in the LRC accumulates the run ticks of the
++ * context, but only gets updated when the context switches out. In order to
++ * check how long a context has been active before it switches out, two things
++ * are required:
++ *
++ * (1) Determine if the context is running:
++ * To do so, we program the WA BB to set an initial value for CTX_TIMESTAMP in
++ * the LRC. The value chosen is 1 since 0 is the initial value when the LRC is
++ * initialized. During a query, we just check for this value to determine if the
++ * context is active. If the context switched out, it would overwrite this
++ * location with the actual CTX_TIMESTAMP MMIO value. Note that WA BB runs as
++ * the last part of context restore, so reusing this LRC location will not
++ * clobber anything.
++ *
++ * (2) Calculate the time that the context has been active for:
++ * The CTX_TIMESTAMP ticks only when the context is active. If a context is
++ * active, we just use the CTX_TIMESTAMP MMIO as the new value of utilization.
++ * While doing so, we need to read the CTX_TIMESTAMP MMIO for the specific
++ * engine instance. Since we do not know which instance the context is running
++ * on until it is scheduled, we also read the ENGINE_ID MMIO in the WA BB and
++ * store it in the PPHSWP.
++ */
++#define CONTEXT_ACTIVE 1ULL
++static void xe_lrc_setup_utilization(struct xe_lrc *lrc)
++{
++	u32 *cmd;
++
++	cmd = lrc->bb_per_ctx_bo->vmap.vaddr;
++
++	*cmd++ = MI_STORE_REGISTER_MEM | MI_SRM_USE_GGTT | MI_SRM_ADD_CS_OFFSET;
++	*cmd++ = ENGINE_ID(0).addr;
++	*cmd++ = __xe_lrc_engine_id_ggtt_addr(lrc);
++	*cmd++ = 0;
++
++	*cmd++ = MI_STORE_DATA_IMM | MI_SDI_GGTT | MI_SDI_NUM_DW(1);
++	*cmd++ = __xe_lrc_ctx_timestamp_ggtt_addr(lrc);
++	*cmd++ = 0;
++	*cmd++ = lower_32_bits(CONTEXT_ACTIVE);
++
++	if (lrc_to_xe(lrc)->info.has_64bit_timestamp) {
++		*cmd++ = MI_STORE_DATA_IMM | MI_SDI_GGTT | MI_SDI_NUM_DW(1);
++		*cmd++ = __xe_lrc_ctx_timestamp_udw_ggtt_addr(lrc);
++		*cmd++ = 0;
++		*cmd++ = upper_32_bits(CONTEXT_ACTIVE);
++	}
++
++	*cmd++ = MI_BATCH_BUFFER_END;
++
++	xe_lrc_write_ctx_reg(lrc, CTX_BB_PER_CTX_PTR,
++			     xe_bo_ggtt_addr(lrc->bb_per_ctx_bo) | 1);
++
+ }
+ 
+ #define PVC_CTX_ASID		(0x2e + 1)
+@@ -892,6 +984,7 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+ 	void *init_data = NULL;
+ 	u32 arb_enable;
+ 	u32 lrc_size;
++	u32 bo_flags;
+ 	int err;
+ 
+ 	kref_init(&lrc->refcount);
+@@ -910,13 +1003,22 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+ 				       XE_BO_FLAG_VRAM_IF_DGFX(tile) |
+ 				       XE_BO_FLAG_GGTT |
+ 				       XE_BO_FLAG_GGTT_INVALIDATE);
++	bo_flags = XE_BO_FLAG_VRAM_IF_DGFX(tile) | XE_BO_FLAG_GGTT |
++				       XE_BO_FLAG_GGTT_INVALIDATE;
+ 	if (IS_ERR(lrc->bo))
+ 		return PTR_ERR(lrc->bo);
+ 
++	lrc->bb_per_ctx_bo = xe_bo_create_pin_map(xe, tile, NULL, SZ_4K,
++						  ttm_bo_type_kernel,
++						  bo_flags);
++	if (IS_ERR(lrc->bb_per_ctx_bo)) {
++		err = PTR_ERR(lrc->bb_per_ctx_bo);
++		goto err_lrc_finish;
++	}
++
+ 	lrc->size = lrc_size;
+ 	lrc->ring.size = ring_size;
+ 	lrc->ring.tail = 0;
+-	lrc->ctx_timestamp = 0;
+ 
+ 	xe_hw_fence_ctx_init(&lrc->fence_ctx, hwe->gt,
+ 			     hwe->fence_irq, hwe->name);
+@@ -979,7 +1081,10 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+ 				     RING_CTL_SIZE(lrc->ring.size) | RING_VALID);
+ 	}
+ 
++	lrc->ctx_timestamp = 0;
+ 	xe_lrc_write_ctx_reg(lrc, CTX_TIMESTAMP, 0);
++	if (lrc_to_xe(lrc)->info.has_64bit_timestamp)
++		xe_lrc_write_ctx_reg(lrc, CTX_TIMESTAMP_UDW, 0);
+ 
+ 	if (xe->info.has_asid && vm)
+ 		xe_lrc_write_ctx_reg(lrc, PVC_CTX_ASID, vm->usm.asid);
+@@ -1008,6 +1113,8 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+ 	map = __xe_lrc_start_seqno_map(lrc);
+ 	xe_map_write32(lrc_to_xe(lrc), &map, lrc->fence_ctx.next_seqno - 1);
+ 
++	xe_lrc_setup_utilization(lrc);
++
+ 	return 0;
+ 
+ err_lrc_finish:
+@@ -1226,6 +1333,21 @@ struct iosys_map xe_lrc_parallel_map(struct xe_lrc *lrc)
+ 	return __xe_lrc_parallel_map(lrc);
+ }
+ 
++/**
++ * xe_lrc_engine_id() - Read engine id value
++ * @lrc: Pointer to the lrc.
++ *
++ * Returns: context id value
++ */
++static u32 xe_lrc_engine_id(struct xe_lrc *lrc)
++{
++	struct xe_device *xe = lrc_to_xe(lrc);
++	struct iosys_map map;
++
++	map = __xe_lrc_engine_id_map(lrc);
++	return xe_map_read32(xe, &map);
++}
++
+ static int instr_dw(u32 cmd_header)
+ {
+ 	/* GFXPIPE "SINGLE_DW" opcodes are a single dword */
+@@ -1672,7 +1794,7 @@ struct xe_lrc_snapshot *xe_lrc_snapshot_capture(struct xe_lrc *lrc)
+ 	snapshot->lrc_offset = xe_lrc_pphwsp_offset(lrc);
+ 	snapshot->lrc_size = lrc->bo->size - snapshot->lrc_offset;
+ 	snapshot->lrc_snapshot = NULL;
+-	snapshot->ctx_timestamp = xe_lrc_ctx_timestamp(lrc);
++	snapshot->ctx_timestamp = lower_32_bits(xe_lrc_ctx_timestamp(lrc));
+ 	snapshot->ctx_job_timestamp = xe_lrc_ctx_job_timestamp(lrc);
+ 	return snapshot;
+ }
+@@ -1772,22 +1894,74 @@ void xe_lrc_snapshot_free(struct xe_lrc_snapshot *snapshot)
+ 	kfree(snapshot);
+ }
+ 
++static int get_ctx_timestamp(struct xe_lrc *lrc, u32 engine_id, u64 *reg_ctx_ts)
++{
++	u16 class = REG_FIELD_GET(ENGINE_CLASS_ID, engine_id);
++	u16 instance = REG_FIELD_GET(ENGINE_INSTANCE_ID, engine_id);
++	struct xe_hw_engine *hwe;
++	u64 val;
++
++	hwe = xe_gt_hw_engine(lrc->gt, class, instance, false);
++	if (xe_gt_WARN_ONCE(lrc->gt, !hwe || xe_hw_engine_is_reserved(hwe),
++			    "Unexpected engine class:instance %d:%d for context utilization\n",
++			    class, instance))
++		return -1;
++
++	if (lrc_to_xe(lrc)->info.has_64bit_timestamp)
++		val = xe_mmio_read64_2x32(&hwe->gt->mmio,
++					  RING_CTX_TIMESTAMP(hwe->mmio_base));
++	else
++		val = xe_mmio_read32(&hwe->gt->mmio,
++				     RING_CTX_TIMESTAMP(hwe->mmio_base));
++
++	*reg_ctx_ts = val;
++
++	return 0;
++}
++
+ /**
+  * xe_lrc_update_timestamp() - Update ctx timestamp
+  * @lrc: Pointer to the lrc.
+  * @old_ts: Old timestamp value
+  *
+  * Populate @old_ts current saved ctx timestamp, read new ctx timestamp and
+- * update saved value.
++ * update saved value. With support for active contexts, the calculation may be
++ * slightly racy, so follow a read-again logic to ensure that the context is
++ * still active before returning the right timestamp.
+  *
+  * Returns: New ctx timestamp value
+  */
+-u32 xe_lrc_update_timestamp(struct xe_lrc *lrc, u32 *old_ts)
++u64 xe_lrc_update_timestamp(struct xe_lrc *lrc, u64 *old_ts)
+ {
++	u64 lrc_ts, reg_ts;
++	u32 engine_id;
++
+ 	*old_ts = lrc->ctx_timestamp;
+ 
+-	lrc->ctx_timestamp = xe_lrc_ctx_timestamp(lrc);
++	lrc_ts = xe_lrc_ctx_timestamp(lrc);
++	/* CTX_TIMESTAMP mmio read is invalid on VF, so return the LRC value */
++	if (IS_SRIOV_VF(lrc_to_xe(lrc))) {
++		lrc->ctx_timestamp = lrc_ts;
++		goto done;
++	}
++
++	if (lrc_ts == CONTEXT_ACTIVE) {
++		engine_id = xe_lrc_engine_id(lrc);
++		if (!get_ctx_timestamp(lrc, engine_id, &reg_ts))
++			lrc->ctx_timestamp = reg_ts;
++
++		/* read lrc again to ensure context is still active */
++		lrc_ts = xe_lrc_ctx_timestamp(lrc);
++	}
++
++	/*
++	 * If context switched out, just use the lrc_ts. Note that this needs to
++	 * be a separate if condition.
++	 */
++	if (lrc_ts != CONTEXT_ACTIVE)
++		lrc->ctx_timestamp = lrc_ts;
+ 
++done:
+ 	trace_xe_lrc_update_timestamp(lrc, *old_ts);
+ 
+ 	return lrc->ctx_timestamp;
+diff --git a/drivers/gpu/drm/xe/xe_lrc.h b/drivers/gpu/drm/xe/xe_lrc.h
+index 4206e6a8b..13c083559 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.h
++++ b/drivers/gpu/drm/xe/xe_lrc.h
+@@ -117,7 +117,8 @@ void xe_lrc_snapshot_print(struct xe_lrc_snapshot *snapshot, struct drm_printer
+ void xe_lrc_snapshot_free(struct xe_lrc_snapshot *snapshot);
+ 
+ u32 xe_lrc_ctx_timestamp_ggtt_addr(struct xe_lrc *lrc);
+-u32 xe_lrc_ctx_timestamp(struct xe_lrc *lrc);
++u32 xe_lrc_ctx_timestamp_udw_ggtt_addr(struct xe_lrc *lrc);
++u64 xe_lrc_ctx_timestamp(struct xe_lrc *lrc);
+ u32 xe_lrc_ctx_job_timestamp_ggtt_addr(struct xe_lrc *lrc);
+ u32 xe_lrc_ctx_job_timestamp(struct xe_lrc *lrc);
+ 
+@@ -133,6 +134,6 @@ u32 xe_lrc_ctx_job_timestamp(struct xe_lrc *lrc);
+  *
+  * Returns the current LRC timestamp
+  */
+-u32 xe_lrc_update_timestamp(struct xe_lrc *lrc, u32 *old_ts);
++u64 xe_lrc_update_timestamp(struct xe_lrc *lrc, u64 *old_ts);
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_lrc_types.h b/drivers/gpu/drm/xe/xe_lrc_types.h
+index cd38586ae..ae24cf6f8 100644
+--- a/drivers/gpu/drm/xe/xe_lrc_types.h
++++ b/drivers/gpu/drm/xe/xe_lrc_types.h
+@@ -52,7 +52,10 @@ struct xe_lrc {
+ 	struct xe_hw_fence_ctx fence_ctx;
+ 
+ 	/** @ctx_timestamp: readout value of CTX_TIMESTAMP on last update */
+-	u32 ctx_timestamp;
++	u64 ctx_timestamp;
++
++	/** @bb_per_ctx_bo: buffer object for per context batch wa buffer */
++	struct xe_bo *bb_per_ctx_bo;
+ };
+ 
+ struct xe_lrc_snapshot;
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index efe4ea46d..b0007f2dd 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -167,6 +167,7 @@ static const struct xe_graphics_desc graphics_xelpg = {
+ 	.has_indirect_ring_state = 1, \
+ 	.has_range_tlb_invalidation = 1, \
+ 	.has_usm = 1, \
++	.has_64bit_timestamp = 1, \
+ 	.va_bits = 48, \
+ 	.vm_max_level = 4, \
+ 	.hw_engine_mask = \
+@@ -694,6 +695,7 @@ static int xe_info_init(struct xe_device *xe,
+ 
+ 	xe->info.has_range_tlb_invalidation = graphics_desc->has_range_tlb_invalidation;
+ 	xe->info.has_usm = graphics_desc->has_usm;
++	xe->info.has_64bit_timestamp = graphics_desc->has_64bit_timestamp;
+ 
+ 	/*
+ 	 * All platforms have at least one primary GT.  Any platform with media
+diff --git a/drivers/gpu/drm/xe/xe_pci_types.h b/drivers/gpu/drm/xe/xe_pci_types.h
+index 665b4447b..7c3da4640 100644
+--- a/drivers/gpu/drm/xe/xe_pci_types.h
++++ b/drivers/gpu/drm/xe/xe_pci_types.h
+@@ -30,6 +30,7 @@ struct xe_graphics_desc {
+ 	u8 has_indirect_ring_state:1;
+ 	u8 has_range_tlb_invalidation:1;
+ 	u8 has_usm:1;
++	u8 has_64bit_timestamp:1;
+ };
+ 
+ struct xe_media_desc {
+diff --git a/drivers/gpu/drm/xe/xe_trace_lrc.h b/drivers/gpu/drm/xe/xe_trace_lrc.h
+index 5c669a0b2..d525cbee1 100644
+--- a/drivers/gpu/drm/xe/xe_trace_lrc.h
++++ b/drivers/gpu/drm/xe/xe_trace_lrc.h
+@@ -19,12 +19,12 @@
+ #define __dev_name_lrc(lrc)	dev_name(gt_to_xe((lrc)->fence_ctx.gt)->drm.dev)
+ 
+ TRACE_EVENT(xe_lrc_update_timestamp,
+-	    TP_PROTO(struct xe_lrc *lrc, uint32_t old),
++	    TP_PROTO(struct xe_lrc *lrc, uint64_t old),
+ 	    TP_ARGS(lrc, old),
+ 	    TP_STRUCT__entry(
+ 		     __field(struct xe_lrc *, lrc)
+-		     __field(u32, old)
+-		     __field(u32, new)
++		     __field(u64, old)
++		     __field(u64, new)
+ 		     __string(name, lrc->fence_ctx.name)
+ 		     __string(device_id, __dev_name_lrc(lrc))
+ 	    ),
+@@ -36,7 +36,7 @@ TRACE_EVENT(xe_lrc_update_timestamp,
+ 		   __assign_str(name);
+ 		   __assign_str(device_id);
+ 		   ),
+-	    TP_printk("lrc=:%p lrc->name=%s old=%u new=%u device_id:%s",
++	    TP_printk("lrc=:%p lrc->name=%s old=%llu new=%llu device_id:%s",
+ 		      __entry->lrc, __get_str(name),
+ 		      __entry->old, __entry->new,
+ 		      __get_str(device_id))
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-lrc-Use-a-temporary-buffer-for-WA-BB.patch
+++ b/backport/patches/base/0001-drm-xe-lrc-Use-a-temporary-buffer-for-WA-BB.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 4 Jun 2025 08:03:05 -0700
+Subject: drm/xe/lrc: Use a temporary buffer for WA BB
+
+In case the BO is in iomem, we can't simply take the vaddr and write to
+it. Instead, prepare a separate buffer that is later copied into io
+memory. Right now it's just a few words that could be using
+xe_map_write32(), but the intention is to grow the WA BB for other
+uses.
+
+Fixes: 617d824c5323 ("drm/xe: Add WA BB to capture active context utilization")
+Cc: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Cc: Tvrtko Ursulin <tvrtko.ursulin@igalia.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Link: https://lore.kernel.org/r/20250604-wa-bb-fix-v1-1-0dfc5dafcef0@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit ef48715b2d3df17c060e23b9aa636af3d95652f8)
+Signed-off-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+(backported from commit 9c7632faad434c98f1f2cc06f3647a5a5d05ddbf linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_lrc.c | 24 ++++++++++++++++++++----
+ 1 file changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_lrc.c b/drivers/gpu/drm/xe/xe_lrc.c
+index 48bb8fd16..64f0f4f91 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.c
++++ b/drivers/gpu/drm/xe/xe_lrc.c
+@@ -941,11 +941,18 @@ static void xe_lrc_finish(struct xe_lrc *lrc)
+  * store it in the PPHSWP.
+  */
+ #define CONTEXT_ACTIVE 1ULL
+-static void xe_lrc_setup_utilization(struct xe_lrc *lrc)
++static int xe_lrc_setup_utilization(struct xe_lrc *lrc)
+ {
+-	u32 *cmd;
++	u32 *cmd, *buf = NULL;
+ 
+-	cmd = lrc->bb_per_ctx_bo->vmap.vaddr;
++	if (lrc->bb_per_ctx_bo->vmap.is_iomem) {
++		buf = kmalloc(lrc->bb_per_ctx_bo->size, GFP_KERNEL);
++		if (!buf)
++			return -ENOMEM;
++		cmd = buf;
++	} else {
++		cmd = lrc->bb_per_ctx_bo->vmap.vaddr;
++	}
+ 
+ 	*cmd++ = MI_STORE_REGISTER_MEM | MI_SRM_USE_GGTT | MI_SRM_ADD_CS_OFFSET;
+ 	*cmd++ = ENGINE_ID(0).addr;
+@@ -966,9 +973,16 @@ static void xe_lrc_setup_utilization(struct xe_lrc *lrc)
+ 
+ 	*cmd++ = MI_BATCH_BUFFER_END;
+ 
++	if (buf) {
++		xe_map_memcpy_to(gt_to_xe(lrc->gt), &lrc->bb_per_ctx_bo->vmap, 0,
++				 buf, (cmd - buf) * sizeof(*cmd));
++		kfree(buf);
++	}
++
+ 	xe_lrc_write_ctx_reg(lrc, CTX_BB_PER_CTX_PTR,
+ 			     xe_bo_ggtt_addr(lrc->bb_per_ctx_bo) | 1);
+ 
++	return 0;
+ }
+ 
+ #define PVC_CTX_ASID		(0x2e + 1)
+@@ -1110,7 +1124,9 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+ 	map = __xe_lrc_start_seqno_map(lrc);
+ 	xe_map_write32(lrc_to_xe(lrc), &map, lrc->fence_ctx.next_seqno - 1);
+ 
+-	xe_lrc_setup_utilization(lrc);
++	err = xe_lrc_setup_utilization(lrc);
++	if (err)
++		goto err_lrc_finish;
+ 
+ 	return 0;
+ 
+-- 
+2.34.1
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-Add-EUDEBUG_ENABLE-exec-queue-property.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Add-EUDEBUG_ENABLE-exec-queue-property.patch
@@ -59,7 +59,7 @@ index fecb7c8a9..4644d6846 100644
  
  	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
 diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
-index 7e880a08c..58c6906ba 100644
+index a9741fa29..40a77c0cd 100644
 --- a/drivers/gpu/drm/xe/xe_exec_queue.c
 +++ b/drivers/gpu/drm/xe/xe_exec_queue.c
 @@ -112,6 +112,7 @@ static struct xe_exec_queue *__xe_exec_queue_alloc(struct xe_device *xe,
@@ -187,10 +187,10 @@ index 5ef96deaa..779a52daf 100644
  		err = PTR_ERR(port->lrc);
  		goto err;
 diff --git a/drivers/gpu/drm/xe/xe_lrc.c b/drivers/gpu/drm/xe/xe_lrc.c
-index bbb9ffbf6..ecb05b9fe 100644
+index 64f0f4f91..14faa6082 100644
 --- a/drivers/gpu/drm/xe/xe_lrc.c
 +++ b/drivers/gpu/drm/xe/xe_lrc.c
-@@ -883,7 +883,7 @@ static void xe_lrc_finish(struct xe_lrc *lrc)
+@@ -989,7 +989,7 @@ static int xe_lrc_setup_utilization(struct xe_lrc *lrc)
  #define PVC_CTX_ACC_CTR_THOLD	(0x2a + 1)
  
  static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
@@ -199,7 +199,7 @@ index bbb9ffbf6..ecb05b9fe 100644
  {
  	struct xe_gt *gt = hwe->gt;
  	struct xe_tile *tile = gt_to_tile(gt);
-@@ -1008,6 +1008,16 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+@@ -1124,6 +1124,16 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
  	map = __xe_lrc_start_seqno_map(lrc);
  	xe_map_write32(lrc_to_xe(lrc), &map, lrc->fence_ctx.next_seqno - 1);
  
@@ -213,10 +213,10 @@ index bbb9ffbf6..ecb05b9fe 100644
 +		xe_lrc_write_ctx_reg(lrc, CTX_CONTEXT_CONTROL, ctx_control);
 +	}
 +
- 	return 0;
- 
- err_lrc_finish:
-@@ -1028,7 +1038,7 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+ 	err = xe_lrc_setup_utilization(lrc);
+ 	if (err)
+ 		goto err_lrc_finish;
+@@ -1148,7 +1158,7 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
   * upon failure.
   */
  struct xe_lrc *xe_lrc_create(struct xe_hw_engine *hwe, struct xe_vm *vm,
@@ -225,7 +225,7 @@ index bbb9ffbf6..ecb05b9fe 100644
  {
  	struct xe_lrc *lrc;
  	int err;
-@@ -1037,7 +1047,7 @@ struct xe_lrc *xe_lrc_create(struct xe_hw_engine *hwe, struct xe_vm *vm,
+@@ -1157,7 +1167,7 @@ struct xe_lrc *xe_lrc_create(struct xe_hw_engine *hwe, struct xe_vm *vm,
  	if (!lrc)
  		return ERR_PTR(-ENOMEM);
  
@@ -235,7 +235,7 @@ index bbb9ffbf6..ecb05b9fe 100644
  		kfree(lrc);
  		return ERR_PTR(err);
 diff --git a/drivers/gpu/drm/xe/xe_lrc.h b/drivers/gpu/drm/xe/xe_lrc.h
-index 4206e6a8b..7a40b54d2 100644
+index 13c083559..3e9e1394f 100644
 --- a/drivers/gpu/drm/xe/xe_lrc.h
 +++ b/drivers/gpu/drm/xe/xe_lrc.h
 @@ -41,8 +41,10 @@ struct xe_lrc_snapshot {

--- a/series
+++ b/series
@@ -28,6 +28,8 @@ backport/patches/base/0001-drm-xe-xe2_hpg-Define-additional-Xe2_HPG-GMD_ID.patch
 backport/patches/base/0001-drm-xe-xe2hpg-Add-Wa_16025250150.patch
 backport/patches/base/0001-drm-xe-xe2_hpg-Add-set-of-workarounds.patch
 backport/patches/base/0001-drm-xe-display-Re-use-display-vmas-when-possible.patch
+backport/patches/base/0001-drm-xe-Add-WA-BB-to-capture-active-context-utilizati.patch
+backport/patches/base/0001-drm-xe-lrc-Use-a-temporary-buffer-for-WA-BB.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
drm-cycles-* values are only being updated when the context switches out.
When a context is currently active,
these values are not getting updated in real-time.
This patch add the WA BB to capture active context utilization

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>