### PR TITLE
backport/base: Add G-State and PCIe link residency counters

### DIFF
--- a/backport/patches/base/0001-drm-xe-xe_debugfs-Exposure-of-G-State-and-pcie-link-.patch
+++ b/backport/patches/base/0001-drm-xe-xe_debugfs-Exposure-of-G-State-and-pcie-link-.patch
@@ -1,0 +1,200 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Soham Purkait <soham.purkait@intel.com>
+Date: Wed, 16 Jul 2025 15:44:12 +0530
+Subject: drm/xe/xe_debugfs: Exposure of G-State and pcie link state
+ residency counters through debugfs
+
+Add debug nodes, "dgfx_pkg_residencies" for G-states (G2, G6, G8, G10,
+ModS) and "dgfx_pcie_link_residencies" for PCIe link states(L0, L1, L1.2)
+residency counters.
+
+v1:
+ - Expose all G-State residency counter values under
+   dgfx_pkg_residencies. (Anshuman)
+ - Include runtime_get/put. (Riana)
+v2:
+ - Move offset macros to drm/xe/regs/xe_pmt. (Riana)
+v3:
+ - Include debugfs node "dgfx_pcie_link_residencies" for pcie link
+   residency counter values.  (Anshuman)
+v4:
+ - Include check for BMG and add helper function for repetitive
+   code. (Riana)
+ - Add for loop and local struct to avoid repetition. (Riana)
+ - Use "drm_debugfs_create_files" to create debugfs. (Karthik)
+v5:
+ - Reorder commits to reflect the correct dependency hierarchy.  (Jonathan)
+ - Simplification of commit message and rectified register offset.(Karthik)
+ - Error handling and return before printing.                       (Riana)
+v6:
+ - Remove check for DGFX as BMG is discrete. (Karthik)
+ - Rearrange residency offsets in ascending order. (Riana)
+v7:
+ - Squash the macros into the patch they are used in. (Lucas)
+
+Signed-off-by: Soham Purkait <soham.purkait@intel.com>
+Reviewed-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Reviewed-by: Karthik Poosa <karthik.poosa@intel.com>
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://lore.kernel.org/r/20250716101412.3062780-2-soham.purkait@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 487579fd8524c58dc237904c1b1d9e7c89e53378 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_pmt.h | 10 ++++
+ drivers/gpu/drm/xe/xe_debugfs.c  | 85 ++++++++++++++++++++++++++++++++
+ 2 files changed, 95 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_pmt.h b/drivers/gpu/drm/xe/regs/xe_pmt.h
+index b0efd9b48d1e..3b3cd72f5f42 100644
+--- a/drivers/gpu/drm/xe/regs/xe_pmt.h
++++ b/drivers/gpu/drm/xe/regs/xe_pmt.h
+@@ -21,4 +21,14 @@
+ #define SG_REMAP_INDEX1			XE_REG(SOC_BASE + 0x08)
+ #define   SG_REMAP_BITS			REG_GENMASK(31, 24)
+ 
++#define BMG_MODS_RESIDENCY_OFFSET		(0x4D0)
++#define BMG_G2_RESIDENCY_OFFSET		(0x530)
++#define BMG_G6_RESIDENCY_OFFSET		(0x538)
++#define BMG_G8_RESIDENCY_OFFSET		(0x540)
++#define BMG_G10_RESIDENCY_OFFSET		(0x548)
++
++#define BMG_PCIE_LINK_L0_RESIDENCY_OFFSET	(0x570)
++#define BMG_PCIE_LINK_L1_RESIDENCY_OFFSET	(0x578)
++#define BMG_PCIE_LINK_L1_2_RESIDENCY_OFFSET	(0x580)
++
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_debugfs.c b/drivers/gpu/drm/xe/xe_debugfs.c
+index 92e6fa8fe3a1..b59c1e727d1e 100644
+--- a/drivers/gpu/drm/xe/xe_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_debugfs.c
+@@ -11,15 +11,18 @@
+ 
+ #include <drm/drm_debugfs.h>
+ 
++#include "regs/xe_pmt.h"
+ #include "xe_bo.h"
+ #include "xe_device.h"
+ #include "xe_force_wake.h"
+ #include "xe_gt_debugfs.h"
+ #include "xe_gt_printk.h"
+ #include "xe_guc_ads.h"
++#include "xe_mmio.h"
+ #include "xe_pm.h"
+ #include "xe_sriov.h"
+ #include "xe_step.h"
++#include "xe_vsec.h"
+ 
+ #ifdef CONFIG_DRM_XE_DEBUG
+ #include "xe_bo_evict.h"
+@@ -29,6 +32,23 @@
+ 
+ DECLARE_FAULT_ATTR(gt_reset_failure);
+ 
++static void read_residency_counter(struct xe_device *xe, struct xe_mmio *mmio,
++				   u32 offset, char *name, struct drm_printer *p)
++{
++	u64 residency = 0;
++	int ret;
++
++	ret = xe_pmt_telem_read(to_pci_dev(xe->drm.dev),
++				xe_mmio_read32(mmio, PUNIT_TELEMETRY_GUID),
++				&residency, offset, sizeof(residency));
++	if (ret != sizeof(residency)) {
++		drm_warn(&xe->drm, "%s counter failed to read, ret %d\n", name, ret);
++		return;
++	}
++
++	drm_printf(p, "%s : %llu\n", name, residency);
++}
++
+ static struct xe_device *node_to_xe(struct drm_info_node *node)
+ {
+ 	return to_xe_device(node->minor->dev);
+@@ -81,11 +101,71 @@ static int sriov_info(struct seq_file *m, void *data)
+ 	return 0;
+ }
+ 
++static int dgfx_pkg_residencies_show(struct seq_file *m, void *data)
++{
++	struct xe_device *xe;
++	struct xe_mmio *mmio;
++	struct drm_printer p;
++
++	xe = node_to_xe(m->private);
++	p = drm_seq_file_printer(m);
++	xe_pm_runtime_get(xe);
++	mmio = xe_root_tile_mmio(xe);
++	struct {
++		u32 offset;
++		char *name;
++	} residencies[] = {
++		{BMG_G2_RESIDENCY_OFFSET, "Package G2"},
++		{BMG_G6_RESIDENCY_OFFSET, "Package G6"},
++		{BMG_G8_RESIDENCY_OFFSET, "Package G8"},
++		{BMG_G10_RESIDENCY_OFFSET, "Package G10"},
++		{BMG_MODS_RESIDENCY_OFFSET, "Package ModS"}
++	};
++
++	for (int i = 0; i < ARRAY_SIZE(residencies); i++)
++		read_residency_counter(xe, mmio, residencies[i].offset, residencies[i].name, &p);
++
++	xe_pm_runtime_put(xe);
++	return 0;
++}
++
++static int dgfx_pcie_link_residencies_show(struct seq_file *m, void *data)
++{
++	struct xe_device *xe;
++	struct xe_mmio *mmio;
++	struct drm_printer p;
++
++	xe = node_to_xe(m->private);
++	p = drm_seq_file_printer(m);
++	xe_pm_runtime_get(xe);
++	mmio = xe_root_tile_mmio(xe);
++
++	struct {
++		u32 offset;
++		char *name;
++	} residencies[] = {
++		{BMG_PCIE_LINK_L0_RESIDENCY_OFFSET, "PCIE LINK L0 RESIDENCY"},
++		{BMG_PCIE_LINK_L1_RESIDENCY_OFFSET, "PCIE LINK L1 RESIDENCY"},
++		{BMG_PCIE_LINK_L1_2_RESIDENCY_OFFSET, "PCIE LINK L1.2 RESIDENCY"}
++	};
++
++	for (int i = 0; i < ARRAY_SIZE(residencies); i++)
++		read_residency_counter(xe, mmio, residencies[i].offset, residencies[i].name, &p);
++
++	xe_pm_runtime_put(xe);
++	return 0;
++}
++
+ static const struct drm_info_list debugfs_list[] = {
+ 	{"info", info, 0},
+ 	{ .name = "sriov_info", .show = sriov_info, },
+ };
+ 
++static const struct drm_info_list debugfs_residencies[] = {
++	{ .name = "dgfx_pkg_residencies", .show = dgfx_pkg_residencies_show, },
++	{ .name = "dgfx_pcie_link_residencies", .show = dgfx_pcie_link_residencies_show, },
++};
++
+ static int forcewake_open(struct inode *inode, struct file *file)
+ {
+ 	struct xe_device *xe = inode->i_private;
+@@ -204,6 +284,11 @@ void xe_debugfs_register(struct xe_device *xe)
+ 				 ARRAY_SIZE(debugfs_list),
+ 				 root, minor);
+ 
++	if (xe->info.platform == XE_BATTLEMAGE)
++		drm_debugfs_create_files(debugfs_residencies,
++					 ARRAY_SIZE(debugfs_residencies),
++					 root, minor);
++
+ 	debugfs_create_file("forcewake_all", 0400, root, xe,
+ 			    &forcewake_all_fops);
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -73,6 +73,7 @@ backport/patches/base/0001-mtd-intel-dg-align-64bit-read-and-write.patch
 backport/patches/base/0001-drm-xe-nvm-add-on-die-non-volatile-memory-device.patch
 backport/patches/base/0001-drm-xe-nvm-add-support-for-access-mode.patch
 backport/patches/base/0001-drm-xe-nvm-add-support-for-non-posted-erase.patch
+backport/patches/base/0001-drm-xe-xe_debugfs-Exposure-of-G-State-and-pcie-link-.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Expose debugfs nodes "dgfx_pkg_residencies" for G-state residency counters
(G2, G6, G8, G10, ModS) and "dgfx_pcie_link_residencies" for PCIe link
residency counters (L0, L1, L1.2).

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>