### PR TITLE
Enable SR-IOV PF mode by default for Xe driver

### DIFF
--- a/backport/patches/features/sriov/0001-drm-xe-pf-Enable-SR-IOV-PF-mode-by-default.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-pf-Enable-SR-IOV-PF-mode-by-default.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Tue, 22 Jul 2025 20:26:16 +0200
+Subject: drm/xe/pf: Enable SR-IOV PF mode by default
+
+We already claim official support for SR-IOV PF/VF modes on PTL
+and BMG platforms, but by default we start the Xe driver on those
+platforms in non-virtualized mode (native) since we still have
+max_vfs modparam set to disable creation of the VFs.
+
+It's time to let the Xe driver support SR-IOV PF mode by default.
+We were already testing this on our CI, which was relying on the
+patch that was enabling it for CONFIG_DRM_XE_DEBUG used by our CI.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Cc: Thomas Hellstrom <thomas.hellstrom@linux.intel.com>
+Cc: Lucas De Marchi <lucas.demarchi@intel.com>
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://lore.kernel.org/r/20250722182618.30811-3-michal.wajdeczko@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit a2b461bd6f3b36bded0a74178dec0e58e4714d3d)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_module.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_module.c b/drivers/gpu/drm/xe/xe_module.c
+index 07b27114be9a..e6b6d6537782 100644
+--- a/drivers/gpu/drm/xe/xe_module.c
++++ b/drivers/gpu/drm/xe/xe_module.c
+@@ -17,12 +17,18 @@
+ #include "xe_observation.h"
+ #include "xe_sched_job.h"
+ 
++#define DEFAULT_MAX_VFS			~0
++#define DEFAULT_MAX_VFS_STR		"unlimited"
++
+ struct xe_modparam xe_modparam = {
+ 	.probe_display = true,
+ 	.guc_log_level = 3,
+ 	.force_probe = CONFIG_DRM_XE_FORCE_PROBE,
++#ifdef CONFIG_PCI_IOV
++	.max_vfs =		DEFAULT_MAX_VFS,
++#endif
+ 	.wedged_mode = 1,
+-	/* the rest are 0 by default */
++        /* the rest are 0 by default */
+ };
+ 
+ module_param_named_unsafe(force_execlist, xe_modparam.force_execlist, bool, 0444);
+@@ -57,7 +63,8 @@ MODULE_PARM_DESC(force_probe,
+ module_param_named(max_vfs, xe_modparam.max_vfs, uint, 0400);
+ MODULE_PARM_DESC(max_vfs,
+ 		 "Limit number of Virtual Functions (VFs) that could be managed. "
+-		 "(0 = no VFs [default]; N = allow up to N VFs)");
++		 "(0=no VFs; N=allow up to N VFs "
++		 "[default=" DEFAULT_MAX_VFS_STR "])");
+ #endif
+ 
+ module_param_named_unsafe(wedged_mode, xe_modparam.wedged_mode, int, 0600);
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -78,6 +78,7 @@ backport/patches/features/sriov/0001-PCI-IOV-Allow-IOV-resources-to-be-resized-i
 backport/patches/features/sriov/0001-PCI-IOV-Check-that-VF-BAR-fits-within-the-reservatio.patch
 backport/patches/features/sriov/0001-PCI-IOV-Allow-drivers-to-control-VF-BAR-size.patch
 backport/patches/features/sriov/0001-drm-xe-pf-Set-VF-LMEM-BAR-size.patch
+backport/patches/features/sriov/0001-drm-xe-pf-Enable-SR-IOV-PF-mode-by-default.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
The Xe driver now supports SR-IOV Physical Function (PF) mode reliably across
supported platforms. This patch enables SR-IOV PF mode by default, removing
the need for manual enablement via module parameters or additional configs.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>