### PR TITLE
backport/sriov: Add MI_MATH support and disable unsupported VF features

### DIFF
--- a/backport/patches/features/sriov/0001-drm-xe-Add-MI_LOAD_REGISTER_REG-command-definition.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Add-MI_LOAD_REGISTER_REG-command-definition.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Mon, 3 Mar 2025 18:35:18 +0100
+Subject: drm/xe: Add MI_LOAD_REGISTER_REG command definition
+
+The MI_LOAD_REGISTER_REG command reads value from a source register
+location and writes that value to a destination register location.
+
+Bspec: 45730, 60233
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250303173522.1822-2-michal.wajdeczko@intel.com
+(cherry-picked from commit 4383dd88fa77b8489b627125b268c3f1ab934e37 linux-next )
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/instructions/xe_mi_commands.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/instructions/xe_mi_commands.h b/drivers/gpu/drm/xe/instructions/xe_mi_commands.h
+index 167fb0f742de..526bad9d4bac 100644
+--- a/drivers/gpu/drm/xe/instructions/xe_mi_commands.h
++++ b/drivers/gpu/drm/xe/instructions/xe_mi_commands.h
+@@ -61,6 +61,10 @@
+ #define MI_LOAD_REGISTER_MEM		(__MI_INSTR(0x29) | XE_INSTR_NUM_DW(4))
+ #define   MI_LRM_USE_GGTT		REG_BIT(22)
+ 
++#define MI_LOAD_REGISTER_REG		(__MI_INSTR(0x2a) | XE_INSTR_NUM_DW(3))
++#define   MI_LRR_DST_CS_MMIO		REG_BIT(19)
++#define   MI_LRR_SRC_CS_MMIO		REG_BIT(18)
++
+ #define MI_COPY_MEM_MEM			(__MI_INSTR(0x2e) | XE_INSTR_NUM_DW(5))
+ #define   MI_COPY_MEM_MEM_SRC_GGTT	REG_BIT(22)
+ #define   MI_COPY_MEM_MEM_DST_GGTT	REG_BIT(21)
+-- 
+2.34.1
+

--- a/backport/patches/features/sriov/0001-drm-xe-Add-MI_MATH-and-ALU-instruction-definitions.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Add-MI_MATH-and-ALU-instruction-definitions.patch
@@ -1,0 +1,141 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Tue, 4 Mar 2025 17:23:07 +0100
+Subject: drm/xe: Add MI_MATH and ALU instruction definitions
+
+The command streamer implements an Arithmetic Logic Unit (ALU)
+which supports basic arithmetic and logical operations on two
+64-bit operands. Access to this ALU is thru the MI_MATH command
+and sixteen General Purpose Register (GPR) 64-bit registers,
+which are used as temporary storage.
+
+Bspec: 45737, 60236 # MI
+Bspec: 45525, 60132 # ALU
+Bspec: 45533, 60309 # GPR
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250304162307.1866-1-michal.wajdeczko@intel.com
+(cherry-picked from commit b823f80bbd63f67c926a3a0c5dcf246fb8736d7b linux-next )
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ .../gpu/drm/xe/instructions/xe_alu_commands.h | 79 +++++++++++++++++++
+ .../gpu/drm/xe/instructions/xe_mi_commands.h  |  1 +
+ drivers/gpu/drm/xe/regs/xe_engine_regs.h      |  4 +
+ 3 files changed, 84 insertions(+)
+ create mode 100644 drivers/gpu/drm/xe/instructions/xe_alu_commands.h
+
+diff --git a/drivers/gpu/drm/xe/instructions/xe_alu_commands.h b/drivers/gpu/drm/xe/instructions/xe_alu_commands.h
+new file mode 100644
+index 000000000000..2987b10d3e16
+--- /dev/null
++++ b/drivers/gpu/drm/xe/instructions/xe_alu_commands.h
+@@ -0,0 +1,79 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2025 Intel Corporation
++ */
++
++#ifndef _XE_ALU_COMMANDS_H_
++#define _XE_ALU_COMMANDS_H_
++
++#include "instructions/xe_instr_defs.h"
++
++/* Instruction Opcodes */
++#define CS_ALU_OPCODE_NOOP			0x000
++#define CS_ALU_OPCODE_FENCE_RD			0x001
++#define CS_ALU_OPCODE_FENCE_WR			0x002
++#define CS_ALU_OPCODE_LOAD			0x080
++#define CS_ALU_OPCODE_LOADINV			0x480
++#define CS_ALU_OPCODE_LOAD0			0x081
++#define CS_ALU_OPCODE_LOAD1			0x481
++#define CS_ALU_OPCODE_LOADIND			0x082
++#define CS_ALU_OPCODE_ADD			0x100
++#define CS_ALU_OPCODE_SUB			0x101
++#define CS_ALU_OPCODE_AND			0x102
++#define CS_ALU_OPCODE_OR			0x103
++#define CS_ALU_OPCODE_XOR			0x104
++#define CS_ALU_OPCODE_SHL			0x105
++#define CS_ALU_OPCODE_SHR			0x106
++#define CS_ALU_OPCODE_SAR			0x107
++#define CS_ALU_OPCODE_STORE			0x180
++#define CS_ALU_OPCODE_STOREINV			0x580
++#define CS_ALU_OPCODE_STOREIND			0x181
++
++/* Instruction Operands */
++#define CS_ALU_OPERAND_REG(n)			REG_FIELD_PREP(GENMASK(3, 0), (n))
++#define CS_ALU_OPERAND_REG0			0x0
++#define CS_ALU_OPERAND_REG1			0x1
++#define CS_ALU_OPERAND_REG2			0x2
++#define CS_ALU_OPERAND_REG3			0x3
++#define CS_ALU_OPERAND_REG4			0x4
++#define CS_ALU_OPERAND_REG5			0x5
++#define CS_ALU_OPERAND_REG6			0x6
++#define CS_ALU_OPERAND_REG7			0x7
++#define CS_ALU_OPERAND_REG8			0x8
++#define CS_ALU_OPERAND_REG9			0x9
++#define CS_ALU_OPERAND_REG10			0xa
++#define CS_ALU_OPERAND_REG11			0xb
++#define CS_ALU_OPERAND_REG12			0xc
++#define CS_ALU_OPERAND_REG13			0xd
++#define CS_ALU_OPERAND_REG14			0xe
++#define CS_ALU_OPERAND_REG15			0xf
++#define CS_ALU_OPERAND_SRCA			0x20
++#define CS_ALU_OPERAND_SRCB			0x21
++#define CS_ALU_OPERAND_ACCU			0x31
++#define CS_ALU_OPERAND_ZF			0x32
++#define CS_ALU_OPERAND_CF			0x33
++#define CS_ALU_OPERAND_NA			0 /* N/A operand */
++
++/* Command Streamer ALU Instructions */
++#define CS_ALU_INSTR(opcode, op1, op2)		(REG_FIELD_PREP(GENMASK(31, 20), (opcode)) | \
++						 REG_FIELD_PREP(GENMASK(19, 10), (op1)) | \
++						 REG_FIELD_PREP(GENMASK(9, 0), (op2)))
++
++#define __CS_ALU_INSTR(opcode, op1, op2)	CS_ALU_INSTR(CS_ALU_OPCODE_##opcode, \
++							     CS_ALU_OPERAND_##op1, \
++							     CS_ALU_OPERAND_##op2)
++
++#define CS_ALU_INSTR_NOOP			__CS_ALU_INSTR(NOOP, NA, NA)
++#define CS_ALU_INSTR_LOAD(op1, op2)		__CS_ALU_INSTR(LOAD, op1, op2)
++#define CS_ALU_INSTR_LOADINV(op1, op2)		__CS_ALU_INSTR(LOADINV, op1, op2)
++#define CS_ALU_INSTR_LOAD0(op1)			__CS_ALU_INSTR(LOAD0, op1, NA)
++#define CS_ALU_INSTR_LOAD1(op1)			__CS_ALU_INSTR(LOAD1, op1, NA)
++#define CS_ALU_INSTR_ADD			__CS_ALU_INSTR(ADD, NA, NA)
++#define CS_ALU_INSTR_SUB			__CS_ALU_INSTR(SUB, NA, NA)
++#define CS_ALU_INSTR_AND			__CS_ALU_INSTR(AND, NA, NA)
++#define CS_ALU_INSTR_OR				__CS_ALU_INSTR(OR, NA, NA)
++#define CS_ALU_INSTR_XOR			__CS_ALU_INSTR(XOR, NA, NA)
++#define CS_ALU_INSTR_STORE(op1, op2)		__CS_ALU_INSTR(STORE, op1, op2)
++#define CS_ALU_INSTR_STOREINV(op1, op2)		__CS_ALU_INSTR(STOREINV, op1, op2)
++
++#endif
+diff --git a/drivers/gpu/drm/xe/instructions/xe_mi_commands.h b/drivers/gpu/drm/xe/instructions/xe_mi_commands.h
+index 526bad9d4bac..eba582058d55 100644
+--- a/drivers/gpu/drm/xe/instructions/xe_mi_commands.h
++++ b/drivers/gpu/drm/xe/instructions/xe_mi_commands.h
+@@ -32,6 +32,7 @@
+ #define MI_BATCH_BUFFER_END		__MI_INSTR(0xA)
+ #define MI_TOPOLOGY_FILTER		__MI_INSTR(0xD)
+ #define MI_FORCE_WAKEUP			__MI_INSTR(0x1D)
++#define MI_MATH(n)			(__MI_INSTR(0x1A) | XE_INSTR_NUM_DW((n) + 1))
+ 
+ #define MI_STORE_DATA_IMM		__MI_INSTR(0x20)
+ #define   MI_SDI_GGTT			REG_BIT(22)
+diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
+index 4f372dc2cb89..659cf85fa3d6 100644
+--- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
+@@ -184,6 +184,10 @@
+ #define   PREEMPT_GPGPU_LEVEL_MASK		PREEMPT_GPGPU_LEVEL(1, 1)
+ #define   PREEMPT_3D_OBJECT_LEVEL		REG_BIT(0)
+ 
++#define CS_GPR_DATA(base, n)			XE_REG((base) + 0x600 + (n) * 4)
++#define CS_GPR_REG(base, n)			CS_GPR_DATA((base), (n) * 2)
++#define CS_GPR_REG_UDW(base, n)			CS_GPR_DATA((base), (n) * 2 + 1)
++
+ #define VDBOX_CGCTL3F08(base)			XE_REG((base) + 0x3f08)
+ #define   CG3DDISHRS_CLKGATE_DIS		REG_BIT(5)
+ 
+-- 
+2.34.1
+

--- a/backport/patches/features/sriov/0001-drm-xe-Avoid-reading-RMW-registers-in-emit_wa_job.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Avoid-reading-RMW-registers-in-emit_wa_job.patch
@@ -1,0 +1,165 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Mon, 3 Mar 2025 18:35:20 +0100
+Subject: drm/xe: Avoid reading RMW registers in emit_wa_job
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+To allow VFs properly handle LRC WAs, we should postpone doing
+all RMW register operations and let them be run by the engine
+itself, since attempt to perform read registers from within the
+driver will fail on the VF. Use MI_MATH and ALU for that.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Cc: Michał Winiarski <michal.winiarski@intel.com>
+Cc: Matt Roper <matthew.d.roper@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+iLink: https://patchwork.freedesktop.org/patch/msgid/20250303173522.1822-4-michal.wajdeczko@intel.com
+(cherry-picked from commit f2f90989ccff2d010472d47e4e62f7afe8ce67ff linux-next )
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_gt.c | 84 ++++++++++++++++++++++++++++----------
+ 1 file changed, 63 insertions(+), 21 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
+index 10a9e3c72b36..8068b4bc0a09 100644
+--- a/drivers/gpu/drm/xe/xe_gt.c
++++ b/drivers/gpu/drm/xe/xe_gt.c
+@@ -12,8 +12,10 @@
+ 
+ #include <generated/xe_wa_oob.h>
+ 
++#include "instructions/xe_alu_commands.h"
+ #include "instructions/xe_gfxpipe_commands.h"
+ #include "instructions/xe_mi_commands.h"
++#include "regs/xe_engine_regs.h"
+ #include "regs/xe_gt_regs.h"
+ #include "xe_assert.h"
+ #include "xe_bb.h"
+@@ -176,15 +178,6 @@ static int emit_nop_job(struct xe_gt *gt, struct xe_exec_queue *q)
+ 	return 0;
+ }
+ 
+-/*
+- * Convert back from encoded value to type-safe, only to be used when reg.mcr
+- * is true
+- */
+-static struct xe_reg_mcr to_xe_reg_mcr(const struct xe_reg reg)
+-{
+-	return (const struct xe_reg_mcr){.__reg.raw = reg.raw };
+-}
+-
+ static int emit_wa_job(struct xe_gt *gt, struct xe_exec_queue *q)
+ {
+ 	struct xe_reg_sr *sr = &q->hwe->reg_lrc;
+@@ -194,6 +187,7 @@ static int emit_wa_job(struct xe_gt *gt, struct xe_exec_queue *q)
+ 	struct xe_bb *bb;
+ 	struct dma_fence *fence;
+ 	long timeout;
++	int count_rmw = 0;
+ 	int count = 0;
+ 
+ 	if (q->hwe->class == XE_ENGINE_CLASS_RENDER)
+@@ -206,30 +200,32 @@ static int emit_wa_job(struct xe_gt *gt, struct xe_exec_queue *q)
+ 	if (IS_ERR(bb))
+ 		return PTR_ERR(bb);
+ 
+-	xa_for_each(&sr->xa, idx, entry)
+-		++count;
++	/* count RMW registers as those will be handled separately */
++	xa_for_each(&sr->xa, idx, entry) {
++		if (entry->reg.masked || entry->clr_bits == ~0)
++			++count;
++		else
++			++count_rmw;
++	}
+ 
+-	if (count) {
++	if (count || count_rmw)
+ 		xe_gt_dbg(gt, "LRC WA %s save-restore batch\n", sr->name);
+ 
++	if (count) {
++		/* emit single LRI with all non RMW regs */
++
+ 		bb->cs[bb->len++] = MI_LOAD_REGISTER_IMM | MI_LRI_NUM_REGS(count);
+ 
+ 		xa_for_each(&sr->xa, idx, entry) {
+ 			struct xe_reg reg = entry->reg;
+-			struct xe_reg_mcr reg_mcr = to_xe_reg_mcr(reg);
+ 			u32 val;
+ 
+-			/*
+-			 * Skip reading the register if it's not really needed
+-			 */
+ 			if (reg.masked)
+ 				val = entry->clr_bits << 16;
+-			else if (entry->clr_bits + 1)
+-				val = (reg.mcr ?
+-				       xe_gt_mcr_unicast_read_any(gt, reg_mcr) :
+-				       xe_mmio_read32(&gt->mmio, reg)) & (~entry->clr_bits);
+-			else
++			else if (entry->clr_bits == ~0)
+ 				val = 0;
++			else
++				continue;
+ 
+ 			val |= entry->set_bits;
+ 
+@@ -239,6 +235,52 @@ static int emit_wa_job(struct xe_gt *gt, struct xe_exec_queue *q)
+ 		}
+ 	}
+ 
++	if (count_rmw) {
++		/* emit MI_MATH for each RMW reg */
++
++		xa_for_each(&sr->xa, idx, entry) {
++			if (entry->reg.masked || entry->clr_bits == ~0)
++				continue;
++
++			bb->cs[bb->len++] = MI_LOAD_REGISTER_REG | MI_LRR_DST_CS_MMIO;
++			bb->cs[bb->len++] = entry->reg.addr;
++			bb->cs[bb->len++] = CS_GPR_REG(0, 0).addr;
++
++			bb->cs[bb->len++] = MI_LOAD_REGISTER_IMM | MI_LRI_NUM_REGS(2) |
++					    MI_LRI_LRM_CS_MMIO;
++			bb->cs[bb->len++] = CS_GPR_REG(0, 1).addr;
++			bb->cs[bb->len++] = entry->clr_bits;
++			bb->cs[bb->len++] = CS_GPR_REG(0, 2).addr;
++			bb->cs[bb->len++] = entry->set_bits;
++
++			bb->cs[bb->len++] = MI_MATH(8);
++			bb->cs[bb->len++] = CS_ALU_INSTR_LOAD(SRCA, REG0);
++			bb->cs[bb->len++] = CS_ALU_INSTR_LOADINV(SRCB, REG1);
++			bb->cs[bb->len++] = CS_ALU_INSTR_AND;
++			bb->cs[bb->len++] = CS_ALU_INSTR_STORE(REG0, ACCU);
++			bb->cs[bb->len++] = CS_ALU_INSTR_LOAD(SRCA, REG0);
++			bb->cs[bb->len++] = CS_ALU_INSTR_LOAD(SRCB, REG2);
++			bb->cs[bb->len++] = CS_ALU_INSTR_OR;
++			bb->cs[bb->len++] = CS_ALU_INSTR_STORE(REG0, ACCU);
++
++			bb->cs[bb->len++] = MI_LOAD_REGISTER_REG | MI_LRR_SRC_CS_MMIO;
++			bb->cs[bb->len++] = CS_GPR_REG(0, 0).addr;
++			bb->cs[bb->len++] = entry->reg.addr;
++
++			xe_gt_dbg(gt, "REG[%#x] = ~%#x|%#x\n",
++				  entry->reg.addr, entry->clr_bits, entry->set_bits);
++		}
++
++		/* reset used GPR */
++		bb->cs[bb->len++] = MI_LOAD_REGISTER_IMM | MI_LRI_NUM_REGS(3) | MI_LRI_LRM_CS_MMIO;
++		bb->cs[bb->len++] = CS_GPR_REG(0, 0).addr;
++		bb->cs[bb->len++] = 0;
++		bb->cs[bb->len++] = CS_GPR_REG(0, 1).addr;
++		bb->cs[bb->len++] = 0;
++		bb->cs[bb->len++] = CS_GPR_REG(0, 2).addr;
++		bb->cs[bb->len++] = 0;
++	}
++
+ 	xe_lrc_emit_hwe_state_instructions(q, bb);
+ 
+ 	job = xe_bb_create_job(q, bb);
+-- 
+2.34.1
+

--- a/backport/patches/features/sriov/0001-drm-xe-vf-Disable-CSC-support-on-VF.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-vf-Disable-CSC-support-on-VF.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lukasz Laguna <lukasz.laguna@intel.com>
+Date: Tue, 29 Jul 2025 14:34:37 +0200
+Subject: drm/xe/vf: Disable CSC support on VF
+
+CSC is not accessible by VF drivers, so disable its support flag on VF
+to prevent further initialization attempts.
+
+Fixes: e02cea83d32d ("drm/xe/gsc: add Battlemage support")
+Signed-off-by: Lukasz Laguna <lukasz.laguna@intel.com>
+Cc: Alexander Usyskin <alexander.usyskin@intel.com>
+Cc: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://lore.kernel.org/r/20250729123437.5933-1-lukasz.laguna@intel.com
+(cherry picked from commit 552dbba1caaf0cb40ce961806d757615e26ec668 linux-next)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 6dc84e4ed281..5bd2f7d7b4ea 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -681,6 +681,7 @@ static void sriov_update_device_info(struct xe_device *xe)
+ 	/* disable features that are not available/applicable to VFs */
+ 	if (IS_SRIOV_VF(xe)) {
+ 		xe->info.probe_display = 0;
++		xe->info.has_heci_cscfi = 0;
+ 		xe->info.has_heci_gscfi = 0;
+ 		xe->info.skip_guc_pc = 1;
+ 		xe->info.skip_pcode = 1;
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -79,6 +79,10 @@ backport/patches/features/sriov/0001-PCI-IOV-Check-that-VF-BAR-fits-within-the-r
 backport/patches/features/sriov/0001-PCI-IOV-Allow-drivers-to-control-VF-BAR-size.patch
 backport/patches/features/sriov/0001-drm-xe-pf-Set-VF-LMEM-BAR-size.patch
 backport/patches/features/sriov/0001-drm-xe-pf-Enable-SR-IOV-PF-mode-by-default.patch
+backport/patches/features/sriov/0001-drm-xe-Add-MI_LOAD_REGISTER_REG-command-definition.patch
+backport/patches/features/sriov/0001-drm-xe-Add-MI_MATH-and-ALU-instruction-definitions.patch
+backport/patches/features/sriov/0001-drm-xe-Avoid-reading-RMW-registers-in-emit_wa_job.patch
+backport/patches/features/sriov/0001-drm-xe-vf-Disable-CSC-support-on-VF.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Add definitions for MI_MATH, ALU, GPR, and MI_LOAD_REGISTER_REG commands.
Use MI-based logic to replace direct register reads in emit_wa_job to support
virtual functions (VF), which cannot perform such reads. Additionally, disable
CSC support on VF since it's not accessible in that environment.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>