### PR TITLE
backport/base: Add sysfs for fan/VR version and skip unsupported cmds

### DIFF
--- a/backport/patches/base/0001-drm-xe-Don-t-fail-probe-on-unsupported-mailbox-comma.patch
+++ b/backport/patches/base/0001-drm-xe-Don-t-fail-probe-on-unsupported-mailbox-comma.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Tue, 15 Jul 2025 03:25:03 +0530
+Subject: drm/xe: Don't fail probe on unsupported mailbox command
+
+If the device is running older pcode firmware, it is possible that newer
+mailbox commands are not supported by it. The sysfs attributes aren't
+useful in that case, but we shouldn't fail driver probe because of it.
+As of now, it is unknown if we can distinguish unsupported commands before
+attempting them. But until we figure out a way to do that, fix the
+regressions.
+
+v2: Add debug message (Lucas)
+
+Fixes: cdc36b66cd41 ("drm/xe: Expose fan control and voltage regulator version")
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Tested-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Link: https://lore.kernel.org/r/20250714215503.2897748-1-raag.jadav@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry picked from commit ed5461daa150b037e36b8202381da1ef85d6b16b)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit d9e9aa3e971b37c6d6dfd15ad8dc65537a925725 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device_sysfs.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device_sysfs.c b/drivers/gpu/drm/xe/xe_device_sysfs.c
+index 8dd56f590acc..18d53299fdb1 100644
+--- a/drivers/gpu/drm/xe/xe_device_sysfs.c
++++ b/drivers/gpu/drm/xe/xe_device_sysfs.c
+@@ -166,8 +166,13 @@ static int late_bind_create_files(struct device *dev)
+ 
+ 	ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_CAPABILITY_STATUS, 0),
+ 			    &cap, NULL);
+-	if (ret)
++	if (ret) {
++		if (ret == -ENXIO) {
++			drm_dbg(&xe->drm, "Late binding not supported by firmware\n");
++			ret = 0;
++		}
+ 		goto out;
++	}
+ 
+ 	if (REG_FIELD_GET(V1_FAN_SUPPORTED, cap)) {
+ 		ret = sysfs_create_file(&dev->kobj, &dev_attr_lb_fan_control_version.attr);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Expose-fan-control-and-voltage-regulator-vers.patch
+++ b/backport/patches/base/0001-drm-xe-Expose-fan-control-and-voltage-regulator-vers.patch
@@ -1,0 +1,228 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Wed, 9 Jul 2025 22:12:24 +0530
+Subject: drm/xe: Expose fan control and voltage regulator version
+
+Add sysfs attributes for late binding features which expose bound version
+to the user.
+
+v2: Rework attribute and macro naming (Badal)
+v3: Drop fancy formatting (Rodrigo)
+v4: Form version string using local variables (Rodrigo)
+
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://lore.kernel.org/r/20250709164224.2676086-1-raag.jadav@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit cdc36b66cd41d0f6e18e86d7aa50554c852f97e2 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device_sysfs.c | 143 ++++++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_pcode_api.h    |  15 +++
+ 2 files changed, 157 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device_sysfs.c b/drivers/gpu/drm/xe/xe_device_sysfs.c
+index 4e32750de3a7..8dd56f590acc 100644
+--- a/drivers/gpu/drm/xe/xe_device_sysfs.c
++++ b/drivers/gpu/drm/xe/xe_device_sysfs.c
+@@ -24,6 +24,12 @@
+  *
+  * vram_d3cold_threshold - Report/change vram used threshold(in MB) below
+  * which vram save/restore is permissible during runtime D3cold entry/exit.
++ *
++ * lb_fan_control_version - Fan control version provisioned by late binding.
++ * Exposed only if supported by the device.
++ *
++ * lb_voltage_regulator_version - Voltage regulator version provisioned by late
++ * binding. Exposed only if supported by the device.
+  */
+ 
+ static ssize_t
+@@ -71,6 +77,135 @@ vram_d3cold_threshold_store(struct device *dev, struct device_attribute *attr,
+ 
+ static DEVICE_ATTR_RW(vram_d3cold_threshold);
+ 
++static ssize_t
++lb_fan_control_version_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
++	struct xe_tile *root = xe_device_get_root_tile(xe);
++	u32 cap, ver_low = FAN_TABLE, ver_high = FAN_TABLE;
++	u16 major = 0, minor = 0, hotfix = 0, build = 0;
++	int ret;
++
++	xe_pm_runtime_get(xe);
++
++	ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_CAPABILITY_STATUS, 0),
++			    &cap, NULL);
++	if (ret)
++		goto out;
++
++	if (REG_FIELD_GET(V1_FAN_PROVISIONED, cap)) {
++		ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_VERSION_LOW, 0),
++				    &ver_low, NULL);
++		if (ret)
++			goto out;
++
++		ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_VERSION_HIGH, 0),
++				    &ver_high, NULL);
++		if (ret)
++			goto out;
++
++		major = REG_FIELD_GET(MAJOR_VERSION_MASK, ver_low);
++		minor = REG_FIELD_GET(MINOR_VERSION_MASK, ver_low);
++		hotfix = REG_FIELD_GET(HOTFIX_VERSION_MASK, ver_high);
++		build = REG_FIELD_GET(BUILD_VERSION_MASK, ver_high);
++	}
++out:
++	xe_pm_runtime_put(xe);
++
++	return ret ?: sysfs_emit(buf, "%u.%u.%u.%u\n", major, minor, hotfix, build);
++}
++static DEVICE_ATTR_ADMIN_RO(lb_fan_control_version);
++
++static ssize_t
++lb_voltage_regulator_version_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
++	struct xe_tile *root = xe_device_get_root_tile(xe);
++	u32 cap, ver_low = VR_CONFIG, ver_high = VR_CONFIG;
++	u16 major = 0, minor = 0, hotfix = 0, build = 0;
++	int ret;
++
++	xe_pm_runtime_get(xe);
++
++	ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_CAPABILITY_STATUS, 0),
++			    &cap, NULL);
++	if (ret)
++		goto out;
++
++	if (REG_FIELD_GET(VR_PARAMS_PROVISIONED, cap)) {
++		ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_VERSION_LOW, 0),
++				    &ver_low, NULL);
++		if (ret)
++			goto out;
++
++		ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_VERSION_HIGH, 0),
++				    &ver_high, NULL);
++		if (ret)
++			goto out;
++
++		major = REG_FIELD_GET(MAJOR_VERSION_MASK, ver_low);
++		minor = REG_FIELD_GET(MINOR_VERSION_MASK, ver_low);
++		hotfix = REG_FIELD_GET(HOTFIX_VERSION_MASK, ver_high);
++		build = REG_FIELD_GET(BUILD_VERSION_MASK, ver_high);
++	}
++out:
++	xe_pm_runtime_put(xe);
++
++	return ret ?: sysfs_emit(buf, "%u.%u.%u.%u\n", major, minor, hotfix, build);
++}
++static DEVICE_ATTR_ADMIN_RO(lb_voltage_regulator_version);
++
++static int late_bind_create_files(struct device *dev)
++{
++	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
++	struct xe_tile *root = xe_device_get_root_tile(xe);
++	u32 cap;
++	int ret;
++
++	xe_pm_runtime_get(xe);
++
++	ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_CAPABILITY_STATUS, 0),
++			    &cap, NULL);
++	if (ret)
++		goto out;
++
++	if (REG_FIELD_GET(V1_FAN_SUPPORTED, cap)) {
++		ret = sysfs_create_file(&dev->kobj, &dev_attr_lb_fan_control_version.attr);
++		if (ret)
++			goto out;
++	}
++
++	if (REG_FIELD_GET(VR_PARAMS_SUPPORTED, cap))
++		ret = sysfs_create_file(&dev->kobj, &dev_attr_lb_voltage_regulator_version.attr);
++out:
++	xe_pm_runtime_put(xe);
++
++	return ret;
++}
++
++static void late_bind_remove_files(struct device *dev)
++{
++	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
++	struct xe_tile *root = xe_device_get_root_tile(xe);
++	u32 cap;
++	int ret;
++
++	xe_pm_runtime_get(xe);
++
++	ret = xe_pcode_read(root, PCODE_MBOX(PCODE_LATE_BINDING, GET_CAPABILITY_STATUS, 0),
++			    &cap, NULL);
++	if (ret)
++		goto out;
++
++	if (REG_FIELD_GET(V1_FAN_SUPPORTED, cap))
++		sysfs_remove_file(&dev->kobj, &dev_attr_lb_fan_control_version.attr);
++
++	if (REG_FIELD_GET(VR_PARAMS_SUPPORTED, cap))
++		sysfs_remove_file(&dev->kobj, &dev_attr_lb_voltage_regulator_version.attr);
++out:
++	xe_pm_runtime_put(xe);
++}
++
+ /**
+  * DOC: PCIe Gen5 Limitations
+  *
+@@ -157,8 +292,10 @@ static void xe_device_sysfs_fini(void *arg)
+ 	if (xe->d3cold.capable)
+ 		sysfs_remove_file(&xe->drm.dev->kobj, &dev_attr_vram_d3cold_threshold.attr);
+ 
+-	if (xe->info.platform == XE_BATTLEMAGE)
++	if (xe->info.platform == XE_BATTLEMAGE) {
+ 		sysfs_remove_files(&xe->drm.dev->kobj, auto_link_downgrade_attrs);
++		late_bind_remove_files(xe->drm.dev);
++	}
+ }
+ 
+ int xe_device_sysfs_init(struct xe_device *xe)
+@@ -176,6 +313,10 @@ int xe_device_sysfs_init(struct xe_device *xe)
+ 		ret = sysfs_create_files(&dev->kobj, auto_link_downgrade_attrs);
+ 		if (ret)
+ 			return ret;
++
++		ret = late_bind_create_files(dev);
++		if (ret)
++			return ret;
+ 	}
+ 
+ 	return devm_add_action_or_reset(dev, xe_device_sysfs_fini, xe);
+diff --git a/drivers/gpu/drm/xe/xe_pcode_api.h b/drivers/gpu/drm/xe/xe_pcode_api.h
+index 9a5dd9c469fe..6b9136bee7ee 100644
+--- a/drivers/gpu/drm/xe/xe_pcode_api.h
++++ b/drivers/gpu/drm/xe/xe_pcode_api.h
+@@ -50,6 +50,21 @@
+ #define	READ_PL_FROM_FW				0x1
+ #define	READ_PL_FROM_PCODE			0x0
+ 
++#define   PCODE_LATE_BINDING			0x5C
++#define     GET_CAPABILITY_STATUS		0x0
++#define       V1_FAN_SUPPORTED			REG_BIT(0)
++#define       VR_PARAMS_SUPPORTED		REG_BIT(3)
++#define       V1_FAN_PROVISIONED		REG_BIT(16)
++#define       VR_PARAMS_PROVISIONED		REG_BIT(19)
++#define     GET_VERSION_LOW			0x1
++#define     GET_VERSION_HIGH			0x2
++#define       MAJOR_VERSION_MASK		REG_GENMASK(31, 16)
++#define       MINOR_VERSION_MASK		REG_GENMASK(15, 0)
++#define       HOTFIX_VERSION_MASK		REG_GENMASK(31, 16)
++#define       BUILD_VERSION_MASK		REG_GENMASK(15, 0)
++#define       FAN_TABLE				1
++#define       VR_CONFIG				2
++
+ #define   PCODE_FREQUENCY_CONFIG		0x6e
+ /* Frequency Config Sub Commands (param1) */
+ #define     PCODE_MBOX_FC_SC_READ_FUSED_P0	0x0
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Stop-setting-drvdata-to-NULL.patch
+++ b/backport/patches/base/0001-drm-xe-Stop-setting-drvdata-to-NULL.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Fri, 21 Feb 2025 16:10:44 -0800
+Subject: drm/xe: Stop setting drvdata to NULL
+
+PCI subsystem is not supposed to call the remove() function when probe
+fails and doesn't need a protection for that. The only places checking
+for NULL drvdata, is on 2 sysfs files and they shouldn't be needed since
+the files are removed and reads on open fds just return an error.
+
+For this protection the core driver implementation in
+drivers/base/dd.c:device_unbind_cleanup() already sets it to NULL, after
+the release of dev resources.
+
+Remove the setting to NULL so it's possible to obtain the xe pointer
+from callbacks like the component unbind from device_unbind_cleanup(),
+i.e. after xe_pci_remove() already finished.
+
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Reviewed-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250222001051.3012936-5-lucas.demarchi@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit 83e3d0876754f820cb2adef55275d09d31676020 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device_sysfs.c | 6 ------
+ drivers/gpu/drm/xe/xe_pci.c          | 7 +------
+ 2 files changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device_sysfs.c b/drivers/gpu/drm/xe/xe_device_sysfs.c
+index 4e32750de3a7..2e657692e5b5 100644
+--- a/drivers/gpu/drm/xe/xe_device_sysfs.c
++++ b/drivers/gpu/drm/xe/xe_device_sysfs.c
+@@ -34,9 +34,6 @@ vram_d3cold_threshold_show(struct device *dev,
+ 	struct xe_device *xe = pdev_to_xe_device(pdev);
+ 	int ret;
+ 
+-	if (!xe)
+-		return -EINVAL;
+-
+ 	xe_pm_runtime_get(xe);
+ 	ret = sysfs_emit(buf, "%d\n", xe->d3cold.vram_threshold);
+ 	xe_pm_runtime_put(xe);
+@@ -53,9 +50,6 @@ vram_d3cold_threshold_store(struct device *dev, struct device_attribute *attr,
+ 	u32 vram_d3cold_threshold;
+ 	int ret;
+ 
+-	if (!xe)
+-		return -EINVAL;
+-
+ 	ret = kstrtou32(buff, 0, &vram_d3cold_threshold);
+ 	if (ret)
+ 		return ret;
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index a37bc4386991..9addca0f2e26 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -758,11 +758,7 @@ static int xe_info_init(struct xe_device *xe,
+ 
+ static void xe_pci_remove(struct pci_dev *pdev)
+ {
+-	struct xe_device *xe;
+-
+-	xe = pdev_to_xe_device(pdev);
+-	if (!xe) /* driver load aborted, nothing to cleanup */
+-		return;
++	struct xe_device *xe = pdev_to_xe_device(pdev);
+ 
+ 	if (IS_SRIOV_PF(xe))
+ 		xe_pci_sriov_configure(pdev, 0);
+@@ -772,7 +768,6 @@ static void xe_pci_remove(struct pci_dev *pdev)
+ 
+ 	xe_device_remove(xe);
+ 	xe_pm_runtime_fini(xe);
+-	pci_set_drvdata(pdev, NULL);
+ }
+ 
+ /*
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -62,6 +62,9 @@ backport/patches/base/0001-drm-xe-Move-survivability-back-to-xe.patch
 backport/patches/base/0001-drm-xe-Add-configfs-to-enable-survivability-mode.patch
 backport/patches/base/0001-drm-xe-Add-documentation-for-survivability-mode.patch
 backport/patches/base/0001-drm-xe-Enable-configfs-support-for-survivability-mod.patch
+backport/patches/base/0001-drm-xe-Expose-fan-control-and-voltage-regulator-vers.patch
+backport/patches/base/0001-drm-xe-Don-t-fail-probe-on-unsupported-mailbox-comma.patch
+backport/patches/base/0001-drm-xe-Stop-setting-drvdata-to-NULL.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Add sysfs attributes for late binding features to expose fan control
and voltage regulator versions to userspace.

On platforms with older pcode firmware, newer mailbox commands may be
unsupported. In such cases, the sysfs attributes are not functional,
but the driver probe should not fail. Handle this gracefully by skipping
the attributes and logging a debug message instead.

Fixes: cdc36b66cd41 ("drm/xe: Expose fan control and voltage regulator version")

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>