### PR TITLE
backport/base: Introduce CPU address mirror VMAs support

### DIFF
--- a/backport/patches/base/0001-drm-xe-vm-Call-vm_bind_ioctl_ops_fini-on-ENODATA-err.patch
+++ b/backport/patches/base/0001-drm-xe-vm-Call-vm_bind_ioctl_ops_fini-on-ENODATA-err.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+Date: Tue, 2 Sep 2025 07:32:55 +0530
+Subject: [PATCH] drm/xe/vm: Call vm_bind_ioctl_ops_fini() on -ENODATA error
+
+When ops_execute() returns -ENODATA in vm_bind_ioctl_ops_execute(),
+the vops structures may remain partially initialized. This can lead
+to resource leaks if they are not cleaned up.
+
+Add a call to vm_bind_ioctl_ops_fini() when encountering -ENODATA to
+properly release allocated resources.
+
+This is a partial backport of upstream commit:
+b43e864af0d4 ("drm/xe/uapi: Add DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR")
+which introduced this cleanup as part of a larger patch.
+
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_vm.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 785b8960050b..ae55fc9ca1b5 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -2786,6 +2786,8 @@ static int vm_bind_ioctl_ops_execute(struct xe_vm *vm,
+ 		fence = ops_execute(vm, vops);
+ 		if (IS_ERR(fence)) {
+ 			err = PTR_ERR(fence);
++			if (PTR_ERR(fence) == -ENODATA)
++				vm_bind_ioctl_ops_fini(vm, vops, NULL);
+ 			goto unlock;
+ 		}
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -74,6 +74,7 @@ backport/patches/base/0001-drm-xe-nvm-add-on-die-non-volatile-memory-device.patc
 backport/patches/base/0001-drm-xe-nvm-add-support-for-access-mode.patch
 backport/patches/base/0001-drm-xe-nvm-add-support-for-non-posted-erase.patch
 backport/patches/base/0001-drm-xe-xe_debugfs-Exposure-of-G-State-and-pcie-link-.patch
+backport/patches/base/0001-drm-xe-vm-Call-vm_bind_ioctl_ops_fini-on-ENODATA-err.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Introduce DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR to support CPU address
mirror VMAs, which create unpopulated VMAs without memory backing or
GPU page tables. These VMAs update GPUVM state and rely on page faults
or prefetches to populate mappings. Enables mixing system and runtime
allocations within a single VM and simplifies SVM integration.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>