### PR TITLE
backport/xe: add and refine boot survivability mode support

### DIFF
--- a/backport/patches/base/0001-drm-xe-Add-configfs-to-enable-survivability-mode.patch
+++ b/backport/patches/base/0001-drm-xe-Add-configfs-to-enable-survivability-mode.patch
@@ -1,0 +1,322 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Mon, 7 Apr 2025 10:44:11 +0530
+Subject: drm/xe: Add configfs to enable survivability mode
+
+Registers a configfs subsystem called 'xe' that creates a
+directory in the mounted configfs directory (/sys/kernel/config)
+Userspace can then create the device that has to be configured
+under the xe directory
+
+	mkdir /sys/kernel/config/xe/0000:03:00.0
+
+The device created will have the following attributes to be
+configured
+
+	/sys/kernel/config/xe/
+		.. 0000:03:00.0/
+			... survivability_mode
+
+v2: fix kernel-doc
+    fix return value (Lucas)
+
+v3: fix kernel-doc (Lucas)
+
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://lore.kernel.org/r/20250407051414.1651616-2-riana.tauro@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit 16280ded45fba1216d1d4c6acfc20c2d5b45ef50 drm-tip)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ Documentation/gpu/xe/index.rst       |   1 +
+ Documentation/gpu/xe/xe_configfs.rst |  10 ++
+ drivers/gpu/drm/xe/Makefile          |   2 +
+ drivers/gpu/drm/xe/xe_configfs.c     | 188 +++++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_configfs.h     |  16 +++
+ drivers/gpu/drm/xe/xe_module.c       |   5 +
+ 6 files changed, 222 insertions(+)
+ create mode 100644 Documentation/gpu/xe/xe_configfs.rst
+ create mode 100644 drivers/gpu/drm/xe/xe_configfs.c
+ create mode 100644 drivers/gpu/drm/xe/xe_configfs.h
+
+diff --git a/Documentation/gpu/xe/index.rst b/Documentation/gpu/xe/index.rst
+index 92cfb25e64d3..b2369561f24e 100644
+--- a/Documentation/gpu/xe/index.rst
++++ b/Documentation/gpu/xe/index.rst
+@@ -25,3 +25,4 @@ DG2, etc is provided to prototype the driver.
+    xe_debugging
+    xe_devcoredump
+    xe-drm-usage-stats.rst
++   xe_configfs
+diff --git a/Documentation/gpu/xe/xe_configfs.rst b/Documentation/gpu/xe/xe_configfs.rst
+new file mode 100644
+index 000000000000..9b9d941eb20e
+--- /dev/null
++++ b/Documentation/gpu/xe/xe_configfs.rst
+@@ -0,0 +1,10 @@
++.. SPDX-License-Identifier: GPL-2.0+
++
++.. _xe_configfs:
++
++============
++Xe Configfs
++============
++
++.. kernel-doc:: drivers/gpu/drm/xe/xe_configfs.c
++   :doc: Xe Configfs
+diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
+index 0f6a5a9977ad..4232e6fc4184 100644
+--- a/drivers/gpu/drm/xe/Makefile
++++ b/drivers/gpu/drm/xe/Makefile
+@@ -125,6 +125,8 @@ xe-$(CONFIG_HWMON) += xe_hwmon.o
+ 
+ xe-$(CONFIG_PERF_EVENTS) += xe_pmu.o
+ 
++xe-$(CONFIG_CONFIGFS_FS) += xe_configfs.o
++
+ # graphics virtualization (SR-IOV) support
+ xe-y += \
+ 	xe_gt_sriov_vf.o \
+diff --git a/drivers/gpu/drm/xe/xe_configfs.c b/drivers/gpu/drm/xe/xe_configfs.c
+new file mode 100644
+index 000000000000..48a9f428bda9
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_configfs.c
+@@ -0,0 +1,188 @@
++// SPDX-License-Identifier: MIT
++/*
++ * Copyright © 2025 Intel Corporation
++ */
++
++#include <linux/configfs.h>
++#include <linux/init.h>
++#include <linux/module.h>
++#include <linux/pci.h>
++
++#include "xe_configfs.h"
++#include "xe_module.h"
++
++/**
++ * DOC: Xe Configfs
++ *
++ * Overview
++ * =========
++ *
++ * Configfs is a filesystem-based manager of kernel objects. XE KMD registers a
++ * configfs subsystem called ``'xe'`` that creates a directory in the mounted configfs directory
++ * The user can create devices under this directory and configure them as necessary
++ * See Documentation/filesystems/configfs.rst for more information about how configfs works.
++ *
++ * Create devices
++ * ===============
++ *
++ * In order to create a device, the user has to create a directory inside ``'xe'``::
++ *
++ *	mkdir /sys/kernel/config/xe/0000:03:00.0/
++ *
++ * Every device created is populated by the driver with entries that can be
++ * used to configure it::
++ *
++ *	/sys/kernel/config/xe/
++ *		.. 0000:03:00.0/
++ *			... survivability_mode
++ *
++ * Configure Attributes
++ * ====================
++ *
++ * Survivability mode:
++ * -------------------
++ *
++ * Enable survivability mode on supported cards. This setting only takes
++ * effect when probing the device. Example to enable it::
++ *
++ *	# echo 1 > /sys/kernel/config/xe/0000:03:00.0/survivability_mode
++ *	# echo 0000:03:00.0 > /sys/bus/pci/drivers/xe/bind  (Enters survivability mode if supported)
++ *
++ * Remove devices
++ * ==============
++ *
++ * The created device directories can be removed using ``rmdir``::
++ *
++ *	rmdir /sys/kernel/config/xe/0000:03:00.0/
++ */
++
++struct xe_config_device {
++	struct config_group group;
++
++	bool survivability_mode;
++
++	/* protects attributes */
++	struct mutex lock;
++};
++
++static struct xe_config_device *to_xe_config_device(struct config_item *item)
++{
++	return container_of(to_config_group(item), struct xe_config_device, group);
++}
++
++static ssize_t survivability_mode_show(struct config_item *item, char *page)
++{
++	struct xe_config_device *dev = to_xe_config_device(item);
++
++	return sprintf(page, "%d\n", dev->survivability_mode);
++}
++
++static ssize_t survivability_mode_store(struct config_item *item, const char *page, size_t len)
++{
++	struct xe_config_device *dev = to_xe_config_device(item);
++	bool survivability_mode;
++	int ret;
++
++	ret = kstrtobool(page, &survivability_mode);
++	if (ret)
++		return ret;
++
++	mutex_lock(&dev->lock);
++	dev->survivability_mode = survivability_mode;
++	mutex_unlock(&dev->lock);
++
++	return len;
++}
++
++CONFIGFS_ATTR(, survivability_mode);
++
++static struct configfs_attribute *xe_config_device_attrs[] = {
++	&attr_survivability_mode,
++	NULL,
++};
++
++static void xe_config_device_release(struct config_item *item)
++{
++	struct xe_config_device *dev = to_xe_config_device(item);
++
++	mutex_destroy(&dev->lock);
++	kfree(dev);
++}
++
++static struct configfs_item_operations xe_config_device_ops = {
++	.release	= xe_config_device_release,
++};
++
++static const struct config_item_type xe_config_device_type = {
++	.ct_item_ops	= &xe_config_device_ops,
++	.ct_attrs	= xe_config_device_attrs,
++	.ct_owner	= THIS_MODULE,
++};
++
++static struct config_group *xe_config_make_device_group(struct config_group *group,
++							const char *name)
++{
++	unsigned int domain, bus, slot, function;
++	struct xe_config_device *dev;
++	struct pci_dev *pdev;
++	int ret;
++
++	ret = sscanf(name, "%04x:%02x:%02x.%x", &domain, &bus, &slot, &function);
++	if (ret != 4)
++		return ERR_PTR(-EINVAL);
++
++	pdev = pci_get_domain_bus_and_slot(domain, bus, PCI_DEVFN(slot, function));
++	if (!pdev)
++		return ERR_PTR(-EINVAL);
++
++	dev = kzalloc(sizeof(*dev), GFP_KERNEL);
++	if (!dev)
++		return ERR_PTR(-ENOMEM);
++
++	config_group_init_type_name(&dev->group, name, &xe_config_device_type);
++
++	mutex_init(&dev->lock);
++
++	return &dev->group;
++}
++
++static struct configfs_group_operations xe_config_device_group_ops = {
++	.make_group	= xe_config_make_device_group,
++};
++
++static const struct config_item_type xe_configfs_type = {
++	.ct_group_ops	= &xe_config_device_group_ops,
++	.ct_owner	= THIS_MODULE,
++};
++
++static struct configfs_subsystem xe_configfs = {
++	.su_group = {
++		.cg_item = {
++			.ci_namebuf = "xe",
++			.ci_type = &xe_configfs_type,
++		},
++	},
++};
++
++int __init xe_configfs_init(void)
++{
++	struct config_group *root = &xe_configfs.su_group;
++	int ret;
++
++	config_group_init(root);
++	mutex_init(&xe_configfs.su_mutex);
++	ret = configfs_register_subsystem(&xe_configfs);
++	if (ret) {
++		pr_err("Error %d while registering %s subsystem\n",
++		       ret, root->cg_item.ci_namebuf);
++		return ret;
++	}
++
++	return 0;
++}
++
++void __exit xe_configfs_exit(void)
++{
++	configfs_unregister_subsystem(&xe_configfs);
++}
++
+diff --git a/drivers/gpu/drm/xe/xe_configfs.h b/drivers/gpu/drm/xe/xe_configfs.h
+new file mode 100644
+index 000000000000..5532320818e4
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_configfs.h
+@@ -0,0 +1,16 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2025 Intel Corporation
++ */
++#ifndef _XE_CONFIGFS_H_
++#define _XE_CONFIGFS_H_
++
++#if IS_ENABLED(CONFIG_CONFIGFS_FS)
++int xe_configfs_init(void);
++void xe_configfs_exit(void);
++#else
++static inline int xe_configfs_init(void) { return 0; };
++static inline void xe_configfs_exit(void) {};
++#endif
++
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_module.c b/drivers/gpu/drm/xe/xe_module.c
+index 07b27114be9a..cf23cfe208be 100644
+--- a/drivers/gpu/drm/xe/xe_module.c
++++ b/drivers/gpu/drm/xe/xe_module.c
+@@ -11,6 +11,7 @@
+ #include <drm/drm_module.h>
+ 
+ #include "xe_drv.h"
++#include "xe_configfs.h"
+ #include "xe_hw_fence.h"
+ #include "xe_pci.h"
+ #include "xe_pm.h"
+@@ -85,6 +86,10 @@ static const struct init_funcs init_funcs[] = {
+ 	{
+ 		.init = xe_check_nomodeset,
+ 	},
++	{
++		.init = xe_configfs_init,
++		.exit = xe_configfs_exit,
++	},
+ 	{
+ 		.init = xe_hw_fence_module_init,
+ 		.exit = xe_hw_fence_module_exit,
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Add-documentation-for-survivability-mode.patch
+++ b/backport/patches/base/0001-drm-xe-Add-documentation-for-survivability-mode.patch
@@ -1,0 +1,87 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Mon, 7 Apr 2025 10:44:12 +0530
+Subject: drm/xe: Add documentation for survivability mode
+
+Add survivability mode document to pcode document as it is enabled
+when pcode detects a failure.
+
+v2: fix kernel-doc (Lucas)
+
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://lore.kernel.org/r/20250407051414.1651616-3-riana.tauro@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit 77052ab24590cb72598e31de4a7c29f99d51d201 drm-tip)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ Documentation/gpu/xe/xe_pcode.rst          |  7 +++++
+ drivers/gpu/drm/xe/xe_survivability_mode.c | 34 +++++++++++++++-------
+ 2 files changed, 30 insertions(+), 11 deletions(-)
+
+diff --git a/Documentation/gpu/xe/xe_pcode.rst b/Documentation/gpu/xe/xe_pcode.rst
+index d2e22cc45061..5937ef3599b0 100644
+--- a/Documentation/gpu/xe/xe_pcode.rst
++++ b/Documentation/gpu/xe/xe_pcode.rst
+@@ -12,3 +12,10 @@ Internal API
+ 
+ .. kernel-doc:: drivers/gpu/drm/xe/xe_pcode.c
+    :internal:
++
++==================
++Boot Survivability
++==================
++
++.. kernel-doc:: drivers/gpu/drm/xe/xe_survivability_mode.c
++   :doc: Xe Boot Survivability
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+index 7b1ec643f0f0..c060f279eace 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.c
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -28,20 +28,32 @@
+  * This is implemented by loading the driver with bare minimum (no drm card) to allow the firmware
+  * to be flashed through mei and collect telemetry. The driver's probe flow is modified
+  * such that it enters survivability mode when pcode initialization is incomplete and boot status
+- * denotes a failure. The driver then  populates the survivability_mode PCI sysfs indicating
+- * survivability mode and provides additional information required for debug
++ * denotes a failure.
+  *
+- * KMD exposes below admin-only readable sysfs in survivability mode
++ * Survivability mode can also be entered manually using the survivability mode attribute available
++ * through configfs which is beneficial in several usecases. It can be used to address scenarios
++ * where pcode does not detect failure or for validation purposes. It can also be used in
++ * In-Field-Repair (IFR) to repair a single card without impacting the other cards in a node.
+  *
+- * device/survivability_mode: The presence of this file indicates that the card is in survivability
+- *			      mode. Also, provides additional information on why the driver entered
+- *			      survivability mode.
++ * Use below command enable survivability mode manually::
+  *
+- *			      Capability Information - Provides boot status
+- *			      Postcode Information   - Provides information about the failure
+- *			      Overflow Information   - Provides history of previous failures
+- *			      Auxiliary Information  - Certain failures may have information in
+- *						       addition to postcode information
++ *	# echo 1 > /sys/kernel/config/xe/0000:03:00.0/survivability_mode
++ *
++ * Refer :ref:`xe_configfs` for more details on how to use configfs
++ *
++ * Survivability mode is indicated by the below admin-only readable sysfs which provides additional
++ * debug information::
++ *
++ *	/sys/bus/pci/devices/<device>/surivability_mode
++ *
++ * Capability Information:
++ *	Provides boot status
++ * Postcode Information:
++ *	Provides information about the failure
++ * Overflow Information
++ *	Provides history of previous failures
++ * Auxiliary Information
++ *	Certain failures may have information in addition to postcode information
+  */
+ 
+ static u32 aux_history_offset(u32 reg_value)
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-Add-functions-and-sysfs-for-boot-survivabilit.patch
+++ b/backport/patches/base/0001-drm-xe-Add-functions-and-sysfs-for-boot-survivabilit.patch
@@ -1,0 +1,410 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Tue, 28 Jan 2025 15:26:30 +0530
+Subject: drm/xe: Add functions and sysfs for boot survivability
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Boot Survivability is a software based workflow for recovering a system
+in a failed boot state. Here system recoverability is concerned with
+recovering the firmware responsible for boot.
+
+This is implemented by loading the driver with bare minimum (no drm card)
+to allow the firmware to be flashed through mei-gsc and collect telemetry.
+The driver's probe flow is modified such that it enters survivability mode
+when pcode initialization is incomplete and boot status denotes a failure.
+In this mode, drm card is not exposed and presence of survivability_mode
+entry in PCI sysfs  is used to indicate survivability mode and
+provide additional information required for debug
+
+This patch adds initialization functions and exposes admin
+readable sysfs entries
+
+The new sysfs will have the below layout
+
+	/sys/bus/.../bdf
+             	     ├── survivability_mode
+
+v2: reorder headers
+    fix doc
+    remove survivability info and use mode to display information
+    use separate function for logging survivability information
+    for critical error (Rodrigo)
+
+v3: use for loop
+    use dev logs instead of drm
+    use helper function for aux history(Rodrigo)
+    remove unnecessary error check of greater than max_scratch
+    as we are reading only 3 bit
+
+v4: fix checkpatch warnings
+    fix space (Rodrigo)
+    rename register
+
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+Acked-by: Ashwin Kumar Kulkarni <ashwin.kumar.kulkarni@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250128095632.1294722-2-riana.tauro@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 5e940312a2ac64ba0d6239aff72135226818b238 drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/Makefile                   |   1 +
+ drivers/gpu/drm/xe/xe_device_types.h          |   4 +
+ drivers/gpu/drm/xe/xe_pcode_api.h             |  14 ++
+ drivers/gpu/drm/xe/xe_survivability_mode.c    | 215 ++++++++++++++++++
+ drivers/gpu/drm/xe/xe_survivability_mode.h    |  17 ++
+ .../gpu/drm/xe/xe_survivability_mode_types.h  |  35 +++
+ 6 files changed, 286 insertions(+)
+ create mode 100644 drivers/gpu/drm/xe/xe_survivability_mode.c
+ create mode 100644 drivers/gpu/drm/xe/xe_survivability_mode.h
+ create mode 100644 drivers/gpu/drm/xe/xe_survivability_mode_types.h
+
+diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
+index 3004ad706c96..0f6a5a9977ad 100644
+--- a/drivers/gpu/drm/xe/Makefile
++++ b/drivers/gpu/drm/xe/Makefile
+@@ -96,6 +96,7 @@ xe-y += xe_bb.o \
+ 	xe_sa.o \
+ 	xe_sched_job.o \
+ 	xe_step.o \
++	xe_survivability_mode.o \
+ 	xe_sync.o \
+ 	xe_tile.o \
+ 	xe_tile_sysfs.o \
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index bcb3f8fefad7..b3420f8c0fc7 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -22,6 +22,7 @@
+ #include "xe_pt_types.h"
+ #include "xe_sriov_types.h"
+ #include "xe_step_types.h"
++#include "xe_survivability_mode_types.h"
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_DEBUG)
+ #define TEST_VM_OPS_ERROR
+@@ -350,6 +351,9 @@ struct xe_device {
+ 		u8 skip_pcode:1;
+ 	} info;
+ 
++	/** @survivability: survivability information for device */
++	struct xe_survivability survivability;
++
+ 	/** @irq: device interrupt state */
+ 	struct {
+ 		/** @irq.lock: lock for processing irq's on this device */
+diff --git a/drivers/gpu/drm/xe/xe_pcode_api.h b/drivers/gpu/drm/xe/xe_pcode_api.h
+index 9a5dd9c469fe..451c7cd6fdef 100644
+--- a/drivers/gpu/drm/xe/xe_pcode_api.h
++++ b/drivers/gpu/drm/xe/xe_pcode_api.h
+@@ -64,6 +64,20 @@
+ #define   FAN_SPEED_CONTROL			0x7D
+ #define     FSC_READ_NUM_FANS			0x4
+ 
++#define	PCODE_SCRATCH(x)	XE_REG(0x138320 + ((x) * 4))
++/* PCODE_SCRATCH0 */
++#define	AUXINFO_REG_OFFSET	REG_GENMASK(17, 15)
++#define OVERFLOW_REG_OFFSET	REG_GENMASK(14, 12)
++#define HISTORY_TRACKING	REG_BIT(11)
++#define OVERFLOW_SUPPORT	REG_BIT(10)
++#define AUXINFO_SUPPORT	REG_BIT(9)
++#define	BOOT_STATUS		REG_GENMASK(3, 1)
++#define	CRITICAL_FAILURE	4
++#define	NON_CRITICAL_FAILURE	7
++
++/* Auxiliary info bits */
++#define	AUXINFO_HISTORY_OFFSET	REG_GENMASK(31, 29)
++
+ struct pcode_err_decode {
+ 	int errno;
+ 	const char *str;
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+new file mode 100644
+index 000000000000..9911e9f6b99b
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -0,0 +1,215 @@
++// SPDX-License-Identifier: MIT
++/*
++ * Copyright © 2025 Intel Corporation
++ */
++
++#include "xe_survivability_mode.h"
++#include "xe_survivability_mode_types.h"
++
++#include <linux/kobject.h>
++#include <linux/pci.h>
++#include <linux/sysfs.h>
++
++#include "xe_device.h"
++#include "xe_gt.h"
++#include "xe_mmio.h"
++#include "xe_pcode_api.h"
++
++#define MAX_SCRATCH_MMIO 8
++
++/**
++ * DOC: Xe Boot Survivability
++ *
++ * Boot Survivability is a software based workflow for recovering a system in a failed boot state
++ * Here system recoverability is concerned with recovering the firmware responsible for boot.
++ *
++ * This is implemented by loading the driver with bare minimum (no drm card) to allow the firmware
++ * to be flashed through mei and collect telemetry. The driver's probe flow is modified
++ * such that it enters survivability mode when pcode initialization is incomplete and boot status
++ * denotes a failure. The driver then  populates the survivability_mode PCI sysfs indicating
++ * survivability mode and provides additional information required for debug
++ *
++ * KMD exposes below admin-only readable sysfs in survivability mode
++ *
++ * device/survivability_mode: The presence of this file indicates that the card is in survivability
++ *			      mode. Also, provides additional information on why the driver entered
++ *			      survivability mode.
++ *
++ *			      Capability Information - Provides boot status
++ *			      Postcode Information   - Provides information about the failure
++ *			      Overflow Information   - Provides history of previous failures
++ *			      Auxiliary Information  - Certain failures may have information in
++ *						       addition to postcode information
++ */
++
++static u32 aux_history_offset(u32 reg_value)
++{
++	return REG_FIELD_GET(AUXINFO_HISTORY_OFFSET, reg_value);
++}
++
++static void set_survivability_info(struct xe_mmio *mmio, struct xe_survivability_info *info,
++				   int id, char *name)
++{
++	strscpy(info[id].name, name, sizeof(info[id].name));
++	info[id].reg = PCODE_SCRATCH(id).raw;
++	info[id].value = xe_mmio_read32(mmio, PCODE_SCRATCH(id));
++}
++
++static void populate_survivability_info(struct xe_device *xe)
++{
++	struct xe_survivability *survivability = &xe->survivability;
++	struct xe_survivability_info *info = survivability->info;
++	struct xe_mmio *mmio;
++	u32 id = 0, reg_value;
++	char name[NAME_MAX];
++	int index;
++
++	mmio = xe_root_tile_mmio(xe);
++	set_survivability_info(mmio, info, id, "Capability Info");
++	reg_value = info[id].value;
++
++	if (reg_value & HISTORY_TRACKING) {
++		id++;
++		set_survivability_info(mmio, info, id, "Postcode Info");
++
++		if (reg_value & OVERFLOW_SUPPORT) {
++			id = REG_FIELD_GET(OVERFLOW_REG_OFFSET, reg_value);
++			set_survivability_info(mmio, info, id, "Overflow Info");
++		}
++	}
++
++	if (reg_value & AUXINFO_SUPPORT) {
++		id = REG_FIELD_GET(AUXINFO_REG_OFFSET, reg_value);
++
++		for (index = 0; id && reg_value; index++, reg_value = info[id].value,
++		     id = aux_history_offset(reg_value)) {
++			snprintf(name, NAME_MAX, "Auxiliary Info %d", index);
++			set_survivability_info(mmio, info, id, name);
++		}
++	}
++}
++
++static void log_survivability_info(struct pci_dev *pdev)
++{
++	struct xe_device *xe = pdev_to_xe_device(pdev);
++	struct xe_survivability *survivability = &xe->survivability;
++	struct xe_survivability_info *info = survivability->info;
++	int id;
++
++	dev_info(&pdev->dev, "Survivability Boot Status : Critical Failure (%d)\n",
++		 survivability->boot_status);
++	for (id = 0; id < MAX_SCRATCH_MMIO; id++) {
++		if (info[id].reg)
++			dev_info(&pdev->dev, "%s: 0x%x - 0x%x\n", info[id].name,
++				 info[id].reg, info[id].value);
++	}
++}
++
++static ssize_t survivability_mode_show(struct device *dev,
++				       struct device_attribute *attr, char *buff)
++{
++	struct pci_dev *pdev = to_pci_dev(dev);
++	struct xe_device *xe = pdev_to_xe_device(pdev);
++	struct xe_survivability *survivability = &xe->survivability;
++	struct xe_survivability_info *info = survivability->info;
++	int index = 0, count = 0;
++
++	for (index = 0; index < MAX_SCRATCH_MMIO; index++) {
++		if (info[index].reg)
++			count += sysfs_emit_at(buff, count, "%s: 0x%x - 0x%x\n", info[index].name,
++					       info[index].reg, info[index].value);
++	}
++
++	return count;
++}
++
++static DEVICE_ATTR_ADMIN_RO(survivability_mode);
++
++static void enable_survivability_mode(struct pci_dev *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct xe_device *xe = pdev_to_xe_device(pdev);
++	struct xe_survivability *survivability = &xe->survivability;
++	int ret = 0;
++
++	/* set survivability mode */
++	survivability->mode = true;
++	dev_info(dev, "In Survivability Mode\n");
++
++	/* create survivability mode sysfs */
++	ret = sysfs_create_file(&dev->kobj, &dev_attr_survivability_mode.attr);
++	if (ret) {
++		dev_warn(dev, "Failed to create survivability sysfs files\n");
++		return;
++	}
++}
++
++/**
++ * xe_survivability_mode_required - checks if survivability mode is required
++ * @xe: xe device instance
++ *
++ * This function reads the boot status from Pcode
++ *
++ * Return: true if boot status indicates failure, false otherwise
++ */
++bool xe_survivability_mode_required(struct xe_device *xe)
++{
++	struct xe_survivability *survivability = &xe->survivability;
++	struct xe_mmio *mmio = xe_root_tile_mmio(xe);
++	u32 data;
++
++	data = xe_mmio_read32(mmio, PCODE_SCRATCH(0));
++	survivability->boot_status = REG_FIELD_GET(BOOT_STATUS, data);
++
++	return (survivability->boot_status == NON_CRITICAL_FAILURE ||
++		survivability->boot_status == CRITICAL_FAILURE);
++}
++
++/**
++ * xe_survivability_mode_remove - remove survivability mode
++ * @xe: xe device instance
++ *
++ * clean up sysfs entries of survivability mode
++ */
++void xe_survivability_mode_remove(struct xe_device *xe)
++{
++	struct xe_survivability *survivability = &xe->survivability;
++	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
++	struct device *dev = &pdev->dev;
++
++	sysfs_remove_file(&dev->kobj, &dev_attr_survivability_mode.attr);
++	kfree(survivability->info);
++	pci_set_drvdata(pdev, NULL);
++}
++
++/**
++ * xe_survivability_mode_init - Initialize the survivability mode
++ * @xe: xe device instance
++ *
++ * Initializes survivability information and enables survivability mode
++ */
++void xe_survivability_mode_init(struct xe_device *xe)
++{
++	struct xe_survivability *survivability = &xe->survivability;
++	struct xe_survivability_info *info;
++	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
++
++	survivability->size = MAX_SCRATCH_MMIO;
++
++	info = kcalloc(survivability->size, sizeof(*info), GFP_KERNEL);
++	if (!info)
++		return;
++
++	survivability->info = info;
++
++	populate_survivability_info(xe);
++
++	/* Only log debug information and exit if it is a critical failure */
++	if (survivability->boot_status == CRITICAL_FAILURE) {
++		log_survivability_info(pdev);
++		kfree(survivability->info);
++		return;
++	}
++
++	enable_survivability_mode(pdev);
++}
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.h b/drivers/gpu/drm/xe/xe_survivability_mode.h
+new file mode 100644
+index 000000000000..410e3ee5f5d1
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.h
+@@ -0,0 +1,17 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2025 Intel Corporation
++ */
++
++#ifndef _XE_SURVIVABILITY_MODE_H_
++#define _XE_SURVIVABILITY_MODE_H_
++
++#include <linux/types.h>
++
++struct xe_device;
++
++void xe_survivability_mode_init(struct xe_device *xe);
++void xe_survivability_mode_remove(struct xe_device *xe);
++bool xe_survivability_mode_required(struct xe_device *xe);
++
++#endif /* _XE_SURVIVABILITY_MODE_H_ */
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode_types.h b/drivers/gpu/drm/xe/xe_survivability_mode_types.h
+new file mode 100644
+index 000000000000..19d433e253df
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_survivability_mode_types.h
+@@ -0,0 +1,35 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2025 Intel Corporation
++ */
++
++#ifndef _XE_SURVIVABILITY_MODE_TYPES_H_
++#define _XE_SURVIVABILITY_MODE_TYPES_H_
++
++#include <linux/limits.h>
++#include <linux/types.h>
++
++struct xe_survivability_info {
++	char name[NAME_MAX];
++	u32 reg;
++	u32 value;
++};
++
++/**
++ * struct xe_survivability: Contains survivability mode information
++ */
++struct xe_survivability {
++	/** @info: struct that holds survivability info from scratch registers */
++	struct xe_survivability_info *info;
++
++	/** @size: number of scratch registers */
++	u32 size;
++
++	/** @boot_status: indicates critical/non critical boot failure */
++	u8 boot_status;
++
++	/** @mode: boolean to indicate survivability mode */
++	bool mode;
++};
++
++#endif /* _XE_SURVIVABILITY_MODE_TYPES_H_ */
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Enable-Boot-Survivability-mode.patch
+++ b/backport/patches/base/0001-drm-xe-Enable-Boot-Survivability-mode.patch
@@ -1,0 +1,163 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Tue, 28 Jan 2025 15:26:31 +0530
+Subject: drm/xe: Enable Boot Survivability mode
+
+Enable boot survivability mode if pcode initialization fails and
+if boot status indicates a failure. In this mode, drm card is not
+exposed and driver probe returns success after loading the bare minimum
+to allow firmware to be flashed via mei.
+
+v2: abstract survivability mode variable
+    add BMG check inside function (Jani, Rodrigo)
+
+v3: return -EBUSY during system suspend (Anshuman)
+    check survivability mode in pci probe only
+    on error
+
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250128095632.1294722-3-riana.tauro@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 256daa32c9e0dcf924b3237e2165d8163f4d89cc drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c             |  7 ++++++-
+ drivers/gpu/drm/xe/xe_pci.c                | 23 ++++++++++++++++++++--
+ drivers/gpu/drm/xe/xe_survivability_mode.c | 16 +++++++++++++++
+ drivers/gpu/drm/xe/xe_survivability_mode.h |  1 +
+ 4 files changed, 44 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index abd953761cae..18cc2bc90e94 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -54,6 +54,7 @@
+ #include "xe_pmu.h"
+ #include "xe_query.h"
+ #include "xe_sriov.h"
++#include "xe_survivability_mode.h"
+ #include "xe_tile.h"
+ #include "xe_ttm_stolen_mgr.h"
+ #include "xe_ttm_sys_mgr.h"
+@@ -590,8 +591,12 @@ int xe_device_probe_early(struct xe_device *xe)
+ 	update_device_info(xe);
+ 
+ 	err = xe_pcode_probe_early(xe);
+-	if (err)
++	if (err) {
++		if (xe_survivability_mode_required(xe))
++			xe_survivability_mode_init(xe);
++
+ 		return err;
++	}
+ 
+ 	err = wait_for_lmem_ready(xe);
+ 	if (err)
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index b0007f2dd5e4..f83d58acfe86 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -30,6 +30,7 @@
+ #include "xe_pm.h"
+ #include "xe_sriov.h"
+ #include "xe_step.h"
++#include "xe_survivability_mode.h"
+ #include "xe_tile.h"
+ 
+ enum toggle_d3cold {
+@@ -766,6 +767,9 @@ static void xe_pci_remove(struct pci_dev *pdev)
+ 	if (IS_SRIOV_PF(xe))
+ 		xe_pci_sriov_configure(pdev, 0);
+ 
++	if (xe_survivability_mode_enabled(xe))
++		return xe_survivability_mode_remove(xe);
++
+ 	xe_device_remove(xe);
+ 	xe_pm_runtime_fini(xe);
+ 	pci_set_drvdata(pdev, NULL);
+@@ -838,8 +842,19 @@ static int xe_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 		return err;
+ 
+ 	err = xe_device_probe_early(xe);
+-	if (err)
++
++	/*
++	 * In Boot Survivability mode, no drm card is exposed
++	 * and driver is loaded with bare minimum to allow
++	 * for firmware to be flashed through mei. Return
++	 * success if survivability mode is enabled.
++	 */
++	if (err) {
++		if (xe_survivability_mode_enabled(xe))
++			return 0;
++
+ 		return err;
++	}
+ 
+ 	err = xe_info_init(xe, desc->graphics, desc->media);
+ 	if (err)
+@@ -926,9 +941,13 @@ static void d3cold_toggle(struct pci_dev *pdev, enum toggle_d3cold toggle)
+ static int xe_pci_suspend(struct device *dev)
+ {
+ 	struct pci_dev *pdev = to_pci_dev(dev);
++	struct xe_device *xe = pdev_to_xe_device(pdev);
+ 	int err;
+ 
+-	err = xe_pm_suspend(pdev_to_xe_device(pdev));
++	if (xe_survivability_mode_enabled(xe))
++		return -EBUSY;
++
++	err = xe_pm_suspend(xe);
+ 	if (err)
+ 		return err;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+index 9911e9f6b99b..633f5effa349 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.c
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -144,6 +144,19 @@ static void enable_survivability_mode(struct pci_dev *pdev)
+ 	}
+ }
+ 
++/**
++ * xe_survivability_mode_enabled - check if survivability mode is enabled
++ * @xe: xe device instance
++ *
++ * Returns true if in survivability mode, false otherwise
++ */
++bool xe_survivability_mode_enabled(struct xe_device *xe)
++{
++	struct xe_survivability *survivability = &xe->survivability;
++
++	return survivability->mode;
++}
++
+ /**
+  * xe_survivability_mode_required - checks if survivability mode is required
+  * @xe: xe device instance
+@@ -158,6 +171,9 @@ bool xe_survivability_mode_required(struct xe_device *xe)
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(xe);
+ 	u32 data;
+ 
++	if (!IS_DGFX(xe) || xe->info.platform < XE_BATTLEMAGE)
++		return false;
++
+ 	data = xe_mmio_read32(mmio, PCODE_SCRATCH(0));
+ 	survivability->boot_status = REG_FIELD_GET(BOOT_STATUS, data);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.h b/drivers/gpu/drm/xe/xe_survivability_mode.h
+index 410e3ee5f5d1..f530507a22c6 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.h
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.h
+@@ -12,6 +12,7 @@ struct xe_device;
+ 
+ void xe_survivability_mode_init(struct xe_device *xe);
+ void xe_survivability_mode_remove(struct xe_device *xe);
++bool xe_survivability_mode_enabled(struct xe_device *xe);
+ bool xe_survivability_mode_required(struct xe_device *xe);
+ 
+ #endif /* _XE_SURVIVABILITY_MODE_H_ */
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Enable-configfs-support-for-survivability-mod.patch
+++ b/backport/patches/base/0001-drm-xe-Enable-configfs-support-for-survivability-mod.patch
@@ -1,0 +1,267 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Mon, 7 Apr 2025 10:44:13 +0530
+Subject: drm/xe: Enable configfs support for survivability mode
+
+Enable survivability mode if supported and configfs attribute is set.
+Enabling survivability mode manually is useful in cases where pcode does
+not detect failure, validation and for IFR (in-field-repair).
+
+To set configfs survivability mode attribute for a device
+
+echo 1 > /sys/kernel/config/xe/0000:03:00.0/survivability_mode
+
+The card enters survivability mode if supported
+
+v2: add a log if survivability mode is enabled for unsupported
+    platforms (Rodrigo)
+
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Lucas De Marchi <lucas.demarchi@intel.com>
+Link: https://lore.kernel.org/r/20250407051414.1651616-4-riana.tauro@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit bc417e54e24bc9c96d3c6eba2c8c60f7919e5afe drm-tip)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_configfs.c           | 62 ++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_configfs.h           |  8 +++
+ drivers/gpu/drm/xe/xe_device.c             |  2 +-
+ drivers/gpu/drm/xe/xe_pci.c                | 19 ++++---
+ drivers/gpu/drm/xe/xe_survivability_mode.c | 35 +++++++++---
+ drivers/gpu/drm/xe/xe_survivability_mode.h |  1 +
+ 6 files changed, 108 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_configfs.c b/drivers/gpu/drm/xe/xe_configfs.c
+index 48a9f428bda9..cb9f175c89a1 100644
+--- a/drivers/gpu/drm/xe/xe_configfs.c
++++ b/drivers/gpu/drm/xe/xe_configfs.c
+@@ -164,6 +164,68 @@ static struct configfs_subsystem xe_configfs = {
+ 	},
+ };
+ 
++static struct xe_config_device *configfs_find_group(struct pci_dev *pdev)
++{
++	struct config_item *item;
++	char name[64];
++
++	snprintf(name, sizeof(name), "%04x:%02x:%02x.%x", pci_domain_nr(pdev->bus),
++		 pdev->bus->number, PCI_SLOT(pdev->devfn), PCI_FUNC(pdev->devfn));
++
++	mutex_lock(&xe_configfs.su_mutex);
++	item = config_group_find_item(&xe_configfs.su_group, name);
++	mutex_unlock(&xe_configfs.su_mutex);
++
++	if (!item)
++		return NULL;
++
++	return to_xe_config_device(item);
++}
++
++/**
++ * xe_configfs_get_survivability_mode - get configfs survivability mode attribute
++ * @pdev: pci device
++ *
++ * find the configfs group that belongs to the pci device and return
++ * the survivability mode attribute
++ *
++ * Return: survivability mode if config group is found, false otherwise
++ */
++bool xe_configfs_get_survivability_mode(struct pci_dev *pdev)
++{
++	struct xe_config_device *dev = configfs_find_group(pdev);
++	bool mode;
++
++	if (!dev)
++		return false;
++
++	mode = dev->survivability_mode;
++	config_item_put(&dev->group.cg_item);
++
++	return mode;
++}
++
++/**
++ * xe_configfs_clear_survivability_mode - clear configfs survivability mode attribute
++ * @pdev: pci device
++ *
++ * find the configfs group that belongs to the pci device and clear survivability
++ * mode attribute
++ */
++void xe_configfs_clear_survivability_mode(struct pci_dev *pdev)
++{
++	struct xe_config_device *dev = configfs_find_group(pdev);
++
++	if (!dev)
++		return;
++
++	mutex_lock(&dev->lock);
++	dev->survivability_mode = 0;
++	mutex_unlock(&dev->lock);
++
++	config_item_put(&dev->group.cg_item);
++}
++
+ int __init xe_configfs_init(void)
+ {
+ 	struct config_group *root = &xe_configfs.su_group;
+diff --git a/drivers/gpu/drm/xe/xe_configfs.h b/drivers/gpu/drm/xe/xe_configfs.h
+index 5532320818e4..d7d041ec2611 100644
+--- a/drivers/gpu/drm/xe/xe_configfs.h
++++ b/drivers/gpu/drm/xe/xe_configfs.h
+@@ -5,12 +5,20 @@
+ #ifndef _XE_CONFIGFS_H_
+ #define _XE_CONFIGFS_H_
+ 
++#include <linux/types.h>
++
++struct pci_dev;
++
+ #if IS_ENABLED(CONFIG_CONFIGFS_FS)
+ int xe_configfs_init(void);
+ void xe_configfs_exit(void);
++bool xe_configfs_get_survivability_mode(struct pci_dev *pdev);
++void xe_configfs_clear_survivability_mode(struct pci_dev *pdev);
+ #else
+ static inline int xe_configfs_init(void) { return 0; };
+ static inline void xe_configfs_exit(void) {};
++static inline bool xe_configfs_get_survivability_mode(struct pci_dev *pdev) { return false; };
++static inline void xe_configfs_clear_survivability_mode(struct pci_dev *pdev) {};
+ #endif
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 3ad26cb1af62..4647f70521d5 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -617,7 +617,7 @@ int xe_device_probe_early(struct xe_device *xe)
+ 	update_device_info(xe);
+ 
+ 	err = xe_pcode_probe_early(xe);
+-	if (err) {
++	if (err || xe_survivability_mode_is_requested(xe)) {
+ 		int save_err = err;
+ 
+ 		/*
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index fd8788e17895..86ba48c4d92a 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -839,18 +839,17 @@ static int xe_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 		return err;
+ 
+ 	err = xe_device_probe_early(xe);
+-	if (err) {
+-		/*
+-		 * In Boot Survivability mode, no drm card is exposed and driver
+-		 * is loaded with bare minimum to allow for firmware to be
+-		 * flashed through mei. If early probe failed, but it managed to
+-		 * enable survivability mode, return success.
+-		 */
+-		if (xe_survivability_mode_is_enabled(xe))
+-			return 0;
++	/*
++	 * In Boot Survivability mode, no drm card is exposed and driver
++	 * is loaded with bare minimum to allow for firmware to be
++	 * flashed through mei. Return success, if survivability mode
++	 * is enabled due to pcode failure or configfs being set
++	 */
++	if (xe_survivability_mode_is_enabled(xe))
++		return 0;
+ 
++	if (err)
+ 		return err;
+-	}
+ 
+ 	err = xe_info_init(xe, desc->graphics, desc->media);
+ 	if (err)
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+index c060f279eace..6c0d47009635 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.c
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -10,6 +10,7 @@
+ #include <linux/pci.h>
+ #include <linux/sysfs.h>
+ 
++#include "xe_configfs.h"
+ #include "xe_device.h"
+ #include "xe_gt.h"
+ #include "xe_heci_gsc.h"
+@@ -145,6 +146,7 @@ static void xe_survivability_mode_fini(void *arg)
+ 	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+ 	struct device *dev = &pdev->dev;
+ 
++	xe_configfs_clear_survivability_mode(pdev);
+ 	sysfs_remove_file(&dev->kobj, &dev_attr_survivability_mode.attr);
+ }
+ 
+@@ -190,23 +192,40 @@ bool xe_survivability_mode_is_enabled(struct xe_device *xe)
+ 	return xe->survivability.mode;
+ }
+ 
+-/*
+- * survivability_mode_requested - check if it's possible to enable
+- * survivability mode and that was requested by firmware
++/**
++ * xe_survivability_mode_is_requested - check if it's possible to enable survivability
++ *					mode that was requested by firmware or userspace
++ * @xe: xe device instance
+  *
+- * This function reads the boot status from Pcode.
++ * This function reads configfs and  boot status from Pcode.
+  *
+  * Return: true if platform support is available and boot status indicates
+- * failure, false otherwise.
++ * failure or if survivability mode is requested, false otherwise.
+  */
+-static bool survivability_mode_requested(struct xe_device *xe)
++bool xe_survivability_mode_is_requested(struct xe_device *xe)
+ {
+ 	struct xe_survivability *survivability = &xe->survivability;
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(xe);
++	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+ 	u32 data;
++	bool survivability_mode;
++
++	if (!IS_DGFX(xe) || IS_SRIOV_VF(xe))
++		return false;
++
++	survivability_mode = xe_configfs_get_survivability_mode(pdev);
+ 
+-	if (!IS_DGFX(xe) || xe->info.platform < XE_BATTLEMAGE || IS_SRIOV_VF(xe))
++	if (xe->info.platform < XE_BATTLEMAGE) {
++		if (survivability_mode) {
++			dev_err(&pdev->dev, "Survivability Mode is not supported on this card\n");
++			xe_configfs_clear_survivability_mode(pdev);
++		}
+ 		return false;
++	}
++
++	/* Enable survivability mode if set via configfs */
++	if (survivability_mode)
++		return true;
+ 
+ 	data = xe_mmio_read32(mmio, PCODE_SCRATCH(0));
+ 	survivability->boot_status = REG_FIELD_GET(BOOT_STATUS, data);
+@@ -230,7 +249,7 @@ int xe_survivability_mode_enable(struct xe_device *xe)
+ 	struct xe_survivability_info *info;
+ 	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+ 
+-	if (!survivability_mode_requested(xe))
++	if (!xe_survivability_mode_is_requested(xe))
+ 		return 0;
+ 
+ 	survivability->size = MAX_SCRATCH_MMIO;
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.h b/drivers/gpu/drm/xe/xe_survivability_mode.h
+index d7e64885570d..02231c2bf008 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.h
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.h
+@@ -12,5 +12,6 @@ struct xe_device;
+ 
+ int xe_survivability_mode_enable(struct xe_device *xe);
+ bool xe_survivability_mode_is_enabled(struct xe_device *xe);
++bool xe_survivability_mode_is_requested(struct xe_device *xe);
+ 
+ #endif /* _XE_SURVIVABILITY_MODE_H_ */
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-Initialize-mei-gsc-and-vsec-in-survivability-.patch
+++ b/backport/patches/base/0001-drm-xe-Initialize-mei-gsc-and-vsec-in-survivability-.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Tue, 28 Jan 2025 15:26:32 +0530
+Subject: drm/xe: Initialize mei-gsc and vsec in survivability mode
+
+Initialize mei-gsc in survivability mode and disable HECI
+interrupts. Also initialize vsec in survivability mode
+
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Reviewed-by: Alexander Usyskin <alexander.usyskin@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250128095632.1294722-4-riana.tauro@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 8b47c9cdb6a78364fe68f8af0abfd6f265577001 drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/xe_heci_gsc.c           | 3 ++-
+ drivers/gpu/drm/xe/xe_survivability_mode.c | 7 +++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_heci_gsc.c b/drivers/gpu/drm/xe/xe_heci_gsc.c
+index d765bfd3636b4..06dc78d3a8123 100644
+--- a/drivers/gpu/drm/xe/xe_heci_gsc.c
++++ b/drivers/gpu/drm/xe/xe_heci_gsc.c
+@@ -12,6 +12,7 @@
+ #include "xe_drv.h"
+ #include "xe_heci_gsc.h"
+ #include "xe_platform_types.h"
++#include "xe_survivability_mode.h"
+ 
+ #define GSC_BAR_LENGTH  0x00000FFC
+ 
+@@ -200,7 +201,7 @@ void xe_heci_gsc_init(struct xe_device *xe)
+ 		return;
+ 	}
+ 
+-	if (!def->use_polling) {
++	if (!def->use_polling && !xe_survivability_mode_enabled(xe)) {
+ 		ret = heci_gsc_irq_setup(xe);
+ 		if (ret)
+ 			goto fail;
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+index 633f5effa3492..c619560af74f0 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.c
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -12,8 +12,10 @@
+ 
+ #include "xe_device.h"
+ #include "xe_gt.h"
++#include "xe_heci_gsc.h"
+ #include "xe_mmio.h"
+ #include "xe_pcode_api.h"
++#include "xe_vsec.h"
+ 
+ #define MAX_SCRATCH_MMIO 8
+ 
+@@ -142,6 +144,10 @@ static void enable_survivability_mode(struct pci_dev *pdev)
+ 		dev_warn(dev, "Failed to create survivability sysfs files\n");
+ 		return;
+ 	}
++
++	xe_heci_gsc_init(xe);
++
++	xe_vsec_init(xe);
+ }
+ 
+ /**
+@@ -194,6 +200,7 @@ void xe_survivability_mode_remove(struct xe_device *xe)
+ 	struct device *dev = &pdev->dev;
+ 
+ 	sysfs_remove_file(&dev->kobj, &dev_attr_survivability_mode.attr);
++	xe_heci_gsc_fini(xe);
+ 	kfree(survivability->info);
+ 	pci_set_drvdata(pdev, NULL);
+ }
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-Move-survivability-back-to-xe.patch
+++ b/backport/patches/base/0001-drm-xe-Move-survivability-back-to-xe.patch
@@ -1,0 +1,165 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Fri, 14 Mar 2025 06:48:58 -0700
+Subject: drm/xe: Move survivability back to xe
+
+Commit d40f275d96e8 ("drm/xe: Move survivability entirely to xe_pci")
+moved the survivability handling to be done entirely in the xe_pci
+layer. However there are some issues with that approach:
+
+1) Survivability mode needs at least the mmio initialized, otherwise it
+   can't really read a register to decide if it should enter that state
+2) SR-IOV mode should be initialized, otherwise it's not possible to
+   check if it's VF
+
+Besides, as pointed by Riana the check for
+xe_survivability_mode_enable() was wrong in xe_pci_probe() since it's
+not a bool return.
+
+Fix that by moving the initialization to be entirely in the xe_device
+layer, with the correct dependencies handled: only after mmio and sriov
+initialization, and not triggering it on error from
+wait_for_lmem_ready(). This restores the trigger behavior before that
+commit. The xe_pci layer now only checks for "is it enabled?",
+like it's doing in xe_pci_suspend()/xe_pci_remove(), etc.
+
+Cc: Riana Tauro <riana.tauro@intel.com>
+Fixes: d40f275d96e8 ("drm/xe: Move survivability entirely to xe_pci")
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250314-fix-survivability-v5-1-fdb3559ea965@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry picked from commit 86b5e0dbba07438de91dd81095464c6c4aa7a372)
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit caf2f15648ba6cb4c329465c5686c9864a081a71 drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c             | 17 +++++++++++++++--
+ drivers/gpu/drm/xe/xe_pci.c                | 16 +++++++---------
+ drivers/gpu/drm/xe/xe_survivability_mode.c | 19 ++++++++++++-------
+ drivers/gpu/drm/xe/xe_survivability_mode.h |  1 -
+ 4 files changed, 34 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index baea0e0af3aa..37b2a2bd4308 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -54,6 +54,7 @@
+ #include "xe_pmu.h"
+ #include "xe_query.h"
+ #include "xe_sriov.h"
++#include "xe_survivability_mode.h"
+ #include "xe_tile.h"
+ #include "xe_ttm_stolen_mgr.h"
+ #include "xe_ttm_sys_mgr.h"
+@@ -590,8 +591,20 @@ int xe_device_probe_early(struct xe_device *xe)
+ 	update_device_info(xe);
+ 
+ 	err = xe_pcode_probe_early(xe);
+-	if (err)
+-		return err;
++	if (err) {
++		int save_err = err;
++
++		/*
++		 * Try to leave device in survivability mode if device is
++		 * possible, but still return the previous error for error
++		 * propagation
++		 */
++		err = xe_survivability_mode_enable(xe);
++		if (err)
++			return err;
++
++		return save_err;
++	}
+ 
+ 	err = wait_for_lmem_ready(xe);
+ 	if (err)
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index b6e15501487e..a3d00a80b8a8 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -842,16 +842,14 @@ static int xe_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 		return err;
+ 
+ 	err = xe_device_probe_early(xe);
+-
+-	/*
+-	 * In Boot Survivability mode, no drm card is exposed and driver is
+-	 * loaded with bare minimum to allow for firmware to be flashed through
+-	 * mei. If early probe fails, check if survivability mode is flagged by
+-	 * HW to be enabled. In that case enable it and return success.
+-	 */
+ 	if (err) {
+-		if (xe_survivability_mode_required(xe) &&
+-		    xe_survivability_mode_enable(xe))
++		/*
++		 * In Boot Survivability mode, no drm card is exposed and driver
++		 * is loaded with bare minimum to allow for firmware to be
++		 * flashed through mei. If early probe failed, but it managed to
++		 * enable survivability mode, return success.
++		 */
++		if (xe_survivability_mode_is_enabled(xe))
+ 			return 0;
+ 
+ 		return err;
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+index d939ce70e6fa..7b1ec643f0f0 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.c
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -178,15 +178,16 @@ bool xe_survivability_mode_is_enabled(struct xe_device *xe)
+ 	return xe->survivability.mode;
+ }
+ 
+-/**
+- * xe_survivability_mode_required - checks if survivability mode is required
+- * @xe: xe device instance
++/*
++ * survivability_mode_requested - check if it's possible to enable
++ * survivability mode and that was requested by firmware
+  *
+- * This function reads the boot status from Pcode
++ * This function reads the boot status from Pcode.
+  *
+- * Return: true if boot status indicates failure, false otherwise
++ * Return: true if platform support is available and boot status indicates
++ * failure, false otherwise.
+  */
+-bool xe_survivability_mode_required(struct xe_device *xe)
++static bool survivability_mode_requested(struct xe_device *xe)
+ {
+ 	struct xe_survivability *survivability = &xe->survivability;
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(xe);
+@@ -208,7 +209,8 @@ bool xe_survivability_mode_required(struct xe_device *xe)
+  *
+  * Initialize survivability information and enable survivability mode
+  *
+- * Return: 0 for success, negative error code otherwise.
++ * Return: 0 if survivability mode is enabled or not requested; negative error
++ * code otherwise.
+  */
+ int xe_survivability_mode_enable(struct xe_device *xe)
+ {
+@@ -216,6 +218,9 @@ int xe_survivability_mode_enable(struct xe_device *xe)
+ 	struct xe_survivability_info *info;
+ 	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+ 
++	if (!survivability_mode_requested(xe))
++		return 0;
++
+ 	survivability->size = MAX_SCRATCH_MMIO;
+ 
+ 	info = devm_kcalloc(xe->drm.dev, survivability->size, sizeof(*info),
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.h b/drivers/gpu/drm/xe/xe_survivability_mode.h
+index f4df5f9025ce..d7e64885570d 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.h
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.h
+@@ -12,6 +12,5 @@ struct xe_device;
+ 
+ int xe_survivability_mode_enable(struct xe_device *xe);
+ bool xe_survivability_mode_is_enabled(struct xe_device *xe);
+-bool xe_survivability_mode_required(struct xe_device *xe);
+ 
+ #endif /* _XE_SURVIVABILITY_MODE_H_ */
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Move-survivability-entirely-to-xe_pci.patch
+++ b/backport/patches/base/0001-drm-xe-Move-survivability-entirely-to-xe_pci.patch
@@ -1,0 +1,274 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Fri, 21 Feb 2025 16:10:48 -0800
+Subject: drm/xe: Move survivability entirely to xe_pci
+
+There's an odd split between xe_pci.c and xe_device.c wrt
+xe_survivability: it's initialized by xe_device, but then finalized by
+xe_pci. Move it entirely to the outer layer, xe_pci, so it controls
+the flow entirely.
+
+This also allows to stop ignoring some of the errors. E.g.: if there's
+an -ENOMEM, it shouldn't continue as if it survivability had been
+enabled.
+
+One change worth mentioning is that if "wait for lmem" fails, it will
+also check the pcode status to decide if it should enter or not in
+survivability mode, which it was not doing before. The bit from pcode
+for that decision should remain the same after lmem failed
+initialization, so it should be fine.
+
+Cc: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250222001051.3012936-9-lucas.demarchi@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit d40f275d96e890ac58cdaf2a46cb928c4240fcb7 drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c             |  7 +-
+ drivers/gpu/drm/xe/xe_heci_gsc.c           |  2 +-
+ drivers/gpu/drm/xe/xe_pci.c                | 17 ++---
+ drivers/gpu/drm/xe/xe_survivability_mode.c | 74 +++++++++++-----------
+ drivers/gpu/drm/xe/xe_survivability_mode.h |  5 +-
+ 5 files changed, 49 insertions(+), 56 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 18cc2bc90e94..abd953761cae 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -54,7 +54,6 @@
+ #include "xe_pmu.h"
+ #include "xe_query.h"
+ #include "xe_sriov.h"
+-#include "xe_survivability_mode.h"
+ #include "xe_tile.h"
+ #include "xe_ttm_stolen_mgr.h"
+ #include "xe_ttm_sys_mgr.h"
+@@ -591,12 +590,8 @@ int xe_device_probe_early(struct xe_device *xe)
+ 	update_device_info(xe);
+ 
+ 	err = xe_pcode_probe_early(xe);
+-	if (err) {
+-		if (xe_survivability_mode_required(xe))
+-			xe_survivability_mode_init(xe);
+-
++	if (err)
+ 		return err;
+-	}
+ 
+ 	err = wait_for_lmem_ready(xe);
+ 	if (err)
+diff --git a/drivers/gpu/drm/xe/xe_heci_gsc.c b/drivers/gpu/drm/xe/xe_heci_gsc.c
+index 06dc78d3a812..992ee47abcdb 100644
+--- a/drivers/gpu/drm/xe/xe_heci_gsc.c
++++ b/drivers/gpu/drm/xe/xe_heci_gsc.c
+@@ -201,7 +201,7 @@ void xe_heci_gsc_init(struct xe_device *xe)
+ 		return;
+ 	}
+ 
+-	if (!def->use_polling && !xe_survivability_mode_enabled(xe)) {
++	if (!def->use_polling && !xe_survivability_mode_is_enabled(xe)) {
+ 		ret = heci_gsc_irq_setup(xe);
+ 		if (ret)
+ 			goto fail;
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index f83d58acfe86..b6e15501487e 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -767,8 +767,8 @@ static void xe_pci_remove(struct pci_dev *pdev)
+ 	if (IS_SRIOV_PF(xe))
+ 		xe_pci_sriov_configure(pdev, 0);
+ 
+-	if (xe_survivability_mode_enabled(xe))
+-		return xe_survivability_mode_remove(xe);
++	if (xe_survivability_mode_is_enabled(xe))
++		return;
+ 
+ 	xe_device_remove(xe);
+ 	xe_pm_runtime_fini(xe);
+@@ -844,13 +844,14 @@ static int xe_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 	err = xe_device_probe_early(xe);
+ 
+ 	/*
+-	 * In Boot Survivability mode, no drm card is exposed
+-	 * and driver is loaded with bare minimum to allow
+-	 * for firmware to be flashed through mei. Return
+-	 * success if survivability mode is enabled.
++	 * In Boot Survivability mode, no drm card is exposed and driver is
++	 * loaded with bare minimum to allow for firmware to be flashed through
++	 * mei. If early probe fails, check if survivability mode is flagged by
++	 * HW to be enabled. In that case enable it and return success.
+ 	 */
+ 	if (err) {
+-		if (xe_survivability_mode_enabled(xe))
++		if (xe_survivability_mode_required(xe) &&
++		    xe_survivability_mode_enable(xe))
+ 			return 0;
+ 
+ 		return err;
+@@ -944,7 +945,7 @@ static int xe_pci_suspend(struct device *dev)
+ 	struct xe_device *xe = pdev_to_xe_device(pdev);
+ 	int err;
+ 
+-	if (xe_survivability_mode_enabled(xe))
++	if (xe_survivability_mode_is_enabled(xe))
+ 		return -EBUSY;
+ 
+ 	err = xe_pm_suspend(xe);
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+index 02b4eadf8407..7ba02e085b5b 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.c
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -127,40 +127,54 @@ static ssize_t survivability_mode_show(struct device *dev,
+ 
+ static DEVICE_ATTR_ADMIN_RO(survivability_mode);
+ 
+-static void enable_survivability_mode(struct pci_dev *pdev)
++static void xe_survivability_mode_fini(void *arg)
++{
++	struct xe_device *xe = arg;
++	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
++	struct device *dev = &pdev->dev;
++
++	sysfs_remove_file(&dev->kobj, &dev_attr_survivability_mode.attr);
++	xe_heci_gsc_fini(xe);
++}
++
++static int enable_survivability_mode(struct pci_dev *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct xe_device *xe = pdev_to_xe_device(pdev);
+ 	struct xe_survivability *survivability = &xe->survivability;
+ 	int ret = 0;
+ 
+-	/* set survivability mode */
+-	survivability->mode = true;
+-	dev_info(dev, "In Survivability Mode\n");
+-
+ 	/* create survivability mode sysfs */
+ 	ret = sysfs_create_file(&dev->kobj, &dev_attr_survivability_mode.attr);
+ 	if (ret) {
+ 		dev_warn(dev, "Failed to create survivability sysfs files\n");
+-		return;
++		return ret;
+ 	}
+ 
++	ret = devm_add_action_or_reset(xe->drm.dev,
++				       xe_survivability_mode_fini, xe);
++	if (ret)
++		return ret;
++
+ 	xe_heci_gsc_init(xe);
+ 
+ 	xe_vsec_init(xe);
++
++	survivability->mode = true;
++	dev_err(dev, "In Survivability Mode\n");
++
++	return 0;
+ }
+ 
+ /**
+- * xe_survivability_mode_enabled - check if survivability mode is enabled
++ * xe_survivability_mode_is_enabled - check if survivability mode is enabled
+  * @xe: xe device instance
+  *
+  * Returns true if in survivability mode, false otherwise
+  */
+-bool xe_survivability_mode_enabled(struct xe_device *xe)
++bool xe_survivability_mode_is_enabled(struct xe_device *xe)
+ {
+-	struct xe_survivability *survivability = &xe->survivability;
+-
+-	return survivability->mode;
++	return xe->survivability.mode;
+ }
+ 
+ /**
+@@ -183,35 +197,19 @@ bool xe_survivability_mode_required(struct xe_device *xe)
+ 	data = xe_mmio_read32(mmio, PCODE_SCRATCH(0));
+ 	survivability->boot_status = REG_FIELD_GET(BOOT_STATUS, data);
+ 
+-	return (survivability->boot_status == NON_CRITICAL_FAILURE ||
+-		survivability->boot_status == CRITICAL_FAILURE);
++	return survivability->boot_status == NON_CRITICAL_FAILURE ||
++		survivability->boot_status == CRITICAL_FAILURE;
+ }
+ 
+ /**
+- * xe_survivability_mode_remove - remove survivability mode
++ * xe_survivability_mode_enable - Initialize and enable the survivability mode
+  * @xe: xe device instance
+  *
+- * clean up sysfs entries of survivability mode
+- */
+-void xe_survivability_mode_remove(struct xe_device *xe)
+-{
+-	struct xe_survivability *survivability = &xe->survivability;
+-	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+-	struct device *dev = &pdev->dev;
+-
+-	sysfs_remove_file(&dev->kobj, &dev_attr_survivability_mode.attr);
+-	xe_heci_gsc_fini(xe);
+-	kfree(survivability->info);
+-	pci_set_drvdata(pdev, NULL);
+-}
+-
+-/**
+- * xe_survivability_mode_init - Initialize the survivability mode
+- * @xe: xe device instance
++ * Initialize survivability information and enable survivability mode
+  *
+- * Initializes survivability information and enables survivability mode
++ * Return: 0 for success, negative error code otherwise.
+  */
+-void xe_survivability_mode_init(struct xe_device *xe)
++int xe_survivability_mode_enable(struct xe_device *xe)
+ {
+ 	struct xe_survivability *survivability = &xe->survivability;
+ 	struct xe_survivability_info *info;
+@@ -219,9 +217,10 @@ void xe_survivability_mode_init(struct xe_device *xe)
+ 
+ 	survivability->size = MAX_SCRATCH_MMIO;
+ 
+-	info = kcalloc(survivability->size, sizeof(*info), GFP_KERNEL);
++	info = devm_kcalloc(xe->drm.dev, survivability->size, sizeof(*info),
++			    GFP_KERNEL);
+ 	if (!info)
+-		return;
++		return -ENOMEM;
+ 
+ 	survivability->info = info;
+ 
+@@ -230,9 +229,8 @@ void xe_survivability_mode_init(struct xe_device *xe)
+ 	/* Only log debug information and exit if it is a critical failure */
+ 	if (survivability->boot_status == CRITICAL_FAILURE) {
+ 		log_survivability_info(pdev);
+-		kfree(survivability->info);
+-		return;
++		return -ENXIO;
+ 	}
+ 
+-	enable_survivability_mode(pdev);
++	return enable_survivability_mode(pdev);
+ }
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.h b/drivers/gpu/drm/xe/xe_survivability_mode.h
+index f530507a22c6..f4df5f9025ce 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.h
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.h
+@@ -10,9 +10,8 @@
+ 
+ struct xe_device;
+ 
+-void xe_survivability_mode_init(struct xe_device *xe);
+-void xe_survivability_mode_remove(struct xe_device *xe);
+-bool xe_survivability_mode_enabled(struct xe_device *xe);
++int xe_survivability_mode_enable(struct xe_device *xe);
++bool xe_survivability_mode_is_enabled(struct xe_device *xe);
+ bool xe_survivability_mode_required(struct xe_device *xe);
+ 
+ #endif /* _XE_SURVIVABILITY_MODE_H_ */
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Skip-survivability-mode-for-VF.patch
+++ b/backport/patches/base/0001-drm-xe-Skip-survivability-mode-for-VF.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Fri, 31 Jan 2025 13:35:27 +0530
+Subject: drm/xe: Skip survivability mode for VF
+
+Follow the probe flow in case of VF and do not enter survivability mode
+in case of pcode init failure.
+
+Fixes: 5e940312a2ac ("drm/xe: Add functions and sysfs for boot survivability")
+Suggested-by: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250131080527.2256475-1-riana.tauro@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit d9bc304437da6b74ac2b6644fe47702b8286eb8d drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/xe_survivability_mode.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+index c619560af74f0..02b4eadf84079 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.c
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -177,7 +177,7 @@ bool xe_survivability_mode_required(struct xe_device *xe)
+ 	struct xe_mmio *mmio = xe_root_tile_mmio(xe);
+ 	u32 data;
+ 
+-	if (!IS_DGFX(xe) || xe->info.platform < XE_BATTLEMAGE)
++	if (!IS_DGFX(xe) || xe->info.platform < XE_BATTLEMAGE || IS_SRIOV_VF(xe))
+ 		return false;
+ 
+ 	data = xe_mmio_read32(mmio, PCODE_SCRATCH(0));
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-Stop-ignoring-errors-from-xe_heci_gsc_init.patch
+++ b/backport/patches/base/0001-drm-xe-Stop-ignoring-errors-from-xe_heci_gsc_init.patch
@@ -1,0 +1,171 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Fri, 21 Feb 2025 16:10:49 -0800
+Subject: drm/xe: Stop ignoring errors from xe_heci_gsc_init()
+
+Do not ignore errors from xe_heci_gsc_init(). For example, it shouldn't
+be fine to report successfully entering survivability mode when there's
+no communication with gsc working. The driver should also not be
+half-initialized in the normal case neither.
+
+Cc: Riana Tauro <riana.tauro@intel.com>
+Cc: Alexander Usyskin <alexander.usyskin@intel.com>
+Reviewed-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250222001051.3012936-10-lucas.demarchi@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(backported from commit 292b1a8a50545b47d4fafc54452147abd2d1d86c drm-tip)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c             |  6 ++--
+ drivers/gpu/drm/xe/xe_heci_gsc.c           | 35 +++++++++-------------
+ drivers/gpu/drm/xe/xe_heci_gsc.h           |  3 +-
+ drivers/gpu/drm/xe/xe_survivability_mode.c |  5 ++--
+ 4 files changed, 21 insertions(+), 28 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index f035a44c23dd0..f8a9d4b5dd4e1 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -771,7 +771,9 @@ int xe_device_probe(struct xe_device *xe)
+ 			goto err_fini_gt;
+ 	}
+ 
+-	xe_heci_gsc_init(xe);
++	err = xe_heci_gsc_init(xe);
++	if (err)
++		return err;
+ 
+ 	err = xe_oa_init(xe);
+ 	if (err)
+@@ -840,8 +842,6 @@ void xe_device_remove(struct xe_device *xe)
+ 
+ 	xe_oa_fini(xe);
+ 
+-	xe_heci_gsc_fini(xe);
+-
+ 	for_each_gt(gt, xe, id)
+ 		xe_gt_remove(gt);
+ }
+diff --git a/drivers/gpu/drm/xe/xe_heci_gsc.c b/drivers/gpu/drm/xe/xe_heci_gsc.c
+index 992ee47abcdb7..3ea325d3db99d 100644
+--- a/drivers/gpu/drm/xe/xe_heci_gsc.c
++++ b/drivers/gpu/drm/xe/xe_heci_gsc.c
+@@ -89,12 +89,9 @@ static void heci_gsc_release_dev(struct device *dev)
+ 	kfree(adev);
+ }
+ 
+-void xe_heci_gsc_fini(struct xe_device *xe)
++static void xe_heci_gsc_fini(void *arg)
+ {
+-	struct xe_heci_gsc *heci_gsc = &xe->heci_gsc;
+-
+-	if (!xe->info.has_heci_gscfi && !xe->info.has_heci_cscfi)
+-		return;
++	struct xe_heci_gsc *heci_gsc = arg;
+ 
+ 	if (heci_gsc->adev) {
+ 		struct auxiliary_device *aux_dev = &heci_gsc->adev->aux_dev;
+@@ -106,6 +103,7 @@ void xe_heci_gsc_fini(struct xe_device *xe)
+ 
+ 	if (heci_gsc->irq >= 0)
+ 		irq_free_desc(heci_gsc->irq);
++
+ 	heci_gsc->irq = -1;
+ }
+ 
+@@ -172,14 +170,14 @@ static int heci_gsc_add_device(struct xe_device *xe, const struct heci_gsc_def *
+ 	return ret;
+ }
+ 
+-void xe_heci_gsc_init(struct xe_device *xe)
++int xe_heci_gsc_init(struct xe_device *xe)
+ {
+ 	struct xe_heci_gsc *heci_gsc = &xe->heci_gsc;
+ 	const struct heci_gsc_def *def;
+ 	int ret;
+ 
+ 	if (!xe->info.has_heci_gscfi && !xe->info.has_heci_cscfi)
+-		return;
++		return 0;
+ 
+ 	heci_gsc->irq = -1;
+ 
+@@ -191,29 +189,24 @@ void xe_heci_gsc_init(struct xe_device *xe)
+ 		def = &heci_gsc_def_dg2;
+ 	} else if (xe->info.platform == XE_DG1) {
+ 		def = &heci_gsc_def_dg1;
+-	} else {
+-		drm_warn_once(&xe->drm, "Unknown platform\n");
+-		return;
+ 	}
+ 
+-	if (!def->name) {
+-		drm_warn_once(&xe->drm, "HECI is not implemented!\n");
+-		return;
++	if (!def || !def->name) {
++		drm_warn(&xe->drm, "HECI is not implemented!\n");
++		return 0;
+ 	}
+ 
++	ret = devm_add_action_or_reset(xe->drm.dev, xe_heci_gsc_fini, heci_gsc);
++	if (ret)
++		return ret;
++
+ 	if (!def->use_polling && !xe_survivability_mode_is_enabled(xe)) {
+ 		ret = heci_gsc_irq_setup(xe);
+ 		if (ret)
+-			goto fail;
++			return ret;
+ 	}
+ 
+-	ret = heci_gsc_add_device(xe, def);
+-	if (ret)
+-		goto fail;
+-
+-	return;
+-fail:
+-	xe_heci_gsc_fini(xe);
++	return heci_gsc_add_device(xe, def);
+ }
+ 
+ void xe_heci_gsc_irq_handler(struct xe_device *xe, u32 iir)
+diff --git a/drivers/gpu/drm/xe/xe_heci_gsc.h b/drivers/gpu/drm/xe/xe_heci_gsc.h
+index 48b3b18380453..745eb6783942d 100644
+--- a/drivers/gpu/drm/xe/xe_heci_gsc.h
++++ b/drivers/gpu/drm/xe/xe_heci_gsc.h
+@@ -33,8 +33,7 @@ struct xe_heci_gsc {
+ 	int irq;
+ };
+ 
+-void xe_heci_gsc_init(struct xe_device *xe);
+-void xe_heci_gsc_fini(struct xe_device *xe);
++int xe_heci_gsc_init(struct xe_device *xe);
+ void xe_heci_gsc_irq_handler(struct xe_device *xe, u32 iir);
+ void xe_heci_csc_irq_handler(struct xe_device *xe, u32 iir);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_survivability_mode.c b/drivers/gpu/drm/xe/xe_survivability_mode.c
+index 7ba02e085b5b1..d939ce70e6fa8 100644
+--- a/drivers/gpu/drm/xe/xe_survivability_mode.c
++++ b/drivers/gpu/drm/xe/xe_survivability_mode.c
+@@ -134,7 +134,6 @@ static void xe_survivability_mode_fini(void *arg)
+ 	struct device *dev = &pdev->dev;
+ 
+ 	sysfs_remove_file(&dev->kobj, &dev_attr_survivability_mode.attr);
+-	xe_heci_gsc_fini(xe);
+ }
+ 
+ static int enable_survivability_mode(struct pci_dev *pdev)
+@@ -156,7 +155,9 @@ static int enable_survivability_mode(struct pci_dev *pdev)
+ 	if (ret)
+ 		return ret;
+ 
+-	xe_heci_gsc_init(xe);
++	ret = xe_heci_gsc_init(xe);
++	if (ret)
++		return ret;
+ 
+ 	xe_vsec_init(xe);
+ 
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -52,6 +52,16 @@ backport/patches/base/0001-platform-x86-intel-pmt-add-register-access-helpers.pa
 backport/patches/base/0001-platform-x86-intel-pmt-refactor-base-parameter.patch
 backport/patches/base/0001-platform-x86-intel-pmt-use-a-version-struct.patch
 backport/patches/base/0001-platform-x86-intel-pmt-support-BMG-crashlog.patch
+backport/patches/base/0001-drm-xe-Add-functions-and-sysfs-for-boot-survivabilit.patch
+backport/patches/base/0001-drm-xe-Enable-Boot-Survivability-mode.patch
+backport/patches/base/0001-drm-xe-Initialize-mei-gsc-and-vsec-in-survivability-.patch
+backport/patches/base/0001-drm-xe-Skip-survivability-mode-for-VF.patch
+backport/patches/base/0001-drm-xe-Move-survivability-entirely-to-xe_pci.patch
+backport/patches/base/0001-drm-xe-Stop-ignoring-errors-from-xe_heci_gsc_init.patch
+backport/patches/base/0001-drm-xe-Move-survivability-back-to-xe.patch
+backport/patches/base/0001-drm-xe-Add-configfs-to-enable-survivability-mode.patch
+backport/patches/base/0001-drm-xe-Add-documentation-for-survivability-mode.patch
+backport/patches/base/0001-drm-xe-Enable-configfs-support-for-survivability-mod.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Introduce boot survivability mode for recovering systems in failed boot
states. The driver enters a minimal init path to allow firmware flashing
via mei-gsc and telemetry collection. Add sysfs/configfs interfaces,
handle VF cases, move code between subsystems, and improve error handling
in probe sequence.

Backported patches:
 - drm/xe: Add functions and sysfs for boot survivability
 - drm/xe: Enable Boot Survivability mode
 - drm/xe: Initialize mei-gsc and vsec in survivability mode
 - drm/xe: Skip survivability mode for VF
 - drm/xe: Move survivability entirely to xe_pci
 - drm/xe: Stop ignoring errors from xe_heci_gsc_init()
 - drm/xe: Move survivability back to xe
 - drm/xe: Add configfs to enable survivability mode
 - drm/xe: Add documentation for survivability mode
 - drm/xe: Enable configfs support for survivability mode

Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>