### PR TITLE
patches/base: Various BMG WA updates, GUC PC improvements and cleanups

### DIFF
--- a/backport/patches/base/0001-drm-xe-Split-xe_device_td_flush.patch
+++ b/backport/patches/base/0001-drm-xe-Split-xe_device_td_flush.patch
@@ -1,0 +1,129 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 18 Jun 2025 11:50:00 -0700
+Subject: drm/xe: Split xe_device_td_flush()
+
+xe_device_td_flush() has 2 possible implementations: an entire L2 flush
+or a transient flush, depending on WA 16023588340. Make this clear by
+splitting the function so it calls each of them.
+
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://lore.kernel.org/r/20250618-wa-22019338487-v5-3-b888388477f2@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit 5e300ed8a545bdffc26b579c526b5fef7b2d5365 linux-next)
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_device.c | 68 ++++++++++++++++++++--------------
+ 1 file changed, 40 insertions(+), 28 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index ccad9b1ffd04..e48c2db1f3d2 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -906,38 +906,15 @@ void xe_device_wmb(struct xe_device *xe)
+ 		xe_mmio_write32(xe_root_tile_mmio(xe), VF_CAP_REG, 0);
+ }
+ 
+-/**
+- * xe_device_td_flush() - Flush transient L3 cache entries
+- * @xe: The device
+- *
+- * Display engine has direct access to memory and is never coherent with L3/L4
+- * caches (or CPU caches), however KMD is responsible for specifically flushing
+- * transient L3 GPU cache entries prior to the flip sequence to ensure scanout
+- * can happen from such a surface without seeing corruption.
+- *
+- * Display surfaces can be tagged as transient by mapping it using one of the
+- * various L3:XD PAT index modes on Xe2.
+- *
+- * Note: On non-discrete xe2 platforms, like LNL, the entire L3 cache is flushed
+- * at the end of each submission via PIPE_CONTROL for compute/render, since SA
+- * Media is not coherent with L3 and we want to support render-vs-media
+- * usescases. For other engines like copy/blt the HW internally forces uncached
+- * behaviour, hence why we can skip the TDF on such platforms.
++/*
++ * Issue a TRANSIENT_FLUSH_REQUEST and wait for completion on each gt.
+  */
+-void xe_device_td_flush(struct xe_device *xe)
++static void tdf_request_sync(struct xe_device *xe)
+ {
+-	struct xe_gt *gt;
+ 	unsigned int fw_ref;
++	struct xe_gt *gt;
+ 	u8 id;
+ 
+-	if (!IS_DGFX(xe) || GRAPHICS_VER(xe) < 20)
+-		return;
+-
+-	if (XE_WA(xe_root_mmio_gt(xe), 16023588340)) {
+-		xe_device_l2_flush(xe);
+-		return;
+-	}
+-
+ 	for_each_gt(gt, xe, id) {
+ 		if (xe_gt_is_media_type(gt))
+ 			continue;
+@@ -947,6 +924,7 @@ void xe_device_td_flush(struct xe_device *xe)
+ 			return;
+ 
+ 		xe_mmio_write32(&gt->mmio, XE2_TDF_CTRL, TRANSIENT_FLUSH_REQUEST);
++
+ 		/*
+ 		 * FIXME: We can likely do better here with our choice of
+ 		 * timeout. Currently we just assume the worst case, i.e. 150us,
+@@ -977,15 +955,49 @@ void xe_device_l2_flush(struct xe_device *xe)
+ 		return;
+ 
+ 	spin_lock(&gt->global_invl_lock);
+-	xe_mmio_write32(&gt->mmio, XE2_GLOBAL_INVAL, 0x1);
+ 
++	xe_mmio_write32(&gt->mmio, XE2_GLOBAL_INVAL, 0x1);
+ 	if (xe_mmio_wait32(&gt->mmio, XE2_GLOBAL_INVAL, 0x1, 0x0, 500, NULL, true))
+ 		xe_gt_err_once(gt, "Global invalidation timeout\n");
++
+ 	spin_unlock(&gt->global_invl_lock);
+ 
+ 	xe_force_wake_put(gt_to_fw(gt), fw_ref);
+ }
+ 
++/**
++ * xe_device_td_flush() - Flush transient L3 cache entries
++ * @xe: The device
++ *
++ * Display engine has direct access to memory and is never coherent with L3/L4
++ * caches (or CPU caches), however KMD is responsible for specifically flushing
++ * transient L3 GPU cache entries prior to the flip sequence to ensure scanout
++ * can happen from such a surface without seeing corruption.
++ *
++ * Display surfaces can be tagged as transient by mapping it using one of the
++ * various L3:XD PAT index modes on Xe2.
++ *
++ * Note: On non-discrete xe2 platforms, like LNL, the entire L3 cache is flushed
++ * at the end of each submission via PIPE_CONTROL for compute/render, since SA
++ * Media is not coherent with L3 and we want to support render-vs-media
++ * usescases. For other engines like copy/blt the HW internally forces uncached
++ * behaviour, hence why we can skip the TDF on such platforms.
++ */
++void xe_device_td_flush(struct xe_device *xe)
++{
++	struct xe_gt *root_gt;
++
++	if (!IS_DGFX(xe) || GRAPHICS_VER(xe) < 20)
++		return;
++
++	root_gt = xe_root_mmio_gt(xe);
++	if (XE_WA(root_gt, 16023588340))
++		/* A transient flush is not sufficient: flush the L2 */
++		xe_device_l2_flush(xe);
++	else
++		tdf_request_sync(xe);
++}
++
+ u32 xe_device_ccs_bytes(struct xe_device *xe, u64 size)
+ {
+ 	return xe_device_has_flat_ccs(xe) ?
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-bmg-Update-Wa_14022085890.patch
+++ b/backport/patches/base/0001-drm-xe-bmg-Update-Wa_14022085890.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vinay Belgaumkar <vinay.belgaumkar@intel.com>
+Date: Thu, 12 Jun 2025 00:09:02 -0700
+Subject: drm/xe/bmg: Update Wa_14022085890
+
+Set GT min frequency to 1200Mhz once driver load is complete.
+
+v2: Review comments (Rodrigo)
+v3: Apply Wa earlier so user_req_min is not clobbered.
+v4: Apply to all GTs (Lucas)
+
+Cc: Matt Roper <matthew.d.roper@intel.com>
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Vinay Belgaumkar <vinay.belgaumkar@intel.com>
+Reviewed-by: Stuart Summers <stuart.summers@intel.com>
+Link: https://lore.kernel.org/r/20250612-wa-14022085890-v4-3-94ba5dcc1e30@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit bdde16c9ac5cb56ad2ee19792222fa1853577af7 linux-next )
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc_pc.c     | 5 +++++
+ drivers/gpu/drm/xe/xe_wa_oob.rules | 3 +++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
+index 36f34978e985..c8ebf687192f 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc.c
++++ b/drivers/gpu/drm/xe/xe_guc_pc.c
+@@ -50,6 +50,7 @@
+ 
+ #define LNL_MERT_FREQ_CAP	800
+ #define BMG_MERT_FREQ_CAP	2133
++#define BMG_MIN_FREQ		1200
+ 
+ #define SLPC_RESET_TIMEOUT_MS 5 /* roughly 5ms, but no need for precision */
+ #define SLPC_RESET_EXTENDED_TIMEOUT_MS 1000 /* To be used only at pc_start */
+@@ -816,6 +817,7 @@ void xe_guc_pc_init_early(struct xe_guc_pc *pc)
+ 
+ static int pc_adjust_freq_bounds(struct xe_guc_pc *pc)
+ {
++	struct xe_tile *tile = gt_to_tile(pc_to_gt(pc));
+ 	int ret;
+ 
+ 	lockdep_assert_held(&pc->freq_lock);
+@@ -842,6 +844,9 @@ static int pc_adjust_freq_bounds(struct xe_guc_pc *pc)
+ 	if (pc_get_min_freq(pc) > pc->rp0_freq)
+ 		ret = pc_set_min_freq(pc, pc->rp0_freq);
+ 
++	if (XE_WA(tile->primary_gt, 14022085890))
++		ret = pc_set_min_freq(pc, max(BMG_MIN_FREQ, pc_get_min_freq(pc)));
++
+ out:
+ 	return ret;
+ }
+diff --git a/drivers/gpu/drm/xe/xe_wa_oob.rules b/drivers/gpu/drm/xe/xe_wa_oob.rules
+index 2c986715aeaf..a115a32bd26c 100644
+--- a/drivers/gpu/drm/xe/xe_wa_oob.rules
++++ b/drivers/gpu/drm/xe/xe_wa_oob.rules
+@@ -46,3 +46,6 @@
+ no_media_l3	MEDIA_VERSION(3000)
+ 14022866841	GRAPHICS_VERSION(3000), GRAPHICS_STEP(A0, B0)
+ 		MEDIA_VERSION(3000), MEDIA_STEP(A0, B0)
++# SoC workaround - currently applies to all platforms with the following
++# primary GT GMDID
++14022085890	GRAPHICS_VERSION(2001)
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-bmg-Update-Wa_16023588340.patch
+++ b/backport/patches/base/0001-drm-xe-bmg-Update-Wa_16023588340.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vinay Belgaumkar <vinay.belgaumkar@intel.com>
+Date: Thu, 12 Jun 2025 00:09:01 -0700
+Subject: drm/xe/bmg: Update Wa_16023588340
+
+This allows for additional L2 caching modes.
+
+Fixes: 01570b446939 ("drm/xe/bmg: implement Wa_16023588340")
+Cc: Matthew Auld <matthew.auld@intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Signed-off-by: Vinay Belgaumkar <vinay.belgaumkar@intel.com>
+Link: https://lore.kernel.org/r/20250612-wa-14022085890-v4-2-94ba5dcc1e30@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry-picked from commit 6ab42fa03d4c88a0ddf5e56e62794853b198e7bf linux-next )
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
+index 6b4b9eca2c38..c8e796b45458 100644
+--- a/drivers/gpu/drm/xe/xe_gt.c
++++ b/drivers/gpu/drm/xe/xe_gt.c
+@@ -115,7 +115,7 @@ static void xe_gt_enable_host_l2_vram(struct xe_gt *gt)
+ 		xe_gt_mcr_multicast_write(gt, XE2_GAMREQSTRM_CTRL, reg);
+ 	}
+ 
+-	xe_gt_mcr_multicast_write(gt, XEHPC_L3CLOS_MASK(3), 0x3);
++	xe_gt_mcr_multicast_write(gt, XEHPC_L3CLOS_MASK(3), 0xF);
+ 	xe_force_wake_put(gt_to_fw(gt), fw_ref);
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-bmg-Update-Wa_22019338487.patch
+++ b/backport/patches/base/0001-drm-xe-bmg-Update-Wa_22019338487.patch
@@ -1,0 +1,261 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vinay Belgaumkar <vinay.belgaumkar@intel.com>
+Date: Wed, 18 Jun 2025 11:50:01 -0700
+Subject: drm/xe/bmg: Update Wa_22019338487
+
+Limit GT max frequency to 2600MHz and wait for frequency to reduce
+before proceeding with a transient flush. This is really only needed for
+the transient flush: if L2 flush is needed due to 16023588340 then
+there's no need to do this additional wait since we are already using
+the bigger hammer.
+
+v2: Use generic names, ensure user set max frequency requests wait
+for flush to complete (Rodrigo)
+v3:
+ - User requests wait via wait_var_event_timeout (Lucas)
+ - Close races on flush + user requests (Lucas)
+ - Fix xe_guc_pc_remove_flush_freq_limit() being called on last gt
+   rather than root gt (Lucas)
+v4:
+ - Only apply the freq reducing part if a TDF is needed: L2 flush trumps
+   the need for waiting a lower frequency
+
+Fixes: aaa08078e725 ("drm/xe/bmg: Apply Wa_22019338487")
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Vinay Belgaumkar <vinay.belgaumkar@intel.com>
+Link: https://lore.kernel.org/r/20250618-wa-22019338487-v5-4-b888388477f2@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit deea6a7d6d803d6bb874a3e6f1b312e560e6c6df linux-next)
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c       |   8 +-
+ drivers/gpu/drm/xe/xe_guc_pc.c       | 125 +++++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_guc_pc.h       |   2 +
+ drivers/gpu/drm/xe/xe_guc_pc_types.h |   2 +
+ 4 files changed, 135 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index e48c2db1f3d2..9ae0ee985b4b 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -41,6 +41,7 @@
+ #include "xe_gt_printk.h"
+ #include "xe_gt_sriov_vf.h"
+ #include "xe_guc.h"
++#include "xe_guc_pc.h"
+ #include "xe_hw_engine_group.h"
+ #include "xe_hwmon.h"
+ #include "xe_irq.h"
+@@ -991,11 +992,14 @@ void xe_device_td_flush(struct xe_device *xe)
+ 		return;
+ 
+ 	root_gt = xe_root_mmio_gt(xe);
+-	if (XE_WA(root_gt, 16023588340))
++	if (XE_WA(root_gt, 16023588340)) {
+ 		/* A transient flush is not sufficient: flush the L2 */
+ 		xe_device_l2_flush(xe);
+-	else
++	} else {
++		xe_guc_pc_apply_flush_freq_limit(&root_gt->uc.guc.pc);
+ 		tdf_request_sync(xe);
++		xe_guc_pc_remove_flush_freq_limit(&root_gt->uc.guc.pc);
++	}
+ }
+ 
+ u32 xe_device_ccs_bytes(struct xe_device *xe, u64 size)
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
+index fe1e3673803f..50d48b8343be 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc.c
++++ b/drivers/gpu/drm/xe/xe_guc_pc.c
+@@ -7,7 +7,9 @@
+ 
+ #include <linux/cleanup.h>
+ #include <linux/delay.h>
++#include <linux/jiffies.h>
+ #include <linux/ktime.h>
++#include <linux/wait_bit.h>
+ 
+ #include <drm/drm_managed.h>
+ #include <generated/xe_wa_oob.h>
+@@ -52,9 +54,11 @@
+ #define LNL_MERT_FREQ_CAP	800
+ #define BMG_MERT_FREQ_CAP	2133
+ #define BMG_MIN_FREQ		1200
++#define BMG_MERT_FLUSH_FREQ_CAP	2600
+ 
+ #define SLPC_RESET_TIMEOUT_MS 5 /* roughly 5ms, but no need for precision */
+ #define SLPC_RESET_EXTENDED_TIMEOUT_MS 1000 /* To be used only at pc_start */
++#define SLPC_ACT_FREQ_TIMEOUT_MS 100
+ 
+ /**
+  * DOC: GuC Power Conservation (PC)
+@@ -142,6 +146,36 @@ static int wait_for_pc_state(struct xe_guc_pc *pc,
+ 	return -ETIMEDOUT;
+ }
+ 
++static int wait_for_flush_complete(struct xe_guc_pc *pc)
++{
++	const unsigned long timeout = msecs_to_jiffies(30);
++
++	if (!wait_var_event_timeout(&pc->flush_freq_limit,
++				    !atomic_read(&pc->flush_freq_limit),
++				    timeout))
++		return -ETIMEDOUT;
++
++	return 0;
++}
++
++static int wait_for_act_freq_limit(struct xe_guc_pc *pc, u32 freq)
++{
++	int timeout_us = SLPC_ACT_FREQ_TIMEOUT_MS * USEC_PER_MSEC;
++	int slept, wait = 10;
++
++	for (slept = 0; slept < timeout_us;) {
++		if (xe_guc_pc_get_act_freq(pc) <= freq)
++			return 0;
++
++		usleep_range(wait, wait << 1);
++		slept += wait;
++		wait <<= 1;
++		if (slept + wait > timeout_us)
++			wait = timeout_us - slept;
++	}
++
++	return -ETIMEDOUT;
++}
+ static int pc_action_reset(struct xe_guc_pc *pc)
+ {
+ 	struct xe_guc_ct *ct = pc_to_ct(pc);
+@@ -687,6 +721,11 @@ static int xe_guc_pc_set_max_freq_locked(struct xe_guc_pc *pc, u32 freq)
+  */
+ int xe_guc_pc_set_max_freq(struct xe_guc_pc *pc, u32 freq)
+ {
++	if (XE_WA(pc_to_gt(pc), 22019338487)) {
++		if (wait_for_flush_complete(pc) != 0)
++			return -EAGAIN;
++	}
++
+ 	guard(mutex)(&pc->freq_lock);
+ 
+ 	return xe_guc_pc_set_max_freq_locked(pc, freq);
+@@ -887,6 +926,92 @@ static int pc_adjust_requested_freq(struct xe_guc_pc *pc)
+ 	return ret;
+ }
+ 
++static bool needs_flush_freq_limit(struct xe_guc_pc *pc)
++{
++	struct xe_gt *gt = pc_to_gt(pc);
++
++	return  XE_WA(gt, 22019338487) &&
++		pc->rp0_freq > BMG_MERT_FLUSH_FREQ_CAP;
++}
++
++/**
++ * xe_guc_pc_apply_flush_freq_limit() - Limit max GT freq during L2 flush
++ * @pc: the xe_guc_pc object
++ *
++ * As per the WA, reduce max GT frequency during L2 cache flush
++ */
++void xe_guc_pc_apply_flush_freq_limit(struct xe_guc_pc *pc)
++{
++	struct xe_gt *gt = pc_to_gt(pc);
++	u32 max_freq;
++	int ret;
++
++	if (!needs_flush_freq_limit(pc))
++		return;
++
++	guard(mutex)(&pc->freq_lock);
++
++	ret = xe_guc_pc_get_max_freq_locked(pc, &max_freq);
++	if (!ret && max_freq > BMG_MERT_FLUSH_FREQ_CAP) {
++		ret = pc_set_max_freq(pc, BMG_MERT_FLUSH_FREQ_CAP);
++		if (ret) {
++			xe_gt_err_once(gt, "Failed to cap max freq on flush to %u, %pe\n",
++				       BMG_MERT_FLUSH_FREQ_CAP, ERR_PTR(ret));
++			return;
++		}
++
++		atomic_set(&pc->flush_freq_limit, 1);
++
++		/*
++		 * If user has previously changed max freq, stash that value to
++		 * restore later, otherwise use the current max. New user
++		 * requests wait on flush.
++		 */
++		if (pc->user_requested_max != 0)
++			pc->stashed_max_freq = pc->user_requested_max;
++		else
++			pc->stashed_max_freq = max_freq;
++	}
++
++	/*
++	 * Wait for actual freq to go below the flush cap: even if the previous
++	 * max was below cap, the current one might still be above it
++	 */
++	ret = wait_for_act_freq_limit(pc, BMG_MERT_FLUSH_FREQ_CAP);
++	if (ret)
++		xe_gt_err_once(gt, "Actual freq did not reduce to %u, %pe\n",
++			       BMG_MERT_FLUSH_FREQ_CAP, ERR_PTR(ret));
++}
++
++/**
++ * xe_guc_pc_remove_flush_freq_limit() - Remove max GT freq limit after L2 flush completes.
++ * @pc: the xe_guc_pc object
++ *
++ * Retrieve the previous GT max frequency value.
++ */
++void xe_guc_pc_remove_flush_freq_limit(struct xe_guc_pc *pc)
++{
++	struct xe_gt *gt = pc_to_gt(pc);
++	int ret = 0;
++
++	if (!needs_flush_freq_limit(pc))
++		return;
++
++	if (!atomic_read(&pc->flush_freq_limit))
++		return;
++
++	mutex_lock(&pc->freq_lock);
++
++	ret = pc_set_max_freq(&gt->uc.guc.pc, pc->stashed_max_freq);
++	if (ret)
++		xe_gt_err_once(gt, "Failed to restore max freq %u:%d",
++			       pc->stashed_max_freq, ret);
++
++	atomic_set(&pc->flush_freq_limit, 0);
++	mutex_unlock(&pc->freq_lock);
++	wake_up_var(&pc->flush_freq_limit);
++}
++
+ static int pc_set_mert_freq_cap(struct xe_guc_pc *pc)
+ {
+ 	int ret;
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc.h b/drivers/gpu/drm/xe/xe_guc_pc.h
+index 71978bfbbf90..9d5b37d43933 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc.h
++++ b/drivers/gpu/drm/xe/xe_guc_pc.h
+@@ -36,5 +36,7 @@ u64 xe_guc_pc_mc6_residency(struct xe_guc_pc *pc);
+ void xe_guc_pc_init_early(struct xe_guc_pc *pc);
+ int xe_guc_pc_restore_stashed_freq(struct xe_guc_pc *pc);
+ void xe_guc_pc_raise_unslice(struct xe_guc_pc *pc);
++void xe_guc_pc_apply_flush_freq_limit(struct xe_guc_pc *pc);
++void xe_guc_pc_remove_flush_freq_limit(struct xe_guc_pc *pc);
+ 
+ #endif /* _XE_GUC_PC_H_ */
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc_types.h b/drivers/gpu/drm/xe/xe_guc_pc_types.h
+index 2978ac9a249b..c02053948a57 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc_types.h
++++ b/drivers/gpu/drm/xe/xe_guc_pc_types.h
+@@ -15,6 +15,8 @@
+ struct xe_guc_pc {
+ 	/** @bo: GGTT buffer object that is shared with GuC PC */
+ 	struct xe_bo *bo;
++	/** @flush_freq_limit: 1 when max freq changes are limited by driver */
++	atomic_t flush_freq_limit;
+ 	/** @rp0_freq: HW RP0 frequency - The Maximum one */
+ 	u32 rp0_freq;
+ 	/** @rpa_freq: HW RPa frequency - The Achievable one */
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-guc-Ignore-GuC-CT-errors-when-wedged.patch
+++ b/backport/patches/base/0001-drm-xe-guc-Ignore-GuC-CT-errors-when-wedged.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vinay Belgaumkar <vinay.belgaumkar@intel.com>
+Date: Thu, 12 Jun 2025 00:09:00 -0700
+Subject: drm/xe/guc: Ignore GuC CT errors when wedged
+
+Messaging to GuC may get canceled when device is wedged. Don't
+flag this as an error in xe_guc_pc code.
+
+Cc: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Signed-off-by: Vinay Belgaumkar <vinay.belgaumkar@intel.com>
+Reviewed-by: Stuart Summers <stuart.summers@intel.com>
+Link: https://lore.kernel.org/r/20250612-wa-14022085890-v4-1-94ba5dcc1e30@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry-picked from commit fa424387379650cdc0ce42c2f6e76e020b4c04d1 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc_pc.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
+index 24994d5424e8..36f34978e985 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc.c
++++ b/drivers/gpu/drm/xe/xe_guc_pc.c
+@@ -152,7 +152,7 @@ static int pc_action_reset(struct xe_guc_pc *pc)
+ 	int ret;
+ 
+ 	ret = xe_guc_ct_send(ct, action, ARRAY_SIZE(action), 0, 0);
+-	if (ret)
++	if (ret && !(xe_device_wedged(pc_to_xe(pc)) && ret == -ECANCELED))
+ 		xe_gt_err(pc_to_gt(pc), "GuC PC reset failed: %pe\n",
+ 			  ERR_PTR(ret));
+ 
+@@ -176,7 +176,7 @@ static int pc_action_query_task_state(struct xe_guc_pc *pc)
+ 
+ 	/* Blocking here to ensure the results are ready before reading them */
+ 	ret = xe_guc_ct_send_block(ct, action, ARRAY_SIZE(action));
+-	if (ret)
++	if (ret && !(xe_device_wedged(pc_to_xe(pc)) && ret == -ECANCELED))
+ 		xe_gt_err(pc_to_gt(pc), "GuC PC query task state failed: %pe\n",
+ 			  ERR_PTR(ret));
+ 
+@@ -199,7 +199,7 @@ static int pc_action_set_param(struct xe_guc_pc *pc, u8 id, u32 value)
+ 		return -EAGAIN;
+ 
+ 	ret = xe_guc_ct_send(ct, action, ARRAY_SIZE(action), 0, 0);
+-	if (ret)
++	if (ret && !(xe_device_wedged(pc_to_xe(pc)) && ret == -ECANCELED))
+ 		xe_gt_err(pc_to_gt(pc), "GuC PC set param[%u]=%u failed: %pe\n",
+ 			  id, value, ERR_PTR(ret));
+ 
+@@ -221,7 +221,7 @@ static int pc_action_unset_param(struct xe_guc_pc *pc, u8 id)
+ 		return -EAGAIN;
+ 
+ 	ret = xe_guc_ct_send(ct, action, ARRAY_SIZE(action), 0, 0);
+-	if (ret)
++	if (ret && !(xe_device_wedged(pc_to_xe(pc)) && ret == -ECANCELED))
+ 		xe_gt_err(pc_to_gt(pc), "GuC PC unset param failed: %pe",
+ 			  ERR_PTR(ret));
+ 
+@@ -238,7 +238,7 @@ static int pc_action_setup_gucrc(struct xe_guc_pc *pc, u32 mode)
+ 	int ret;
+ 
+ 	ret = xe_guc_ct_send(ct, action, ARRAY_SIZE(action), 0, 0);
+-	if (ret)
++	if (ret && !(xe_device_wedged(pc_to_xe(pc)) && ret == -ECANCELED))
+ 		xe_gt_err(pc_to_gt(pc), "GuC RC enable mode=%u failed: %pe\n",
+ 			  mode, ERR_PTR(ret));
+ 	return ret;
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-guc_pc-Add-_locked-variant-for-min-max-freq.patch
+++ b/backport/patches/base/0001-drm-xe-guc_pc-Add-_locked-variant-for-min-max-freq.patch
@@ -1,0 +1,218 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 18 Jun 2025 11:49:58 -0700
+Subject: drm/xe/guc_pc: Add _locked variant for min/max freq
+
+There are places in which the getters/setters are called one after the
+other causing a multiple lock()/unlock(). These are not currently a
+problem since they are all happening from the same thread, but there's a
+race possibility as calls are added outside of the early init when the
+max/min and stashed values need to be correlated.
+
+Add the _locked() variants to prepare for that.
+
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://lore.kernel.org/r/20250618-wa-22019338487-v5-1-b888388477f2@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit 1beae9aa2b88d3a02eb666e7b777eb2d7bc645f4)
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc_pc.c | 123 ++++++++++++++++++---------------
+ 1 file changed, 69 insertions(+), 54 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
+index c8ebf687192f..cf81c41d93b4 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc.c
++++ b/drivers/gpu/drm/xe/xe_guc_pc.c
+@@ -5,6 +5,7 @@
+ 
+ #include "xe_guc_pc.h"
+ 
++#include <linux/cleanup.h>
+ #include <linux/delay.h>
+ #include <linux/ktime.h>
+ 
+@@ -553,6 +554,25 @@ u32 xe_guc_pc_get_rpn_freq(struct xe_guc_pc *pc)
+ 	return pc->rpn_freq;
+ }
+ 
++static int xe_guc_pc_get_min_freq_locked(struct xe_guc_pc *pc, u32 *freq)
++{
++	int ret;
++
++	lockdep_assert_held(&pc->freq_lock);
++
++	/* Might be in the middle of a gt reset */
++	if (!pc->freq_ready)
++		return -EAGAIN;
++
++	ret = pc_action_query_task_state(pc);
++	if (ret)
++		return ret;
++
++	*freq = pc_get_min_freq(pc);
++
++	return 0;
++}
++
+ /**
+  * xe_guc_pc_get_min_freq - Get the min operational frequency
+  * @pc: The GuC PC
+@@ -562,27 +582,29 @@ u32 xe_guc_pc_get_rpn_freq(struct xe_guc_pc *pc)
+  *         -EAGAIN if GuC PC not ready (likely in middle of a reset).
+  */
+ int xe_guc_pc_get_min_freq(struct xe_guc_pc *pc, u32 *freq)
++{
++	guard(mutex)(&pc->freq_lock);
++
++	return xe_guc_pc_get_min_freq_locked(pc, freq);
++}
++
++static int xe_guc_pc_set_min_freq_locked(struct xe_guc_pc *pc, u32 freq)
+ {
+ 	int ret;
+ 
+-	xe_device_assert_mem_access(pc_to_xe(pc));
++	lockdep_assert_held(&pc->freq_lock);
+ 
+-	mutex_lock(&pc->freq_lock);
+-	if (!pc->freq_ready) {
+-		/* Might be in the middle of a gt reset */
+-		ret = -EAGAIN;
+-		goto out;
+-	}
++	/* Might be in the middle of a gt reset */
++	if (!pc->freq_ready)
++		return -EAGAIN;
+ 
+-	ret = pc_action_query_task_state(pc);
++	ret = pc_set_min_freq(pc, freq);
+ 	if (ret)
+-		goto out;
++		return ret;
+ 
+-	*freq = pc_get_min_freq(pc);
++	pc->user_requested_min = freq;
+ 
+-out:
+-	mutex_unlock(&pc->freq_lock);
+-	return ret;
++	return 0;
+ }
+ 
+ /**
+@@ -595,25 +617,29 @@ int xe_guc_pc_get_min_freq(struct xe_guc_pc *pc, u32 *freq)
+  *         -EINVAL if value out of bounds.
+  */
+ int xe_guc_pc_set_min_freq(struct xe_guc_pc *pc, u32 freq)
++{
++	guard(mutex)(&pc->freq_lock);
++
++	return xe_guc_pc_set_min_freq_locked(pc, freq);
++}
++
++static int xe_guc_pc_get_max_freq_locked(struct xe_guc_pc *pc, u32 *freq)
+ {
+ 	int ret;
+ 
+-	mutex_lock(&pc->freq_lock);
+-	if (!pc->freq_ready) {
+-		/* Might be in the middle of a gt reset */
+-		ret = -EAGAIN;
+-		goto out;
+-	}
++	lockdep_assert_held(&pc->freq_lock);
+ 
+-	ret = pc_set_min_freq(pc, freq);
++	/* Might be in the middle of a gt reset */
++	if (!pc->freq_ready)
++		return -EAGAIN;
++
++	ret = pc_action_query_task_state(pc);
+ 	if (ret)
+-		goto out;
++		return ret;
+ 
+-	pc->user_requested_min = freq;
++	*freq = pc_get_max_freq(pc);
+ 
+-out:
+-	mutex_unlock(&pc->freq_lock);
+-	return ret;
++	return 0;
+ }
+ 
+ /**
+@@ -625,25 +651,29 @@ int xe_guc_pc_set_min_freq(struct xe_guc_pc *pc, u32 freq)
+  *         -EAGAIN if GuC PC not ready (likely in middle of a reset).
+  */
+ int xe_guc_pc_get_max_freq(struct xe_guc_pc *pc, u32 *freq)
++{
++	guard(mutex)(&pc->freq_lock);
++
++	return xe_guc_pc_get_max_freq_locked(pc, freq);
++}
++
++static int xe_guc_pc_set_max_freq_locked(struct xe_guc_pc *pc, u32 freq)
+ {
+ 	int ret;
+ 
+-	mutex_lock(&pc->freq_lock);
+-	if (!pc->freq_ready) {
+-		/* Might be in the middle of a gt reset */
+-		ret = -EAGAIN;
+-		goto out;
+-	}
++	lockdep_assert_held(&pc->freq_lock);
+ 
+-	ret = pc_action_query_task_state(pc);
++	/* Might be in the middle of a gt reset */
++	if (!pc->freq_ready)
++		return -EAGAIN;
++
++	ret = pc_set_max_freq(pc, freq);
+ 	if (ret)
+-		goto out;
++		return ret;
+ 
+-	*freq = pc_get_max_freq(pc);
++	pc->user_requested_max = freq;
+ 
+-out:
+-	mutex_unlock(&pc->freq_lock);
+-	return ret;
++	return 0;
+ }
+ 
+ /**
+@@ -657,24 +687,9 @@ int xe_guc_pc_get_max_freq(struct xe_guc_pc *pc, u32 *freq)
+  */
+ int xe_guc_pc_set_max_freq(struct xe_guc_pc *pc, u32 freq)
+ {
+-	int ret;
+-
+-	mutex_lock(&pc->freq_lock);
+-	if (!pc->freq_ready) {
+-		/* Might be in the middle of a gt reset */
+-		ret = -EAGAIN;
+-		goto out;
+-	}
+-
+-	ret = pc_set_max_freq(pc, freq);
+-	if (ret)
+-		goto out;
++	guard(mutex)(&pc->freq_lock);
+ 
+-	pc->user_requested_max = freq;
+-
+-out:
+-	mutex_unlock(&pc->freq_lock);
+-	return ret;
++	return xe_guc_pc_set_max_freq_locked(pc, freq);
+ }
+ 
+ /**
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-xe_guc_pc-Lock-once-to-update-stashed-frequen.patch
+++ b/backport/patches/base/0001-drm-xe-xe_guc_pc-Lock-once-to-update-stashed-frequen.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 18 Jun 2025 11:49:59 -0700
+Subject: drm/xe/xe_guc_pc: Lock once to update stashed frequencies
+
+pc_set_mert_freq_cap() currently lock()/unlock() the mutex multiple times
+to stash the current frequencies. It's not a problem since
+xe_guc_pc_restore_stashed_freq() is guaranteed to be called only later
+in the init sequence. However, now that we have _locked() variants for
+this functions, use them and avoid potential issues when called from
+other places or using the same pattern.
+
+While at it, prefer and early return for the WA check to reduce
+indentation.
+
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://lore.kernel.org/r/20250618-wa-22019338487-v5-2-b888388477f2@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit d878c97daa603573e5af01fd8beec2fffdb42ad1 linux-next)
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc_pc.c | 39 +++++++++++++++++-----------------
+ 1 file changed, 20 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
+index cf81c41d93b4..fe1e3673803f 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc.c
++++ b/drivers/gpu/drm/xe/xe_guc_pc.c
+@@ -889,27 +889,28 @@ static int pc_adjust_requested_freq(struct xe_guc_pc *pc)
+ 
+ static int pc_set_mert_freq_cap(struct xe_guc_pc *pc)
+ {
+-	int ret = 0;
++	int ret;
+ 
+-	if (XE_WA(pc_to_gt(pc), 22019338487)) {
+-		/*
+-		 * Get updated min/max and stash them.
+-		 */
+-		ret = xe_guc_pc_get_min_freq(pc, &pc->stashed_min_freq);
+-		if (!ret)
+-			ret = xe_guc_pc_get_max_freq(pc, &pc->stashed_max_freq);
+-		if (ret)
+-			return ret;
++	if (!XE_WA(pc_to_gt(pc), 22019338487))
++		return 0;
+ 
+-		/*
+-		 * Ensure min and max are bound by MERT_FREQ_CAP until driver loads.
+-		 */
+-		mutex_lock(&pc->freq_lock);
+-		ret = pc_set_min_freq(pc, min(pc->rpe_freq, pc_max_freq_cap(pc)));
+-		if (!ret)
+-			ret = pc_set_max_freq(pc, min(pc->rp0_freq, pc_max_freq_cap(pc)));
+-		mutex_unlock(&pc->freq_lock);
+-	}
++	guard(mutex)(&pc->freq_lock);
++
++	/*
++	 * Get updated min/max and stash them.
++	 */
++	ret = xe_guc_pc_get_min_freq_locked(pc, &pc->stashed_min_freq);
++	if (!ret)
++		ret = xe_guc_pc_get_max_freq_locked(pc, &pc->stashed_max_freq);
++	if (ret)
++		return ret;
++
++	/*
++	 * Ensure min and max are bound by MERT_FREQ_CAP until driver loads.
++	 */
++	ret = pc_set_min_freq(pc, min(pc->rpe_freq, pc_max_freq_cap(pc)));
++	if (!ret)
++		ret = pc_set_max_freq(pc, min(pc->rp0_freq, pc_max_freq_cap(pc)));
+ 
+ 	return ret;
+ }
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -31,6 +31,13 @@ backport/patches/base/0001-drm-xe-display-Re-use-display-vmas-when-possible.patc
 backport/patches/base/0001-drm-xe-Add-WA-BB-to-capture-active-context-utilizati.patch
 backport/patches/base/0001-drm-xe-lrc-Use-a-temporary-buffer-for-WA-BB.patch
 backport/patches/base/0001-drm-xe-uapi-Use-hint-for-guc-to-set-GT-frequency.patch
+backport/patches/base/0001-drm-xe-guc-Ignore-GuC-CT-errors-when-wedged.patch
+backport/patches/base/0001-drm-xe-bmg-Update-Wa_16023588340.patch
+backport/patches/base/0001-drm-xe-bmg-Update-Wa_14022085890.patch
+backport/patches/base/0001-drm-xe-guc_pc-Add-_locked-variant-for-min-max-freq.patch
+backport/patches/base/0001-drm-xe-xe_guc_pc-Lock-once-to-update-stashed-frequen.patch
+backport/patches/base/0001-drm-xe-Split-xe_device_td_flush.patch
+backport/patches/base/0001-drm-xe-bmg-Update-Wa_22019338487.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
- Updated BMG-specific workarounds:
  - Wa_22019338487
  - Wa_14022085890
  - Wa_16023588340

- Split xe_device_td_flush() for better modularity and maintainability.

- Improved GuC PC frequency management:
  - Added _locked variants for min/max frequency updates
  - Consolidated locking for stashed frequency updates

- Updated GuC behavior to ignore CT errors when the device is wedged,
  avoiding unnecessary error propagation.

list of patches in this commit
1. drm/xe/bmg: Update Wa_22019338487
2. drm/xe: Split xe_device_td_flush()
3. drm/xe/xe_guc_pc: Lock once to update stashed frequencies
4. drm/xe/guc_pc: Add _locked variant for min/max freq
5. drm/xe/bmg: Update Wa_14022085890
6. drm/xe/bmg: Update Wa_16023588340
7. drm/xe/guc: Ignore GuC CT errors when wedged

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>