### PR TITLE
patches/base: Clamp power limit writes to max supported value

### DIFF
--- a/backport/patches/base/0001-drm-xe-hwmon-Add-SW-clamp-for-power-limits-writes.patch
+++ b/backport/patches/base/0001-drm-xe-hwmon-Add-SW-clamp-for-power-limits-writes.patch
@@ -1,0 +1,103 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Karthik Poosa <karthik.poosa@intel.com>
+Date: Sat, 9 Aug 2025 00:23:10 +0530
+Subject: [PATCH] drm/xe/hwmon: Add SW clamp for power limits writes
+
+Clamp writes to power limits powerX_crit/currX_crit, powerX_cap,
+powerX_max, to the maximum supported by the pcode mailbox
+when sysfs-provided values exceed this limit.
+Although the pcode already performs clamping, values beyond the pcode
+mailbox's supported range get truncated, leading to incorrect
+critical power settings.
+This patch ensures proper clamping to prevent such truncation.
+
+v2:
+ - Address below review comments. (Riana)
+ - Split comments into multiple sentences.
+ - Use local variables for readability.
+ - Add a debug log.
+ - Use u64 instead of unsigned long.
+
+v3:
+ - Change drm_dbg logs to drm_info. (Badal)
+
+v4:
+ - Rephrase the drm_info log. (Rodrigo, Riana)
+ - Rename variable max_mbx_power_limit to max_supp_power_limit, as
+   limit is same for platforms with and without mailbox power limit
+   support.
+
+Signed-off-by: Karthik Poosa <karthik.poosa@intel.com>
+Fixes: 92d44a422d0d ("drm/xe/hwmon: Expose card reactive critical power")
+Fixes: fb1b70607f73 ("drm/xe/hwmon: Expose power attributes")
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://lore.kernel.org/r/20250808185310.3466529-1-karthik.poosa@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry picked from commit d301eb950da59f962bafe874cf5eb6d61a85b2c2)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit 55d49f06162e45686399df4ae6292167f0deab7c linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_hwmon.c | 29 +++++++++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index ad79843c1b58..f2e4f4d1500c 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -316,6 +316,7 @@ static int xe_hwmon_power_max_write(struct xe_hwmon *hwmon, u32 attr, int channe
+ 	int ret = 0;
+ 	u32 reg_val, max;
+ 	struct xe_reg rapl_limit;
++	u64 max_supp_power_limit = 0;
+ 
+ 	mutex_lock(&hwmon->hwmon_lock);
+ 
+@@ -340,6 +341,20 @@ static int xe_hwmon_power_max_write(struct xe_hwmon *hwmon, u32 attr, int channe
+ 		goto unlock;
+ 	}
+ 
++	/*
++	 * If the sysfs value exceeds the maximum pcode supported power limit value, clamp it to
++	 * the supported maximum (U12.3 format).
++	 * This is to avoid truncation during reg_val calculation below and ensure the valid
++	 * power limit is sent for pcode which would clamp it to card-supported value.
++	 */
++	max_supp_power_limit = ((PWR_LIM_VAL) >> hwmon->scl_shift_power) * SF_POWER;
++	if (value > max_supp_power_limit) {
++		value = max_supp_power_limit;
++		drm_info(&hwmon->xe->drm,
++			 "Power limit clamped as selected %s exceeds channel %d limit\n",
++			 PWR_ATTR_TO_STR(attr), channel);
++	}
++
+ 	/* Computation in 64-bits to avoid overflow. Round to nearest. */
+ 	reg_val = DIV_ROUND_CLOSEST_ULL((u64)value << hwmon->scl_shift_power, SF_POWER);
+ 
+@@ -723,9 +738,23 @@ static int xe_hwmon_power_curr_crit_write(struct xe_hwmon *hwmon, int channel,
+ {
+ 	int ret;
+ 	u32 uval;
++	u64 max_crit_power_curr = 0;
+ 
+ 	mutex_lock(&hwmon->hwmon_lock);
+ 
++	/*
++	 * If the sysfs value exceeds the pcode mailbox cmd POWER_SETUP_SUBCOMMAND_WRITE_I1
++	 * max supported value, clamp it to the command's max (U10.6 format).
++	 * This is to avoid truncation during uval calculation below and ensure the valid power
++	 * limit is sent for pcode which would clamp it to card-supported value.
++	 */
++	max_crit_power_curr = (POWER_SETUP_I1_DATA_MASK >> POWER_SETUP_I1_SHIFT) * scale_factor;
++	if (value > max_crit_power_curr) {
++		value = max_crit_power_curr;
++		drm_info(&hwmon->xe->drm,
++			 "Power limit clamped as selected exceeds channel %d limit\n",
++			 channel);
++	}
+ 	uval = DIV_ROUND_CLOSEST_ULL(value << POWER_SETUP_I1_SHIFT, scale_factor);
+ 	ret = xe_hwmon_pcode_write_i1(hwmon, uval);
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -38,6 +38,7 @@ backport/patches/base/0001-drm-xe-guc_pc-Add-_locked-variant-for-min-max-freq.pa
 backport/patches/base/0001-drm-xe-xe_guc_pc-Lock-once-to-update-stashed-frequen.patch
 backport/patches/base/0001-drm-xe-Split-xe_device_td_flush.patch
 backport/patches/base/0001-drm-xe-bmg-Update-Wa_22019338487.patch
+backport/patches/base/0001-drm-xe-hwmon-Add-SW-clamp-for-power-limits-writes.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Clamp writes to powerX_crit/currX_crit, powerX_cap, and powerX_max
to the maximum value supported by the pcode mailbox. This prevents
truncation of values exceeding the supported range and ensures
correct critical power settings.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>