### PR TITLE
backport/base: Add support for BMG GPU crashlog

### DIFF
--- a/backport/patches/base/0001-drm-xe-Correct-BMG-VSEC-header-sizing.patch
+++ b/backport/patches/base/0001-drm-xe-Correct-BMG-VSEC-header-sizing.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:33 -0400
+Subject: drm/xe: Correct BMG VSEC header sizing
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The intel_vsec_header information for the crashlog feature is
+incorrect.
+
+Update the VSEC header with correct sizing and count.
+
+Since the crashlog entries are "merged" (num_entries = 2), the
+separate capabilities entries must be merged as well.
+
+Fixes: 0c45e76fcc62 ("drm/xe/vsec: Support BMG devices")
+Acked-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Reviewed-by: David E. Box <david.e.box@linux.intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-4-michael.j.ruhl@intel.com
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 5b27388171a18cf6842c700520086ec50194e858 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_vsec.c | 19 ++++---------------
+ 1 file changed, 4 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_vsec.c b/drivers/gpu/drm/xe/xe_vsec.c
+index d279e0ace7d7..8f23a27871b6 100644
+--- a/drivers/gpu/drm/xe/xe_vsec.c
++++ b/drivers/gpu/drm/xe/xe_vsec.c
+@@ -33,30 +33,19 @@ static struct intel_vsec_header bmg_telemetry = {
+ 	.offset = BMG_DISCOVERY_OFFSET,
+ };
+ 
+-static struct intel_vsec_header bmg_punit_crashlog = {
++static struct intel_vsec_header bmg_crashlog = {
+ 	.rev = 1,
+ 	.length = 0x10,
+ 	.id = VSEC_ID_CRASHLOG,
+-	.num_entries = 1,
+-	.entry_size = 4,
++	.num_entries = 2,
++	.entry_size = 6,
+ 	.tbir = 0,
+ 	.offset = BMG_DISCOVERY_OFFSET + 0x60,
+ };
+ 
+-static struct intel_vsec_header bmg_oobmsm_crashlog = {
+-	.rev = 1,
+-	.length = 0x10,
+-	.id = VSEC_ID_CRASHLOG,
+-	.num_entries = 1,
+-	.entry_size = 4,
+-	.tbir = 0,
+-	.offset = BMG_DISCOVERY_OFFSET + 0x78,
+-};
+-
+ static struct intel_vsec_header *bmg_capabilities[] = {
+ 	&bmg_telemetry,
+-	&bmg_punit_crashlog,
+-	&bmg_oobmsm_crashlog,
++	&bmg_crashlog,
+ 	NULL
+ };
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Correct-the-rev-value-for-the-DVSEC-entries.patch
+++ b/backport/patches/base/0001-drm-xe-Correct-the-rev-value-for-the-DVSEC-entries.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:32 -0400
+Subject: drm/xe: Correct the rev value for the DVSEC entries
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+By definition, the Designated Vendor Specific Extended Capability
+(DVSEC) revision should be 1.
+
+Add the rev value to be correct.
+
+Fixes: 0c45e76fcc62 ("drm/xe/vsec: Support BMG devices")
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Reviewed-by: David E. Box <david.e.box@linux.intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-3-michael.j.ruhl@intel.com
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 0ba9e9cf76f2487654bc9bca38218780fa53030e linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_vsec.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_vsec.c b/drivers/gpu/drm/xe/xe_vsec.c
+index 3e573b0b7ebd..d279e0ace7d7 100644
+--- a/drivers/gpu/drm/xe/xe_vsec.c
++++ b/drivers/gpu/drm/xe/xe_vsec.c
+@@ -24,6 +24,7 @@
+ #define BMG_DEVICE_ID 0xE2F8
+ 
+ static struct intel_vsec_header bmg_telemetry = {
++	.rev = 1,
+ 	.length = 0x10,
+ 	.id = VSEC_ID_TELEMETRY,
+ 	.num_entries = 2,
+@@ -33,6 +34,7 @@ static struct intel_vsec_header bmg_telemetry = {
+ };
+ 
+ static struct intel_vsec_header bmg_punit_crashlog = {
++	.rev = 1,
+ 	.length = 0x10,
+ 	.id = VSEC_ID_CRASHLOG,
+ 	.num_entries = 1,
+@@ -42,6 +44,7 @@ static struct intel_vsec_header bmg_punit_crashlog = {
+ };
+ 
+ static struct intel_vsec_header bmg_oobmsm_crashlog = {
++	.rev = 1,
+ 	.length = 0x10,
+ 	.id = VSEC_ID_CRASHLOG,
+ 	.num_entries = 1,
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-add-register-access-helpers.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-add-register-access-helpers.patch
@@ -1,0 +1,118 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:40 -0400
+Subject: platform/x86/intel/pmt: add register access helpers
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The control register is used in a read/modify/write pattern.
+The status register is used in a read/check bit pattern.
+
+Add helpers to eliminate common code.
+
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-11-michael.j.ruhl@intel.com
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit f57b32cb4adb28b62f61c4729f7b85f55518cb2b linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 58 +++++++++++------------
+ 1 file changed, 29 insertions(+), 29 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index 23b3971da40a..ed781548e59d 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -64,20 +64,40 @@ struct pmt_crashlog_priv {
+ /*
+  * I/O
+  */
+-static bool pmt_crashlog_complete(struct intel_pmt_entry *entry)
++
++/* Read, modify, write the control register, setting or clearing @bit based on @set */
++static void pmt_crashlog_rmw(struct intel_pmt_entry *entry, u32 bit, bool set)
+ {
+-	u32 control = readl(entry->disc_table + CONTROL_OFFSET);
++	u32 reg = readl(entry->disc_table + CONTROL_OFFSET);
++
++	reg &= ~CRASHLOG_FLAG_TRIGGER_MASK;
++
++	if (set)
++		reg |= bit;
++	else
++		reg &= ~bit;
++
++	writel(reg, entry->disc_table + CONTROL_OFFSET);
++}
++
++/* Read the status register and see if the specified @bit is set */
++static bool pmt_crashlog_rc(struct intel_pmt_entry *entry, u32 bit)
++{
++	u32 reg = readl(entry->disc_table + CONTROL_OFFSET);
++
++	return !!(reg & bit);
++}
+ 
++static bool pmt_crashlog_complete(struct intel_pmt_entry *entry)
++{
+ 	/* return current value of the crashlog complete flag */
+-	return !!(control & CRASHLOG_FLAG_TRIGGER_COMPLETE);
++	return pmt_crashlog_rc(entry, CRASHLOG_FLAG_TRIGGER_COMPLETE);
+ }
+ 
+ static bool pmt_crashlog_disabled(struct intel_pmt_entry *entry)
+ {
+-	u32 control = readl(entry->disc_table + CONTROL_OFFSET);
+-
+ 	/* return current value of the crashlog disabled flag */
+-	return !!(control & CRASHLOG_FLAG_DISABLE);
++	return pmt_crashlog_rc(entry, CRASHLOG_FLAG_DISABLE);
+ }
+ 
+ static bool pmt_crashlog_supported(struct intel_pmt_entry *entry)
+@@ -98,37 +118,17 @@ static bool pmt_crashlog_supported(struct intel_pmt_entry *entry)
+ static void pmt_crashlog_set_disable(struct intel_pmt_entry *entry,
+ 				     bool disable)
+ {
+-	u32 control = readl(entry->disc_table + CONTROL_OFFSET);
+-
+-	/* clear trigger bits so we are only modifying disable flag */
+-	control &= ~CRASHLOG_FLAG_TRIGGER_MASK;
+-
+-	if (disable)
+-		control |= CRASHLOG_FLAG_DISABLE;
+-	else
+-		control &= ~CRASHLOG_FLAG_DISABLE;
+-
+-	writel(control, entry->disc_table + CONTROL_OFFSET);
++	pmt_crashlog_rmw(entry, CRASHLOG_FLAG_DISABLE, disable);
+ }
+ 
+ static void pmt_crashlog_set_clear(struct intel_pmt_entry *entry)
+ {
+-	u32 control = readl(entry->disc_table + CONTROL_OFFSET);
+-
+-	control &= ~CRASHLOG_FLAG_TRIGGER_MASK;
+-	control |= CRASHLOG_FLAG_TRIGGER_CLEAR;
+-
+-	writel(control, entry->disc_table + CONTROL_OFFSET);
++	pmt_crashlog_rmw(entry, CRASHLOG_FLAG_TRIGGER_CLEAR, true);
+ }
+ 
+ static void pmt_crashlog_set_execute(struct intel_pmt_entry *entry)
+ {
+-	u32 control = readl(entry->disc_table + CONTROL_OFFSET);
+-
+-	control &= ~CRASHLOG_FLAG_TRIGGER_MASK;
+-	control |= CRASHLOG_FLAG_TRIGGER_EXECUTE;
+-
+-	writel(control, entry->disc_table + CONTROL_OFFSET);
++	pmt_crashlog_rmw(entry, CRASHLOG_FLAG_TRIGGER_EXECUTE, true);
+ }
+ 
+ /*
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-correct-types.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-correct-types.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:38 -0400
+Subject: platform/x86/intel/pmt: correct types
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A couple of local variables do not match the return types of some of
+the functions.
+
+Update the mismatched types to match.
+
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Reviewed-by: David E. Box <david.e.box@linux.intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-9-michael.j.ruhl@intel.com
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 5c7bfa1088274bc3820eb2083f8091ff8ad397ec linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index 440d2045e90d..881f4abdae14 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -138,7 +138,7 @@ static ssize_t
+ enable_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+ 	struct intel_pmt_entry *entry = dev_get_drvdata(dev);
+-	int enabled = !pmt_crashlog_disabled(entry);
++	bool enabled = !pmt_crashlog_disabled(entry);
+ 
+ 	return sprintf(buf, "%d\n", enabled);
+ }
+@@ -169,7 +169,7 @@ static ssize_t
+ trigger_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+ 	struct intel_pmt_entry *entry;
+-	int trigger;
++	bool trigger;
+ 
+ 	entry = dev_get_drvdata(dev);
+ 	trigger = pmt_crashlog_complete(entry);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-decouple-sysfs-and-namespace.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-decouple-sysfs-and-namespace.patch
@@ -1,0 +1,108 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:39 -0400
+Subject: platform/x86/intel/pmt: decouple sysfs and namespace
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The PMT namespace includes the crashlog sysfs attribute information.
+Other crashlog version/types may need different sysfs attributes.
+Coupling the attributes with the namespace blocks this usage.
+
+Decouple sysfs attributes from the name space and add them to the
+specific entry.
+
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-10-michael.j.ruhl@intel.com
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 8ab4f88d46c70bade0633b56a0f03e20102bf10c linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/class.c    | 12 ++++++------
+ drivers/platform/x86/intel/pmt/class.h    |  2 +-
+ drivers/platform/x86/intel/pmt/crashlog.c |  3 ++-
+ 3 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/class.c b/drivers/platform/x86/intel/pmt/class.c
+index d046e8752173..3b6bf2f14dcb 100644
+--- a/drivers/platform/x86/intel/pmt/class.c
++++ b/drivers/platform/x86/intel/pmt/class.c
+@@ -285,8 +285,8 @@ static int intel_pmt_dev_register(struct intel_pmt_entry *entry,
+ 
+ 	entry->kobj = &dev->kobj;
+ 
+-	if (ns->attr_grp) {
+-		ret = sysfs_create_group(entry->kobj, ns->attr_grp);
++	if (entry->attr_grp) {
++		ret = sysfs_create_group(entry->kobj, entry->attr_grp);
+ 		if (ret)
+ 			goto fail_sysfs_create_group;
+ 	}
+@@ -327,8 +327,8 @@ static int intel_pmt_dev_register(struct intel_pmt_entry *entry,
+ fail_add_endpoint:
+ 	sysfs_remove_bin_file(entry->kobj, &entry->pmt_bin_attr);
+ fail_ioremap:
+-	if (ns->attr_grp)
+-		sysfs_remove_group(entry->kobj, ns->attr_grp);
++	if (entry->attr_grp)
++		sysfs_remove_group(entry->kobj, entry->attr_grp);
+ fail_sysfs_create_group:
+ 	device_unregister(dev);
+ fail_dev_create:
+@@ -370,8 +370,8 @@ void intel_pmt_dev_destroy(struct intel_pmt_entry *entry,
+ 	if (entry->size)
+ 		sysfs_remove_bin_file(entry->kobj, &entry->pmt_bin_attr);
+ 
+-	if (ns->attr_grp)
+-		sysfs_remove_group(entry->kobj, ns->attr_grp);
++	if (entry->attr_grp)
++		sysfs_remove_group(entry->kobj, entry->attr_grp);
+ 
+ 	device_unregister(dev);
+ 	xa_erase(ns->xa, entry->devid);
+diff --git a/drivers/platform/x86/intel/pmt/class.h b/drivers/platform/x86/intel/pmt/class.h
+index f6ce80c4e051..d5d86b8a2d15 100644
+--- a/drivers/platform/x86/intel/pmt/class.h
++++ b/drivers/platform/x86/intel/pmt/class.h
+@@ -42,6 +42,7 @@ struct intel_pmt_entry {
+ 	struct pci_dev		*pcidev;
+ 	struct intel_pmt_header	header;
+ 	struct bin_attribute	pmt_bin_attr;
++	const struct attribute_group *attr_grp;
+ 	struct kobject		*kobj;
+ 	void __iomem		*disc_table;
+ 	void __iomem		*base;
+@@ -55,7 +56,6 @@ struct intel_pmt_entry {
+ struct intel_pmt_namespace {
+ 	const char *name;
+ 	struct xarray *xa;
+-	const struct attribute_group *attr_grp;
+ 	int (*pmt_header_decode)(struct intel_pmt_entry *entry,
+ 				 struct device *dev);
+ 	int (*pmt_add_endpoint)(struct intel_vsec_device *ivdev,
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index 881f4abdae14..23b3971da40a 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -243,6 +243,8 @@ static int pmt_crashlog_header_decode(struct intel_pmt_entry *entry,
+ 	/* Size is measured in DWORDS, but accessor returns bytes */
+ 	header->size = GET_SIZE(readl(disc_table + SIZE_OFFSET));
+ 
++	entry->attr_grp = &pmt_crashlog_group;
++
+ 	return 0;
+ }
+ 
+@@ -250,7 +252,6 @@ static DEFINE_XARRAY_ALLOC(crashlog_array);
+ static struct intel_pmt_namespace pmt_crashlog_ns = {
+ 	.name = "crashlog",
+ 	.xa = &crashlog_array,
+-	.attr_grp = &pmt_crashlog_group,
+ 	.pmt_header_decode = pmt_crashlog_header_decode,
+ };
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-fix-a-crashlog-NULL-pointer-a.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-fix-a-crashlog-NULL-pointer-a.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:31 -0400
+Subject: platform/x86/intel/pmt: fix a crashlog NULL pointer access
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Usage of the intel_pmt_read() for binary sysfs, requires a pcidev. The
+current use of the endpoint value is only valid for telemetry endpoint
+usage.
+
+Without the ep, the crashlog usage causes the following NULL pointer
+exception:
+
+BUG: kernel NULL pointer dereference, address: 0000000000000000
+Oops: Oops: 0000 [#1] SMP NOPTI
+RIP: 0010:intel_pmt_read+0x3b/0x70 [pmt_class]
+Code:
+Call Trace:
+ <TASK>
+ ? sysfs_kf_bin_read+0xc0/0xe0
+ kernfs_fop_read_iter+0xac/0x1a0
+ vfs_read+0x26d/0x350
+ ksys_read+0x6b/0xe0
+ __x64_sys_read+0x1d/0x30
+ x64_sys_call+0x1bc8/0x1d70
+ do_syscall_64+0x6d/0x110
+
+Augment struct intel_pmt_entry with a pointer to the pcidev to avoid
+the NULL pointer exception.
+
+Fixes: 045a513040cc ("platform/x86/intel/pmt: Use PMT callbacks")
+Cc: stable@vger.kernel.org
+Reviewed-by: David E. Box <david.e.box@linux.intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-2-michael.j.ruhl@intel.com
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 54d5cd4719c5e87f33d271c9ac2e393147d934f8 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/class.c | 3 ++-
+ drivers/platform/x86/intel/pmt/class.h | 1 +
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/class.c b/drivers/platform/x86/intel/pmt/class.c
+index 7233b654bbad..d046e8752173 100644
+--- a/drivers/platform/x86/intel/pmt/class.c
++++ b/drivers/platform/x86/intel/pmt/class.c
+@@ -97,7 +97,7 @@ intel_pmt_read(struct file *filp, struct kobject *kobj,
+ 	if (count > entry->size - off)
+ 		count = entry->size - off;
+ 
+-	count = pmt_telem_read_mmio(entry->ep->pcidev, entry->cb, entry->header.guid, buf,
++	count = pmt_telem_read_mmio(entry->pcidev, entry->cb, entry->header.guid, buf,
+ 				    entry->base, off, count);
+ 
+ 	return count;
+@@ -252,6 +252,7 @@ static int intel_pmt_populate_entry(struct intel_pmt_entry *entry,
+ 		return -EINVAL;
+ 	}
+ 
++	entry->pcidev = pci_dev;
+ 	entry->guid = header->guid;
+ 	entry->size = header->size;
+ 	entry->cb = ivdev->priv_data;
+diff --git a/drivers/platform/x86/intel/pmt/class.h b/drivers/platform/x86/intel/pmt/class.h
+index b2006d57779d..f6ce80c4e051 100644
+--- a/drivers/platform/x86/intel/pmt/class.h
++++ b/drivers/platform/x86/intel/pmt/class.h
+@@ -39,6 +39,7 @@ struct intel_pmt_header {
+ 
+ struct intel_pmt_entry {
+ 	struct telem_endpoint	*ep;
++	struct pci_dev		*pcidev;
+ 	struct intel_pmt_header	header;
+ 	struct bin_attribute	pmt_bin_attr;
+ 	struct kobject		*kobj;
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-mutex-clean-up.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-mutex-clean-up.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:35 -0400
+Subject: platform/x86/intel/pmt: mutex clean up
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The header file for mutex usage and mutex_destroy() cleanup code is
+absent from the crashlog.c module.
+
+Add the header file and mutex_destroy().
+
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-6-michael.j.ruhl@intel.com
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 75a496aa054326d9ebf27b39e1af8b5b770311ba linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index d40c8e212733..6e32fc1f8f1d 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -12,6 +12,7 @@
+ #include <linux/intel_vsec.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/pci.h>
+ #include <linux/slab.h>
+ #include <linux/uaccess.h>
+@@ -262,8 +263,12 @@ static void pmt_crashlog_remove(struct auxiliary_device *auxdev)
+ 	struct pmt_crashlog_priv *priv = auxiliary_get_drvdata(auxdev);
+ 	int i;
+ 
+-	for (i = 0; i < priv->num_entries; i++)
+-		intel_pmt_dev_destroy(&priv->entry[i].entry, &pmt_crashlog_ns);
++	for (i = 0; i < priv->num_entries; i++) {
++		struct crashlog_entry *crashlog = &priv->entry[i];
++
++		intel_pmt_dev_destroy(&crashlog->entry, &pmt_crashlog_ns);
++		mutex_destroy(&crashlog->control_mutex);
++	}
+ }
+ 
+ static int pmt_crashlog_probe(struct auxiliary_device *auxdev,
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-re-order-trigger-logic.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-re-order-trigger-logic.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:37 -0400
+Subject: platform/x86/intel/pmt: re-order trigger logic
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Setting the clear bit or checking the complete bit before checking to
+see if crashlog is disabled seems incorrect.
+
+Check disable before accessing any other bits.
+
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Reviewed-by: David E. Box <david.e.box@linux.intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-8-michael.j.ruhl@intel.com
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 147c18d8efaa1fa006fdd0b901d51092dc3b2189 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index c3ca95854aba..440d2045e90d 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -193,6 +193,10 @@ trigger_store(struct device *dev, struct device_attribute *attr,
+ 
+ 	guard(mutex)(&entry->control_mutex);
+ 
++	/* if device is currently disabled, return busy */
++	if (pmt_crashlog_disabled(&entry->entry))
++		return -EBUSY;
++
+ 	if (!trigger) {
+ 		pmt_crashlog_set_clear(&entry->entry);
+ 		return count;
+@@ -202,10 +206,6 @@ trigger_store(struct device *dev, struct device_attribute *attr,
+ 	if (pmt_crashlog_complete(&entry->entry))
+ 		return -EEXIST;
+ 
+-	/* if device is currently disabled, return busy */
+-	if (pmt_crashlog_disabled(&entry->entry))
+-		return -EBUSY;
+-
+ 	pmt_crashlog_set_execute(&entry->entry);
+ 
+ 	return count;
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-refactor-base-parameter.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-refactor-base-parameter.patch
@@ -1,0 +1,193 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:41 -0400
+Subject: platform/x86/intel/pmt: refactor base parameter
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+To support an upcoming crashlog change, use the parent of
+struct intel_pmt_entry, struct crashlog_entry, as a main parameter.
+
+Using struct crashlog_entry will allow for a more flexible interface
+to control the crashlog feature.
+
+- Refactor to use struct crashlog_entry in place of
+  struct intel_pmt_entry
+- Rename variables from "entry" to "crashlog"
+
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-12-michael.j.ruhl@intel.com
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 66df9fa783aadc2a5ae8ca11ead0b13032d24e7e linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 58 ++++++++++++-----------
+ 1 file changed, 30 insertions(+), 28 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index ed781548e59d..087b7110ddd2 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -66,8 +66,9 @@ struct pmt_crashlog_priv {
+  */
+ 
+ /* Read, modify, write the control register, setting or clearing @bit based on @set */
+-static void pmt_crashlog_rmw(struct intel_pmt_entry *entry, u32 bit, bool set)
++static void pmt_crashlog_rmw(struct crashlog_entry *crashlog, u32 bit, bool set)
+ {
++	struct intel_pmt_entry *entry = &crashlog->entry;
+ 	u32 reg = readl(entry->disc_table + CONTROL_OFFSET);
+ 
+ 	reg &= ~CRASHLOG_FLAG_TRIGGER_MASK;
+@@ -81,23 +82,24 @@ static void pmt_crashlog_rmw(struct intel_pmt_entry *entry, u32 bit, bool set)
+ }
+ 
+ /* Read the status register and see if the specified @bit is set */
+-static bool pmt_crashlog_rc(struct intel_pmt_entry *entry, u32 bit)
++static bool pmt_crashlog_rc(struct crashlog_entry *crashlog, u32 bit)
+ {
++	struct intel_pmt_entry *entry = &crashlog->entry;
+ 	u32 reg = readl(entry->disc_table + CONTROL_OFFSET);
+ 
+ 	return !!(reg & bit);
+ }
+ 
+-static bool pmt_crashlog_complete(struct intel_pmt_entry *entry)
++static bool pmt_crashlog_complete(struct crashlog_entry *crashlog)
+ {
+ 	/* return current value of the crashlog complete flag */
+-	return pmt_crashlog_rc(entry, CRASHLOG_FLAG_TRIGGER_COMPLETE);
++	return pmt_crashlog_rc(crashlog, CRASHLOG_FLAG_TRIGGER_COMPLETE);
+ }
+ 
+-static bool pmt_crashlog_disabled(struct intel_pmt_entry *entry)
++static bool pmt_crashlog_disabled(struct crashlog_entry *crashlog)
+ {
+ 	/* return current value of the crashlog disabled flag */
+-	return pmt_crashlog_rc(entry, CRASHLOG_FLAG_DISABLE);
++	return pmt_crashlog_rc(crashlog, CRASHLOG_FLAG_DISABLE);
+ }
+ 
+ static bool pmt_crashlog_supported(struct intel_pmt_entry *entry)
+@@ -115,20 +117,20 @@ static bool pmt_crashlog_supported(struct intel_pmt_entry *entry)
+ 	return crash_type == CRASH_TYPE_OOBMSM && version == 0;
+ }
+ 
+-static void pmt_crashlog_set_disable(struct intel_pmt_entry *entry,
++static void pmt_crashlog_set_disable(struct crashlog_entry *crashlog,
+ 				     bool disable)
+ {
+-	pmt_crashlog_rmw(entry, CRASHLOG_FLAG_DISABLE, disable);
++	pmt_crashlog_rmw(crashlog, CRASHLOG_FLAG_DISABLE, disable);
+ }
+ 
+-static void pmt_crashlog_set_clear(struct intel_pmt_entry *entry)
++static void pmt_crashlog_set_clear(struct crashlog_entry *crashlog)
+ {
+-	pmt_crashlog_rmw(entry, CRASHLOG_FLAG_TRIGGER_CLEAR, true);
++	pmt_crashlog_rmw(crashlog, CRASHLOG_FLAG_TRIGGER_CLEAR, true);
+ }
+ 
+-static void pmt_crashlog_set_execute(struct intel_pmt_entry *entry)
++static void pmt_crashlog_set_execute(struct crashlog_entry *crashlog)
+ {
+-	pmt_crashlog_rmw(entry, CRASHLOG_FLAG_TRIGGER_EXECUTE, true);
++	pmt_crashlog_rmw(crashlog, CRASHLOG_FLAG_TRIGGER_EXECUTE, true);
+ }
+ 
+ /*
+@@ -137,8 +139,8 @@ static void pmt_crashlog_set_execute(struct intel_pmt_entry *entry)
+ static ssize_t
+ enable_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+-	struct intel_pmt_entry *entry = dev_get_drvdata(dev);
+-	bool enabled = !pmt_crashlog_disabled(entry);
++	struct crashlog_entry *crashlog = dev_get_drvdata(dev);
++	bool enabled = !pmt_crashlog_disabled(crashlog);
+ 
+ 	return sprintf(buf, "%d\n", enabled);
+ }
+@@ -147,19 +149,19 @@ static ssize_t
+ enable_store(struct device *dev, struct device_attribute *attr,
+ 	     const char *buf, size_t count)
+ {
+-	struct crashlog_entry *entry;
++	struct crashlog_entry *crashlog;
+ 	bool enabled;
+ 	int result;
+ 
+-	entry = dev_get_drvdata(dev);
++	crashlog = dev_get_drvdata(dev);
+ 
+ 	result = kstrtobool(buf, &enabled);
+ 	if (result)
+ 		return result;
+ 
+-	guard(mutex)(&entry->control_mutex);
++	guard(mutex)(&crashlog->control_mutex);
+ 
+-	pmt_crashlog_set_disable(&entry->entry, !enabled);
++	pmt_crashlog_set_disable(crashlog, !enabled);
+ 
+ 	return count;
+ }
+@@ -168,11 +170,11 @@ static DEVICE_ATTR_RW(enable);
+ static ssize_t
+ trigger_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+-	struct intel_pmt_entry *entry;
++	struct crashlog_entry *crashlog;
+ 	bool trigger;
+ 
+-	entry = dev_get_drvdata(dev);
+-	trigger = pmt_crashlog_complete(entry);
++	crashlog = dev_get_drvdata(dev);
++	trigger = pmt_crashlog_complete(crashlog);
+ 
+ 	return sprintf(buf, "%d\n", trigger);
+ }
+@@ -181,32 +183,32 @@ static ssize_t
+ trigger_store(struct device *dev, struct device_attribute *attr,
+ 	      const char *buf, size_t count)
+ {
+-	struct crashlog_entry *entry;
++	struct crashlog_entry *crashlog;
+ 	bool trigger;
+ 	int result;
+ 
+-	entry = dev_get_drvdata(dev);
++	crashlog = dev_get_drvdata(dev);
+ 
+ 	result = kstrtobool(buf, &trigger);
+ 	if (result)
+ 		return result;
+ 
+-	guard(mutex)(&entry->control_mutex);
++	guard(mutex)(&crashlog->control_mutex);
+ 
+ 	/* if device is currently disabled, return busy */
+-	if (pmt_crashlog_disabled(&entry->entry))
++	if (pmt_crashlog_disabled(crashlog))
+ 		return -EBUSY;
+ 
+ 	if (!trigger) {
+-		pmt_crashlog_set_clear(&entry->entry);
++		pmt_crashlog_set_clear(crashlog);
+ 		return count;
+ 	}
+ 
+ 	/* we cannot trigger a new crash if one is still pending */
+-	if (pmt_crashlog_complete(&entry->entry))
++	if (pmt_crashlog_complete(crashlog))
+ 		return -EEXIST;
+ 
+-	pmt_crashlog_set_execute(&entry->entry);
++	pmt_crashlog_set_execute(crashlog);
+ 
+ 	return count;
+ }
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-support-BMG-crashlog.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-support-BMG-crashlog.patch
@@ -1,0 +1,388 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:43 -0400
+Subject: platform/x86/intel/pmt: support BMG crashlog
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Battlemage GPU has the type 1 version 2 crashlog feature.
+
+Update the crashlog driver to support this crashlog version.
+
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-14-michael.j.ruhl@intel.com
+[ij: make crashlog_type1_ver2 static]
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 2c402a801c19568de97b86a77b25d13448dc080a linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 262 ++++++++++++++++++++--
+ 1 file changed, 249 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index db54f881ba57..b0393c9c5b4b 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -53,25 +53,59 @@
+ #define TYPE1_VER0_COMPLETE		BIT(31)
+ #define TYPE1_VER0_TRIGGER_MASK		GENMASK(31, 28)
+ 
++/*
++ * Type 1 Version 2
++ * status and control are different registers
++ */
++#define TYPE1_VER2_STATUS_OFFSET	0x00
++#define TYPE1_VER2_CONTROL_OFFSET	0x14
++
++/* status register */
++#define TYPE1_VER2_CLEAR_SUPPORT	BIT(20)
++#define TYPE1_VER2_REARMED		BIT(25)
++#define TYPE1_VER2_ERROR		BIT(26)
++#define TYPE1_VER2_CONSUMED		BIT(27)
++#define TYPE1_VER2_DISABLED		BIT(28)
++#define TYPE1_VER2_CLEARED		BIT(29)
++#define TYPE1_VER2_IN_PROGRESS		BIT(30)
++#define TYPE1_VER2_COMPLETE		BIT(31)
++
++/* control register */
++#define TYPE1_VER2_CONSUME		BIT(25)
++#define TYPE1_VER2_REARM		BIT(28)
++#define TYPE1_VER2_EXECUTE		BIT(29)
++#define TYPE1_VER2_CLEAR		BIT(30)
++#define TYPE1_VER2_DISABLE		BIT(31)
++#define TYPE1_VER2_TRIGGER_MASK	\
++	(TYPE1_VER2_EXECUTE | TYPE1_VER2_CLEAR | TYPE1_VER2_DISABLE)
++
+ /* After offset, order alphabetically, not bit ordered */
+ struct crashlog_status {
+ 	u32 offset;
++	u32 clear_supported;
+ 	u32 cleared;
+ 	u32 complete;
++	u32 consumed;
+ 	u32 disabled;
++	u32 error;
++	u32 in_progress;
++	u32 rearmed;
+ };
+ 
+ struct crashlog_control {
+ 	u32 offset;
+ 	u32 trigger_mask;
+ 	u32 clear;
++	u32 consume;
+ 	u32 disable;
+ 	u32 manual;
++	u32 rearm;
+ };
+ 
+ struct crashlog_info {
+ 	const struct crashlog_status status;
+ 	const struct crashlog_control control;
++	const struct attribute_group *attr_grp;
+ };
+ 
+ struct crashlog_entry {
+@@ -128,19 +162,23 @@ static bool pmt_crashlog_disabled(struct crashlog_entry *crashlog)
+ 	return pmt_crashlog_rc(crashlog, crashlog->info->status.disabled);
+ }
+ 
+-static bool pmt_crashlog_supported(struct intel_pmt_entry *entry)
++static bool pmt_crashlog_supported(struct intel_pmt_entry *entry, u32 *crash_type, u32 *version)
+ {
+ 	u32 discovery_header = readl(entry->disc_table + CONTROL_OFFSET);
+-	u32 crash_type, version;
+ 
+-	crash_type = GET_TYPE(discovery_header);
+-	version = GET_VERSION(discovery_header);
++	*crash_type = GET_TYPE(discovery_header);
++	*version = GET_VERSION(discovery_header);
+ 
+ 	/*
+-	 * Currently we only recognize OOBMSM version 0 devices.
+-	 * We can ignore all other crashlog devices in the system.
++	 * Currently we only recognize OOBMSM (type 1) and version 0 or 2
++	 * devices.
++	 *
++	 * Ignore all other crashlog devices in the system.
+ 	 */
+-	return crash_type == CRASH_TYPE_OOBMSM && version == 0;
++	if (*crash_type == CRASH_TYPE_OOBMSM && (*version == 0 || *version == 2))
++		return true;
++
++	return false;
+ }
+ 
+ static void pmt_crashlog_set_disable(struct crashlog_entry *crashlog,
+@@ -159,9 +197,115 @@ static void pmt_crashlog_set_execute(struct crashlog_entry *crashlog)
+ 	pmt_crashlog_rmw(crashlog, crashlog->info->control.manual, true);
+ }
+ 
++static bool pmt_crashlog_cleared(struct crashlog_entry *crashlog)
++{
++	return pmt_crashlog_rc(crashlog, crashlog->info->status.cleared);
++}
++
++static bool pmt_crashlog_consumed(struct crashlog_entry *crashlog)
++{
++	return pmt_crashlog_rc(crashlog, crashlog->info->status.consumed);
++}
++
++static void pmt_crashlog_set_consumed(struct crashlog_entry *crashlog)
++{
++	pmt_crashlog_rmw(crashlog, crashlog->info->control.consume, true);
++}
++
++static bool pmt_crashlog_error(struct crashlog_entry *crashlog)
++{
++	return pmt_crashlog_rc(crashlog, crashlog->info->status.error);
++}
++
++static bool pmt_crashlog_rearm(struct crashlog_entry *crashlog)
++{
++	return pmt_crashlog_rc(crashlog, crashlog->info->status.rearmed);
++}
++
++static void pmt_crashlog_set_rearm(struct crashlog_entry *crashlog)
++{
++	pmt_crashlog_rmw(crashlog, crashlog->info->control.rearm, true);
++}
++
+ /*
+  * sysfs
+  */
++static ssize_t
++clear_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct crashlog_entry *crashlog = dev_get_drvdata(dev);
++	bool cleared = pmt_crashlog_cleared(crashlog);
++
++	return sysfs_emit(buf, "%d\n", cleared);
++}
++
++static ssize_t
++clear_store(struct device *dev, struct device_attribute *attr,
++	    const char *buf, size_t count)
++{
++	struct crashlog_entry *crashlog;
++	bool clear;
++	int result;
++
++	crashlog = dev_get_drvdata(dev);
++
++	result = kstrtobool(buf, &clear);
++	if (result)
++		return result;
++
++	/* set bit only */
++	if (!clear)
++		return -EINVAL;
++
++	guard(mutex)(&crashlog->control_mutex);
++
++	pmt_crashlog_set_clear(crashlog);
++
++	return count;
++}
++static DEVICE_ATTR_RW(clear);
++
++static ssize_t
++consumed_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct crashlog_entry *crashlog = dev_get_drvdata(dev);
++	bool consumed = pmt_crashlog_consumed(crashlog);
++
++	return sysfs_emit(buf, "%d\n", consumed);
++}
++
++static ssize_t
++consumed_store(struct device *dev, struct device_attribute *attr, const char *buf,
++	       size_t count)
++{
++	struct crashlog_entry *crashlog;
++	bool consumed;
++	int result;
++
++	crashlog = dev_get_drvdata(dev);
++
++	result = kstrtobool(buf, &consumed);
++	if (result)
++		return result;
++
++	/* set bit only */
++	if (!consumed)
++		return -EINVAL;
++
++	guard(mutex)(&crashlog->control_mutex);
++
++	if (pmt_crashlog_disabled(crashlog))
++		return -EBUSY;
++
++	if (!pmt_crashlog_complete(crashlog))
++		return -EEXIST;
++
++	pmt_crashlog_set_consumed(crashlog);
++
++	return count;
++}
++static DEVICE_ATTR_RW(consumed);
++
+ static ssize_t
+ enable_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+@@ -193,6 +337,51 @@ enable_store(struct device *dev, struct device_attribute *attr,
+ }
+ static DEVICE_ATTR_RW(enable);
+ 
++static ssize_t
++error_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct crashlog_entry *crashlog = dev_get_drvdata(dev);
++	bool error = pmt_crashlog_error(crashlog);
++
++	return sysfs_emit(buf, "%d\n", error);
++}
++static DEVICE_ATTR_RO(error);
++
++static ssize_t
++rearm_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct crashlog_entry *crashlog = dev_get_drvdata(dev);
++	int rearmed = pmt_crashlog_rearm(crashlog);
++
++	return sysfs_emit(buf, "%d\n", rearmed);
++}
++
++static ssize_t
++rearm_store(struct device *dev, struct device_attribute *attr, const char *buf,
++	    size_t count)
++{
++	struct crashlog_entry *crashlog;
++	bool rearm;
++	int result;
++
++	crashlog = dev_get_drvdata(dev);
++
++	result = kstrtobool(buf, &rearm);
++	if (result)
++		return result;
++
++	/* set only */
++	if (!rearm)
++		return -EINVAL;
++
++	guard(mutex)(&crashlog->control_mutex);
++
++	pmt_crashlog_set_rearm(crashlog);
++
++	return count;
++}
++static DEVICE_ATTR_RW(rearm);
++
+ static ssize_t
+ trigger_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+@@ -240,14 +429,28 @@ trigger_store(struct device *dev, struct device_attribute *attr,
+ }
+ static DEVICE_ATTR_RW(trigger);
+ 
+-static struct attribute *pmt_crashlog_attrs[] = {
++static struct attribute *pmt_crashlog_type1_ver0_attrs[] = {
+ 	&dev_attr_enable.attr,
+ 	&dev_attr_trigger.attr,
+ 	NULL
+ };
+ 
+-static const struct attribute_group pmt_crashlog_group = {
+-	.attrs	= pmt_crashlog_attrs,
++static struct attribute *pmt_crashlog_type1_ver2_attrs[] = {
++	&dev_attr_clear.attr,
++	&dev_attr_consumed.attr,
++	&dev_attr_enable.attr,
++	&dev_attr_error.attr,
++	&dev_attr_rearm.attr,
++	&dev_attr_trigger.attr,
++	NULL
++};
++
++static const struct attribute_group pmt_crashlog_type1_ver0_group = {
++	.attrs	= pmt_crashlog_type1_ver0_attrs,
++};
++
++static const struct attribute_group pmt_crashlog_type1_ver2_group = {
++	.attrs = pmt_crashlog_type1_ver2_attrs,
+ };
+ 
+ static const struct crashlog_info crashlog_type1_ver0 = {
+@@ -261,22 +464,55 @@ static const struct crashlog_info crashlog_type1_ver0 = {
+ 	.control.clear = TYPE1_VER0_CLEAR,
+ 	.control.disable = TYPE1_VER0_DISABLE,
+ 	.control.manual = TYPE1_VER0_EXECUTE,
++	.attr_grp = &pmt_crashlog_type1_ver0_group,
+ };
+ 
++static const struct crashlog_info crashlog_type1_ver2 = {
++	.status.offset = TYPE1_VER2_STATUS_OFFSET,
++	.status.clear_supported = TYPE1_VER2_CLEAR_SUPPORT,
++	.status.cleared = TYPE1_VER2_CLEARED,
++	.status.complete = TYPE1_VER2_COMPLETE,
++	.status.consumed = TYPE1_VER2_CONSUMED,
++	.status.disabled = TYPE1_VER2_DISABLED,
++	.status.error = TYPE1_VER2_ERROR,
++	.status.in_progress = TYPE1_VER2_IN_PROGRESS,
++	.status.rearmed = TYPE1_VER2_REARMED,
++
++	.control.offset = TYPE1_VER2_CONTROL_OFFSET,
++	.control.trigger_mask = TYPE1_VER2_TRIGGER_MASK,
++	.control.clear = TYPE1_VER2_CLEAR,
++	.control.consume = TYPE1_VER2_CONSUME,
++	.control.disable = TYPE1_VER2_DISABLE,
++	.control.manual = TYPE1_VER2_EXECUTE,
++	.control.rearm = TYPE1_VER2_REARM,
++	.attr_grp = &pmt_crashlog_type1_ver2_group,
++};
++
++static const struct crashlog_info *select_crashlog_info(u32 type, u32 version)
++{
++	if (version == 0)
++		return &crashlog_type1_ver0;
++
++	return &crashlog_type1_ver2;
++}
++
+ static int pmt_crashlog_header_decode(struct intel_pmt_entry *entry,
+ 				      struct device *dev)
+ {
+ 	void __iomem *disc_table = entry->disc_table;
+ 	struct intel_pmt_header *header = &entry->header;
+ 	struct crashlog_entry *crashlog;
++	u32 version;
++	u32 type;
+ 
+-	if (!pmt_crashlog_supported(entry))
++	if (!pmt_crashlog_supported(entry, &type, &version))
+ 		return 1;
+ 
+ 	/* initialize the crashlog struct */
+ 	crashlog = container_of(entry, struct crashlog_entry, entry);
+ 	mutex_init(&crashlog->control_mutex);
+-	crashlog->info = &crashlog_type1_ver0;
++
++	crashlog->info = select_crashlog_info(type, version);
+ 
+ 	header->access_type = GET_ACCESS(readl(disc_table));
+ 	header->guid = readl(disc_table + GUID_OFFSET);
+@@ -285,7 +521,7 @@ static int pmt_crashlog_header_decode(struct intel_pmt_entry *entry,
+ 	/* Size is measured in DWORDS, but accessor returns bytes */
+ 	header->size = GET_SIZE(readl(disc_table + SIZE_OFFSET));
+ 
+-	entry->attr_grp = &pmt_crashlog_group;
++	entry->attr_grp = crashlog->info->attr_grp;
+ 
+ 	return 0;
+ }
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-use-a-version-struct.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-use-a-version-struct.patch
@@ -1,0 +1,202 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:42 -0400
+Subject: platform/x86/intel/pmt: use a version struct
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In preparation for supporting multiple crashlog versions, use a struct
+to keep bit offset info for the status and control bits.
+
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-13-michael.j.ruhl@intel.com
+[ij: move crashlog_type1_ver0 to its final place & add consts to crashlog_info]
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 5623fa6859a6cd49366421317e3c5ab183583624 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 92 ++++++++++++++++-------
+ 1 file changed, 66 insertions(+), 26 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index 087b7110ddd2..db54f881ba57 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -24,21 +24,6 @@
+ /* Crashlog discovery header types */
+ #define CRASH_TYPE_OOBMSM	1
+ 
+-/* Control Flags */
+-#define CRASHLOG_FLAG_DISABLE		BIT(28)
+-
+-/*
+- * Bits 29 and 30 control the state of bit 31.
+- *
+- * Bit 29 will clear bit 31, if set, allowing a new crashlog to be captured.
+- * Bit 30 will immediately trigger a crashlog to be generated, setting bit 31.
+- * Bit 31 is the read-only status with a 1 indicating log is complete.
+- */
+-#define CRASHLOG_FLAG_TRIGGER_CLEAR	BIT(29)
+-#define CRASHLOG_FLAG_TRIGGER_EXECUTE	BIT(30)
+-#define CRASHLOG_FLAG_TRIGGER_COMPLETE	BIT(31)
+-#define CRASHLOG_FLAG_TRIGGER_MASK	GENMASK(31, 28)
+-
+ /* Crashlog Discovery Header */
+ #define CONTROL_OFFSET		0x0
+ #define GUID_OFFSET		0x4
+@@ -50,10 +35,50 @@
+ /* size is in bytes */
+ #define GET_SIZE(v)		((v) * sizeof(u32))
+ 
++/*
++ * Type 1 Version 0
++ * status and control registers are combined.
++ *
++ * Bits 29 and 30 control the state of bit 31.
++ * Bit 29 will clear bit 31, if set, allowing a new crashlog to be captured.
++ * Bit 30 will immediately trigger a crashlog to be generated, setting bit 31.
++ * Bit 31 is the read-only status with a 1 indicating log is complete.
++ */
++#define TYPE1_VER0_STATUS_OFFSET	0x00
++#define TYPE1_VER0_CONTROL_OFFSET	0x00
++
++#define TYPE1_VER0_DISABLE		BIT(28)
++#define TYPE1_VER0_CLEAR		BIT(29)
++#define TYPE1_VER0_EXECUTE		BIT(30)
++#define TYPE1_VER0_COMPLETE		BIT(31)
++#define TYPE1_VER0_TRIGGER_MASK		GENMASK(31, 28)
++
++/* After offset, order alphabetically, not bit ordered */
++struct crashlog_status {
++	u32 offset;
++	u32 cleared;
++	u32 complete;
++	u32 disabled;
++};
++
++struct crashlog_control {
++	u32 offset;
++	u32 trigger_mask;
++	u32 clear;
++	u32 disable;
++	u32 manual;
++};
++
++struct crashlog_info {
++	const struct crashlog_status status;
++	const struct crashlog_control control;
++};
++
+ struct crashlog_entry {
+ 	/* entry must be first member of struct */
+ 	struct intel_pmt_entry		entry;
+ 	struct mutex			control_mutex;
++	const struct crashlog_info	*info;
+ };
+ 
+ struct pmt_crashlog_priv {
+@@ -68,24 +93,25 @@ struct pmt_crashlog_priv {
+ /* Read, modify, write the control register, setting or clearing @bit based on @set */
+ static void pmt_crashlog_rmw(struct crashlog_entry *crashlog, u32 bit, bool set)
+ {
++	const struct crashlog_control *control = &crashlog->info->control;
+ 	struct intel_pmt_entry *entry = &crashlog->entry;
+-	u32 reg = readl(entry->disc_table + CONTROL_OFFSET);
++	u32 reg = readl(entry->disc_table + control->offset);
+ 
+-	reg &= ~CRASHLOG_FLAG_TRIGGER_MASK;
++	reg &= ~control->trigger_mask;
+ 
+ 	if (set)
+ 		reg |= bit;
+ 	else
+ 		reg &= ~bit;
+ 
+-	writel(reg, entry->disc_table + CONTROL_OFFSET);
++	writel(reg, entry->disc_table + control->offset);
+ }
+ 
+ /* Read the status register and see if the specified @bit is set */
+ static bool pmt_crashlog_rc(struct crashlog_entry *crashlog, u32 bit)
+ {
+-	struct intel_pmt_entry *entry = &crashlog->entry;
+-	u32 reg = readl(entry->disc_table + CONTROL_OFFSET);
++	const struct crashlog_status *status = &crashlog->info->status;
++	u32 reg = readl(crashlog->entry.disc_table + status->offset);
+ 
+ 	return !!(reg & bit);
+ }
+@@ -93,13 +119,13 @@ static bool pmt_crashlog_rc(struct crashlog_entry *crashlog, u32 bit)
+ static bool pmt_crashlog_complete(struct crashlog_entry *crashlog)
+ {
+ 	/* return current value of the crashlog complete flag */
+-	return pmt_crashlog_rc(crashlog, CRASHLOG_FLAG_TRIGGER_COMPLETE);
++	return pmt_crashlog_rc(crashlog, crashlog->info->status.complete);
+ }
+ 
+ static bool pmt_crashlog_disabled(struct crashlog_entry *crashlog)
+ {
+ 	/* return current value of the crashlog disabled flag */
+-	return pmt_crashlog_rc(crashlog, CRASHLOG_FLAG_DISABLE);
++	return pmt_crashlog_rc(crashlog, crashlog->info->status.disabled);
+ }
+ 
+ static bool pmt_crashlog_supported(struct intel_pmt_entry *entry)
+@@ -120,17 +146,17 @@ static bool pmt_crashlog_supported(struct intel_pmt_entry *entry)
+ static void pmt_crashlog_set_disable(struct crashlog_entry *crashlog,
+ 				     bool disable)
+ {
+-	pmt_crashlog_rmw(crashlog, CRASHLOG_FLAG_DISABLE, disable);
++	pmt_crashlog_rmw(crashlog, crashlog->info->control.disable, disable);
+ }
+ 
+ static void pmt_crashlog_set_clear(struct crashlog_entry *crashlog)
+ {
+-	pmt_crashlog_rmw(crashlog, CRASHLOG_FLAG_TRIGGER_CLEAR, true);
++	pmt_crashlog_rmw(crashlog, crashlog->info->control.clear, true);
+ }
+ 
+ static void pmt_crashlog_set_execute(struct crashlog_entry *crashlog)
+ {
+-	pmt_crashlog_rmw(crashlog, CRASHLOG_FLAG_TRIGGER_EXECUTE, true);
++	pmt_crashlog_rmw(crashlog, crashlog->info->control.manual, true);
+ }
+ 
+ /*
+@@ -224,6 +250,19 @@ static const struct attribute_group pmt_crashlog_group = {
+ 	.attrs	= pmt_crashlog_attrs,
+ };
+ 
++static const struct crashlog_info crashlog_type1_ver0 = {
++	.status.offset = TYPE1_VER0_STATUS_OFFSET,
++	.status.cleared = TYPE1_VER0_CLEAR,
++	.status.complete = TYPE1_VER0_COMPLETE,
++	.status.disabled = TYPE1_VER0_DISABLE,
++
++	.control.offset = TYPE1_VER0_CONTROL_OFFSET,
++	.control.trigger_mask = TYPE1_VER0_TRIGGER_MASK,
++	.control.clear = TYPE1_VER0_CLEAR,
++	.control.disable = TYPE1_VER0_DISABLE,
++	.control.manual = TYPE1_VER0_EXECUTE,
++};
++
+ static int pmt_crashlog_header_decode(struct intel_pmt_entry *entry,
+ 				      struct device *dev)
+ {
+@@ -234,9 +273,10 @@ static int pmt_crashlog_header_decode(struct intel_pmt_entry *entry,
+ 	if (!pmt_crashlog_supported(entry))
+ 		return 1;
+ 
+-	/* initialize control mutex */
++	/* initialize the crashlog struct */
+ 	crashlog = container_of(entry, struct crashlog_entry, entry);
+ 	mutex_init(&crashlog->control_mutex);
++	crashlog->info = &crashlog_type1_ver0;
+ 
+ 	header->access_type = GET_ACCESS(readl(disc_table));
+ 	header->guid = readl(disc_table + GUID_OFFSET);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-use-guard-mutex.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-use-guard-mutex.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:36 -0400
+Subject: platform/x86/intel/pmt: use guard(mutex)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Update the mutex paths to use the new guard() mechanism.
+
+With the removal of goto, do some minor cleanup of the current logic
+path.
+
+Reviewed-by: David E. Box <david.e.box@linux.intel.com>
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-7-michael.j.ruhl@intel.com
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit 4f8fa22d108006b8ec0b94bb67a1bd537a2bf141 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 33 +++++++++++------------
+ 1 file changed, 16 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index 6e32fc1f8f1d..c3ca95854aba 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include <linux/auxiliary_bus.h>
++#include <linux/cleanup.h>
+ #include <linux/intel_vsec.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+@@ -156,9 +157,9 @@ enable_store(struct device *dev, struct device_attribute *attr,
+ 	if (result)
+ 		return result;
+ 
+-	mutex_lock(&entry->control_mutex);
++	guard(mutex)(&entry->control_mutex);
++
+ 	pmt_crashlog_set_disable(&entry->entry, !enabled);
+-	mutex_unlock(&entry->control_mutex);
+ 
+ 	return count;
+ }
+@@ -190,26 +191,24 @@ trigger_store(struct device *dev, struct device_attribute *attr,
+ 	if (result)
+ 		return result;
+ 
+-	mutex_lock(&entry->control_mutex);
++	guard(mutex)(&entry->control_mutex);
+ 
+ 	if (!trigger) {
+ 		pmt_crashlog_set_clear(&entry->entry);
+-	} else if (pmt_crashlog_complete(&entry->entry)) {
+-		/* we cannot trigger a new crash if one is still pending */
+-		result = -EEXIST;
+-		goto err;
+-	} else if (pmt_crashlog_disabled(&entry->entry)) {
+-		/* if device is currently disabled, return busy */
+-		result = -EBUSY;
+-		goto err;
+-	} else {
+-		pmt_crashlog_set_execute(&entry->entry);
++		return count;
+ 	}
+ 
+-	result = count;
+-err:
+-	mutex_unlock(&entry->control_mutex);
+-	return result;
++	/* we cannot trigger a new crash if one is still pending */
++	if (pmt_crashlog_complete(&entry->entry))
++		return -EEXIST;
++
++	/* if device is currently disabled, return busy */
++	if (pmt_crashlog_disabled(&entry->entry))
++		return -EBUSY;
++
++	pmt_crashlog_set_execute(&entry->entry);
++
++	return count;
+ }
+ static DEVICE_ATTR_RW(trigger);
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-pmt-white-space-cleanup.patch
+++ b/backport/patches/base/0001-platform-x86-intel-pmt-white-space-cleanup.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Michael J. Ruhl" <michael.j.ruhl@intel.com>
+Date: Sun, 13 Jul 2025 13:29:34 -0400
+Subject: platform/x86/intel/pmt: white space cleanup
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Noticed two white space issues; cleaned them.
+
+Reviewed-by: David E. Box <david.e.box@linux.intel.com>
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://lore.kernel.org/r/20250713172943.7335-5-michael.j.ruhl@intel.com
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry-picked from commit ba22fe0cffedf5156731fbac729a638f18d17e6b linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/platform/x86/intel/pmt/crashlog.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/pmt/crashlog.c b/drivers/platform/x86/intel/pmt/crashlog.c
+index 6a9eb3c4b313..d40c8e212733 100644
+--- a/drivers/platform/x86/intel/pmt/crashlog.c
++++ b/drivers/platform/x86/intel/pmt/crashlog.c
+@@ -143,7 +143,7 @@ enable_show(struct device *dev, struct device_attribute *attr, char *buf)
+ 
+ static ssize_t
+ enable_store(struct device *dev, struct device_attribute *attr,
+-	    const char *buf, size_t count)
++	     const char *buf, size_t count)
+ {
+ 	struct crashlog_entry *entry;
+ 	bool enabled;
+@@ -177,7 +177,7 @@ trigger_show(struct device *dev, struct device_attribute *attr, char *buf)
+ 
+ static ssize_t
+ trigger_store(struct device *dev, struct device_attribute *attr,
+-	    const char *buf, size_t count)
++	      const char *buf, size_t count)
+ {
+ 	struct crashlog_entry *entry;
+ 	bool trigger;
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -39,6 +39,19 @@ backport/patches/base/0001-drm-xe-xe_guc_pc-Lock-once-to-update-stashed-frequen.
 backport/patches/base/0001-drm-xe-Split-xe_device_td_flush.patch
 backport/patches/base/0001-drm-xe-bmg-Update-Wa_22019338487.patch
 backport/patches/base/0001-drm-xe-hwmon-Add-SW-clamp-for-power-limits-writes.patch
+backport/patches/base/0001-platform-x86-intel-pmt-fix-a-crashlog-NULL-pointer-a.patch
+backport/patches/base/0001-drm-xe-Correct-the-rev-value-for-the-DVSEC-entries.patch
+backport/patches/base/0001-drm-xe-Correct-BMG-VSEC-header-sizing.patch
+backport/patches/base/0001-platform-x86-intel-pmt-white-space-cleanup.patch
+backport/patches/base/0001-platform-x86-intel-pmt-mutex-clean-up.patch
+backport/patches/base/0001-platform-x86-intel-pmt-use-guard-mutex.patch
+backport/patches/base/0001-platform-x86-intel-pmt-re-order-trigger-logic.patch
+backport/patches/base/0001-platform-x86-intel-pmt-correct-types.patch
+backport/patches/base/0001-platform-x86-intel-pmt-decouple-sysfs-and-namespace.patch
+backport/patches/base/0001-platform-x86-intel-pmt-add-register-access-helpers.patch
+backport/patches/base/0001-platform-x86-intel-pmt-refactor-base-parameter.patch
+backport/patches/base/0001-platform-x86-intel-pmt-use-a-version-struct.patch
+backport/patches/base/0001-platform-x86-intel-pmt-support-BMG-crashlog.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Backport support for Intel BMG GPU crashlog feature. The Xe driver exposes
crashlog for BMG devices, but the PMT driver lacked compatibility.
Update the PMT crashlog driver to handle BMG-specific crashlog format.

Patches backported:
platform/x86/intel/pmt: support BMG crashlog
platform/x86/intel/pmt: use a version struct
platform/x86/intel/pmt: refactor base parameter
platform/x86/intel/pmt: add register access helpers
platform/x86/intel/pmt: decouple sysfs and namespace
platform/x86/intel/pmt: correct types
platform/x86/intel/pmt: re-order trigger logic
platform/x86/intel/pmt: use guard(mutex)
platform/x86/intel/pmt: mutex clean up
platform/x86/intel/pmt: white space cleanup
drm/xe: Correct BMG VSEC header sizing
drm/xe: Correct the rev value for the DVSEC entries
platform/x86/intel/pmt: fix a crashlog NULL pointer access

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>