### PR TITLE
backport/base: Add engine disable support and configfs interface

### DIFF
--- a/backport/patches/base/0001-drm-xe-Allow-to-disable-engines.patch
+++ b/backport/patches/base/0001-drm-xe-Allow-to-disable-engines.patch
@@ -1,0 +1,124 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 28 May 2025 14:54:06 -0700
+Subject: drm/xe: Allow to disable engines
+
+Sometimes it's useful to load the driver with a smaller set of engines
+to allow more targeted debugging, particularly on early enabling.
+
+Besides checking what is fused off in hardware, add similar logic to
+disable engines in software. This will use configfs to allow users
+to set what engine to disable, so already add prepare for that. The
+exact configfs interface will be added later.
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250528-engine-mask-v4-3-f4636d2a890a@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry-picked from commit 58b51df807d7394a09ddb95b47099d59465e3777 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_configfs.c  | 15 +++++++++++++++
+ drivers/gpu/drm/xe/xe_configfs.h  |  3 +++
+ drivers/gpu/drm/xe/xe_hw_engine.c | 20 ++++++++++++++++++++
+ 3 files changed, 38 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_configfs.c b/drivers/gpu/drm/xe/xe_configfs.c
+index cb9f175c89a1..8320d57ef5a8 100644
+--- a/drivers/gpu/drm/xe/xe_configfs.c
++++ b/drivers/gpu/drm/xe/xe_configfs.c
+@@ -226,6 +226,21 @@ void xe_configfs_clear_survivability_mode(struct pci_dev *pdev)
+ 	config_item_put(&dev->group.cg_item);
+ }
+ 
++/**
++ * xe_configfs_get_engines_allowed - get engine allowed mask from configfs
++ * @pdev: pci device
++ *
++ * Find the configfs group that belongs to the pci device and return
++ * the mask of engines allowed to be used.
++ *
++ * Return: engine mask with allowed engines
++ */
++u64 xe_configfs_get_engines_allowed(struct pci_dev *pdev)
++{
++	/* dummy implementation */
++	return U64_MAX;
++}
++
+ int __init xe_configfs_init(void)
+ {
+ 	struct config_group *root = &xe_configfs.su_group;
+diff --git a/drivers/gpu/drm/xe/xe_configfs.h b/drivers/gpu/drm/xe/xe_configfs.h
+index ef6d231b3024..fb8764008089 100644
+--- a/drivers/gpu/drm/xe/xe_configfs.h
++++ b/drivers/gpu/drm/xe/xe_configfs.h
+@@ -5,6 +5,7 @@
+ #ifndef _XE_CONFIGFS_H_
+ #define _XE_CONFIGFS_H_
+ 
++#include <linux/limits.h>
+ #include <linux/types.h>
+ 
+ struct pci_dev;
+@@ -14,11 +15,13 @@ int xe_configfs_init(void);
+ void xe_configfs_exit(void);
+ bool xe_configfs_get_survivability_mode(struct pci_dev *pdev);
+ void xe_configfs_clear_survivability_mode(struct pci_dev *pdev);
++u64 xe_configfs_get_engines_allowed(struct pci_dev *pdev);
+ #else
+ static inline int xe_configfs_init(void) { return 0; }
+ static inline void xe_configfs_exit(void) { }
+ static inline bool xe_configfs_get_survivability_mode(struct pci_dev *pdev) { return false; }
+ static inline void xe_configfs_clear_survivability_mode(struct pci_dev *pdev) { }
++static inline u64 xe_configfs_get_engines_allowed(struct pci_dev *pdev) { return U64_MAX; }
+ #endif
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
+index 3d85625914aa..7020c8e536e6 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine.c
+@@ -15,6 +15,7 @@
+ #include "regs/xe_irq_regs.h"
+ #include "xe_assert.h"
+ #include "xe_bo.h"
++#include "xe_configfs.h"
+ #include "xe_device.h"
+ #include "xe_execlist.h"
+ #include "xe_force_wake.h"
+@@ -772,6 +773,24 @@ static void check_gsc_availability(struct xe_gt *gt)
+ 	}
+ }
+ 
++static void check_sw_disable(struct xe_gt *gt)
++{
++	struct xe_device *xe = gt_to_xe(gt);
++	u64 sw_allowed = xe_configfs_get_engines_allowed(to_pci_dev(xe->drm.dev));
++	enum xe_hw_engine_id id;
++
++	for (id = 0; id < XE_NUM_HW_ENGINES; ++id) {
++		if (!(gt->info.engine_mask & BIT(id)))
++			continue;
++
++		if (!(sw_allowed & BIT(id))) {
++			gt->info.engine_mask &= ~BIT(id);
++			xe_gt_info(gt, "%s disabled via configfs\n",
++				   engine_infos[id].name);
++		}
++	}
++}
++
+ int xe_hw_engines_init_early(struct xe_gt *gt)
+ {
+ 	int i;
+@@ -780,6 +799,7 @@ int xe_hw_engines_init_early(struct xe_gt *gt)
+ 	read_copy_fuses(gt);
+ 	read_compute_fuses(gt);
+ 	check_gsc_availability(gt);
++	check_sw_disable(gt);
+ 
+ 	BUILD_BUG_ON(XE_HW_ENGINE_PREEMPT_TIMEOUT < XE_HW_ENGINE_PREEMPT_TIMEOUT_MIN);
+ 	BUILD_BUG_ON(XE_HW_ENGINE_PREEMPT_TIMEOUT > XE_HW_ENGINE_PREEMPT_TIMEOUT_MAX);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Convert-fused-off-messages-to-be-gt-based.patch
+++ b/backport/patches/base/0001-drm-xe-Convert-fused-off-messages-to-be-gt-based.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 28 May 2025 14:54:05 -0700
+Subject: drm/xe: Convert "fused off" messages to be gt-based
+
+It's useful to see in the log message what GT was being checked for
+disabled/fused-off engines. Especially on multi-tile platforms the
+different tiles may be fused differently making it harder to parse
+the information.
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250528-engine-mask-v4-2-f4636d2a890a@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry-picked from commit 2b0ef1f7a2980bf0c5589ff42806eee2d55ea8e6 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_hw_engine.c | 17 ++++++-----------
+ 1 file changed, 6 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
+index 042aba206509..82904e351e7b 100644
+--- a/drivers/gpu/drm/xe/xe_hw_engine.c
++++ b/drivers/gpu/drm/xe/xe_hw_engine.c
+@@ -661,7 +661,7 @@ static void read_media_fuses(struct xe_gt *gt)
+ 
+ 		if (!(BIT(j) & vdbox_mask)) {
+ 			gt->info.engine_mask &= ~BIT(i);
+-			drm_info(&xe->drm, "vcs%u fused off\n", j);
++			xe_gt_info(gt, "vcs%u fused off\n", j);
+ 		}
+ 	}
+ 
+@@ -671,7 +671,7 @@ static void read_media_fuses(struct xe_gt *gt)
+ 
+ 		if (!(BIT(j) & vebox_mask)) {
+ 			gt->info.engine_mask &= ~BIT(i);
+-			drm_info(&xe->drm, "vecs%u fused off\n", j);
++			xe_gt_info(gt, "vecs%u fused off\n", j);
+ 		}
+ 	}
+ }
+@@ -696,15 +696,13 @@ static void read_copy_fuses(struct xe_gt *gt)
+ 
+ 		if (!(BIT(j / 2) & bcs_mask)) {
+ 			gt->info.engine_mask &= ~BIT(i);
+-			drm_info(&xe->drm, "bcs%u fused off\n", j);
++			xe_gt_info(gt, "bcs%u fused off\n", j);
+ 		}
+ 	}
+ }
+ 
+ static void read_compute_fuses_from_dss(struct xe_gt *gt)
+ {
+-	struct xe_device *xe = gt_to_xe(gt);
+-
+ 	/*
+ 	 * CCS fusing based on DSS masks only applies to platforms that can
+ 	 * have more than one CCS.
+@@ -723,14 +721,13 @@ static void read_compute_fuses_from_dss(struct xe_gt *gt)
+ 
+ 		if (!xe_gt_topology_has_dss_in_quadrant(gt, j)) {
+ 			gt->info.engine_mask &= ~BIT(i);
+-			drm_info(&xe->drm, "ccs%u fused off\n", j);
++			xe_gt_info(gt, "ccs%u fused off\n", j);
+ 		}
+ 	}
+ }
+ 
+ static void read_compute_fuses_from_reg(struct xe_gt *gt)
+ {
+-	struct xe_device *xe = gt_to_xe(gt);
+ 	u32 ccs_mask;
+ 
+ 	ccs_mask = xe_mmio_read32(&gt->mmio, XEHP_FUSE4);
+@@ -742,7 +739,7 @@ static void read_compute_fuses_from_reg(struct xe_gt *gt)
+ 
+ 		if ((ccs_mask & BIT(j)) == 0) {
+ 			gt->info.engine_mask &= ~BIT(i);
+-			drm_info(&xe->drm, "ccs%u fused off\n", j);
++			xe_gt_info(gt, "ccs%u fused off\n", j);
+ 		}
+ 	}
+ }
+@@ -757,8 +754,6 @@ static void read_compute_fuses(struct xe_gt *gt)
+ 
+ static void check_gsc_availability(struct xe_gt *gt)
+ {
+-	struct xe_device *xe = gt_to_xe(gt);
+-
+ 	if (!(gt->info.engine_mask & BIT(XE_HW_ENGINE_GSCCS0)))
+ 		return;
+ 
+@@ -774,7 +769,7 @@ static void check_gsc_availability(struct xe_gt *gt)
+ 		xe_mmio_write32(&gt->mmio, GUNIT_GSC_INTR_ENABLE, 0);
+ 		xe_mmio_write32(&gt->mmio, GUNIT_GSC_INTR_MASK, ~0);
+ 
+-		drm_dbg(&xe->drm, "GSC FW not used, disabling gsccs\n");
++		xe_gt_dbg(gt, "GSC FW not used, disabling gsccs\n");
+ 	}
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-configfs-Add-attribute-to-disable-engines.patch
+++ b/backport/patches/base/0001-drm-xe-configfs-Add-attribute-to-disable-engines.patch
@@ -1,0 +1,238 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 28 May 2025 14:54:07 -0700
+Subject: drm/xe/configfs: Add attribute to disable engines
+
+Add the userspace interface to load the driver with fewer engines.
+The syntax is to just echo the engine names to a file in configfs, like
+below:
+
+	echo 'rcs0,bcs0' > /sys/kernel/config/xe/<bdf>/engine_allowed
+
+With that engines other than rcs0 and bcs0 will not be enabled. To
+enable all instances from a class, a '*' can be used.
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250528-engine-mask-v4-4-f4636d2a890a@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry-picked from commit d09bc3edfe5c702463e2640314b7db2219242446 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_configfs.c | 149 ++++++++++++++++++++++++++++++-
+ 1 file changed, 147 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_configfs.c b/drivers/gpu/drm/xe/xe_configfs.c
+index 8320d57ef5a8..8ec1ff1e4e80 100644
+--- a/drivers/gpu/drm/xe/xe_configfs.c
++++ b/drivers/gpu/drm/xe/xe_configfs.c
+@@ -3,14 +3,19 @@
+  * Copyright © 2025 Intel Corporation
+  */
+ 
++#include <linux/bitops.h>
+ #include <linux/configfs.h>
++#include <linux/find.h>
+ #include <linux/init.h>
+ #include <linux/module.h>
+ #include <linux/pci.h>
++#include <linux/string.h>
+ 
+ #include "xe_configfs.h"
+ #include "xe_module.h"
+ 
++#include "xe_hw_engine_types.h"
++
+ /**
+  * DOC: Xe Configfs
+  *
+@@ -48,6 +53,30 @@
+  *	# echo 1 > /sys/kernel/config/xe/0000:03:00.0/survivability_mode
+  *	# echo 0000:03:00.0 > /sys/bus/pci/drivers/xe/bind  (Enters survivability mode if supported)
+  *
++ * Allowed engines:
++ * ----------------
++ *
++ * Allow only a set of engine(s) to be available, disabling the other engines
++ * even if they are available in hardware. This is applied after HW fuses are
++ * considered on each tile. Examples:
++ *
++ * Allow only one render and one copy engines, nothing else::
++ *
++ *	# echo 'rcs0,bcs0' > /sys/kernel/config/xe/0000:03:00.0/engines_allowed
++ *
++ * Allow only compute engines and first copy engine::
++ *
++ *	# echo 'ccs*,bcs0' > /sys/kernel/config/xe/0000:03:00.0/engines_allowed
++ *
++ * Note that the engine names are the per-GT hardware names. On multi-tile
++ * platforms, writing ``rcs0,bcs0`` to this file would allow the first render
++ * and copy engines on each tile.
++ *
++ * The requested configuration may not be supported by the platform and driver
++ * may fail to probe. For example: if at least one copy engine is expected to be
++ * available for migrations, but it's disabled. This is intended for debugging
++ * purposes only.
++ *
+  * Remove devices
+  * ==============
+  *
+@@ -60,11 +89,30 @@ struct xe_config_device {
+ 	struct config_group group;
+ 
+ 	bool survivability_mode;
++	u64 engines_allowed;
+ 
+ 	/* protects attributes */
+ 	struct mutex lock;
+ };
+ 
++struct engine_info {
++	const char *cls;
++	u64 mask;
++};
++
++/* Some helpful macros to aid on the sizing of buffer allocation when parsing */
++#define MAX_ENGINE_CLASS_CHARS 5
++#define MAX_ENGINE_INSTANCE_CHARS 2
++
++static const struct engine_info engine_info[] = {
++	{ .cls = "rcs", .mask = XE_HW_ENGINE_RCS_MASK },
++	{ .cls = "bcs", .mask = XE_HW_ENGINE_BCS_MASK },
++	{ .cls = "vcs", .mask = XE_HW_ENGINE_VCS_MASK },
++	{ .cls = "vecs", .mask = XE_HW_ENGINE_VECS_MASK },
++	{ .cls = "ccs", .mask = XE_HW_ENGINE_CCS_MASK },
++	{ .cls = "gsccs", .mask = XE_HW_ENGINE_GSCCS_MASK },
++};
++
+ static struct xe_config_device *to_xe_config_device(struct config_item *item)
+ {
+ 	return container_of(to_config_group(item), struct xe_config_device, group);
+@@ -94,10 +142,96 @@ static ssize_t survivability_mode_store(struct config_item *item, const char *pa
+ 	return len;
+ }
+ 
++static ssize_t engines_allowed_show(struct config_item *item, char *page)
++{
++	struct xe_config_device *dev = to_xe_config_device(item);
++	char *p = page;
++
++	for (size_t i = 0; i < ARRAY_SIZE(engine_info); i++) {
++		u64 mask = engine_info[i].mask;
++
++		if ((dev->engines_allowed & mask) == mask) {
++			p += sprintf(p, "%s*\n", engine_info[i].cls);
++		} else if (mask & dev->engines_allowed) {
++			u16 bit0 = __ffs64(mask), bit;
++
++			mask &= dev->engines_allowed;
++
++			for_each_set_bit(bit, (const unsigned long *)&mask, 64)
++				p += sprintf(p, "%s%u\n", engine_info[i].cls,
++					     bit - bit0);
++		}
++	}
++
++	return p - page;
++}
++
++static bool lookup_engine_mask(const char *pattern, u64 *mask)
++{
++	for (size_t i = 0; i < ARRAY_SIZE(engine_info); i++) {
++		u8 instance;
++		u16 bit;
++
++		if (!str_has_prefix(pattern, engine_info[i].cls))
++			continue;
++
++		pattern += strlen(engine_info[i].cls);
++
++		if (!strcmp(pattern, "*")) {
++			*mask = engine_info[i].mask;
++			return true;
++		}
++
++		if (kstrtou8(pattern, 10, &instance))
++			return false;
++
++		bit = __ffs64(engine_info[i].mask) + instance;
++		if (bit >= fls64(engine_info[i].mask))
++			return false;
++
++		*mask = BIT_ULL(bit);
++		return true;
++	}
++
++	return false;
++}
++
++static ssize_t engines_allowed_store(struct config_item *item, const char *page,
++				     size_t len)
++{
++	struct xe_config_device *dev = to_xe_config_device(item);
++	size_t patternlen, p;
++	u64 mask, val = 0;
++
++	for (p = 0; p < len; p += patternlen + 1) {
++		char buf[MAX_ENGINE_CLASS_CHARS + MAX_ENGINE_INSTANCE_CHARS + 1];
++
++		patternlen = strcspn(page + p, ",\n");
++		if (patternlen >= sizeof(buf))
++			return -EINVAL;
++
++		memcpy(buf, page + p, patternlen);
++		buf[patternlen] = '\0';
++
++		if (!lookup_engine_mask(buf, &mask))
++			return -EINVAL;
++
++		val |= mask;
++	}
++
++	mutex_lock(&dev->lock);
++	dev->engines_allowed = val;
++	mutex_unlock(&dev->lock);
++
++	return len;
++}
++
+ CONFIGFS_ATTR(, survivability_mode);
++CONFIGFS_ATTR(, engines_allowed);
+ 
+ static struct configfs_attribute *xe_config_device_attrs[] = {
+ 	&attr_survivability_mode,
++	&attr_engines_allowed,
+ 	NULL,
+ };
+ 
+@@ -139,6 +273,9 @@ static struct config_group *xe_config_make_device_group(struct config_group *gro
+ 	if (!dev)
+ 		return ERR_PTR(-ENOMEM);
+ 
++	/* Default values */
++	dev->engines_allowed = U64_MAX;
++
+ 	config_group_init_type_name(&dev->group, name, &xe_config_device_type);
+ 
+ 	mutex_init(&dev->lock);
+@@ -237,8 +374,16 @@ void xe_configfs_clear_survivability_mode(struct pci_dev *pdev)
+  */
+ u64 xe_configfs_get_engines_allowed(struct pci_dev *pdev)
+ {
+-	/* dummy implementation */
+-	return U64_MAX;
++	struct xe_config_device *dev = configfs_find_group(pdev);
++	u64 engines_allowed;
++
++	if (!dev)
++		return U64_MAX;
++
++	engines_allowed = dev->engines_allowed;
++	config_item_put(&dev->group.cg_item);
++
++	return engines_allowed;
+ }
+ 
+ int __init xe_configfs_init(void)
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-configfs-Add-internal-API-to-documentation.patch
+++ b/backport/patches/base/0001-drm-xe-configfs-Add-internal-API-to-documentation.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 28 May 2025 14:54:08 -0700
+Subject: drm/xe/configfs: Add internal API to documentation
+
+Add the internal configfs API like is done with other parts of the
+driver. Also ensure the correct number of '=' chars are used for the
+header.
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250528-engine-mask-v4-5-f4636d2a890a@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry-picked from commit 399c5f54090c1c7d8f9eae7897940e8a11604884 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ Documentation/gpu/xe/xe_configfs.rst | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/gpu/xe/xe_configfs.rst b/Documentation/gpu/xe/xe_configfs.rst
+index 9b9d941eb20e..7f8ec39dc6dd 100644
+--- a/Documentation/gpu/xe/xe_configfs.rst
++++ b/Documentation/gpu/xe/xe_configfs.rst
+@@ -2,9 +2,15 @@
+ 
+ .. _xe_configfs:
+ 
+-============
++===========
+ Xe Configfs
+-============
++===========
+ 
+ .. kernel-doc:: drivers/gpu/drm/xe/xe_configfs.c
+    :doc: Xe Configfs
++
++Internal API
++============
++
++.. kernel-doc:: drivers/gpu/drm/xe/xe_configfs.c
++   :internal:
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-configfs-Drop-trailing-semicolons.patch
+++ b/backport/patches/base/0001-drm-xe-configfs-Drop-trailing-semicolons.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Wed, 28 May 2025 14:54:04 -0700
+Subject: drm/xe/configfs: Drop trailing semicolons
+
+Drop the semicolons from the dummy implementation: they shouldn't be
+there.
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://lore.kernel.org/r/20250528-engine-mask-v4-1-f4636d2a890a@intel.com
+Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
+(cherry-picked from commit d8636cce7a1c81b67ee1fcfd03fe8397e0101a32 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_configfs.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_configfs.h b/drivers/gpu/drm/xe/xe_configfs.h
+index d7d041ec2611..ef6d231b3024 100644
+--- a/drivers/gpu/drm/xe/xe_configfs.h
++++ b/drivers/gpu/drm/xe/xe_configfs.h
+@@ -15,10 +15,10 @@ void xe_configfs_exit(void);
+ bool xe_configfs_get_survivability_mode(struct pci_dev *pdev);
+ void xe_configfs_clear_survivability_mode(struct pci_dev *pdev);
+ #else
+-static inline int xe_configfs_init(void) { return 0; };
+-static inline void xe_configfs_exit(void) {};
+-static inline bool xe_configfs_get_survivability_mode(struct pci_dev *pdev) { return false; };
+-static inline void xe_configfs_clear_survivability_mode(struct pci_dev *pdev) {};
++static inline int xe_configfs_init(void) { return 0; }
++static inline void xe_configfs_exit(void) { }
++static inline bool xe_configfs_get_survivability_mode(struct pci_dev *pdev) { return false; }
++static inline void xe_configfs_clear_survivability_mode(struct pci_dev *pdev) { }
+ #endif
+ 
+ #endif
+-- 
+2.43.0
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
@@ -2321,12 +2321,12 @@ index bb8f881b5503..cbfa051f274a 100644
  	xe_vm_put(vm);
  }
 diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
-index b6de0312894f..042aba206509 100644
+index 45156d1a320c..536cb7ff261a 100644
 --- a/drivers/gpu/drm/xe/xe_hw_engine.c
 +++ b/drivers/gpu/drm/xe/xe_hw_engine.c
-@@ -16,7 +16,7 @@
- #include "xe_assert.h"
+@@ -17,7 +17,7 @@
  #include "xe_bo.h"
+ #include "xe_configfs.h"
  #include "xe_device.h"
 -#include "xe_eudebug.h"
 +#include "prelim/xe_eudebug.h"

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-hw-enablement-for-eudebug.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-hw-enablement-for-eudebug.patch
@@ -28,7 +28,7 @@ Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
  6 files changed, 70 insertions(+)
 
 diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
-index db2d7bd7e..e190d16fc 100644
+index 38984c67f543..fba725bee914 100644
 --- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 @@ -120,6 +120,10 @@
@@ -43,7 +43,7 @@ index db2d7bd7e..e190d16fc 100644
  #define RING_BBADDR_UDW(base)			XE_REG((base) + 0x168)
  
 diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
-index 1f149ba7e..dbc01463c 100644
+index 1f149ba7e5e9..dbc01463c09e 100644
 --- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
 @@ -473,6 +473,14 @@
@@ -76,7 +76,7 @@ index 1f149ba7e..dbc01463c 100644
  #define   DISABLE_TDL_SVHS_GATING		REG_BIT(1)
  #define   DISABLE_DOP_GATING			REG_BIT(0)
 diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
-index cbcf7a72f..fecb7c8a9 100644
+index cbcf7a72fdba..fecb7c8a9779 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.c
 +++ b/drivers/gpu/drm/xe/xe_eudebug.c
 @@ -10,13 +10,21 @@
@@ -150,7 +150,7 @@ index cbcf7a72f..fecb7c8a9 100644
  {
  	spin_lock_init(&xe->eudebug.lock);
 diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
-index 326ddbd50..3cd6bc7bb 100644
+index 326ddbd50651..3cd6bc7bb682 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.h
 +++ b/drivers/gpu/drm/xe/xe_eudebug.h
 @@ -11,6 +11,7 @@ struct xe_device;
@@ -178,18 +178,18 @@ index 326ddbd50..3cd6bc7bb 100644
  static inline void xe_eudebug_file_open(struct xe_file *xef) { }
  static inline void xe_eudebug_file_close(struct xe_file *xef) { }
 diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
-index b26b6fb5c..a2bc42a94 100644
+index 7020c8e536e6..a9bcff5666c0 100644
 --- a/drivers/gpu/drm/xe/xe_hw_engine.c
 +++ b/drivers/gpu/drm/xe/xe_hw_engine.c
-@@ -16,6 +16,7 @@
- #include "xe_assert.h"
+@@ -17,6 +17,7 @@
  #include "xe_bo.h"
+ #include "xe_configfs.h"
  #include "xe_device.h"
 +#include "xe_eudebug.h"
  #include "xe_execlist.h"
  #include "xe_force_wake.h"
  #include "xe_gsc.h"
-@@ -559,6 +560,7 @@ static void hw_engine_init_early(struct xe_gt *gt, struct xe_hw_engine *hwe,
+@@ -560,6 +561,7 @@ static void hw_engine_init_early(struct xe_gt *gt, struct xe_hw_engine *hwe,
  	xe_tuning_process_engine(hwe);
  	xe_wa_process_engine(hwe);
  	hw_engine_setup_default_state(hwe);
@@ -198,7 +198,7 @@ index b26b6fb5c..a2bc42a94 100644
  	xe_reg_sr_init(&hwe->reg_whitelist, hwe->name, gt_to_xe(gt));
  	xe_reg_whitelist_process_engine(hwe);
 diff --git a/drivers/gpu/drm/xe/xe_wa_oob.rules b/drivers/gpu/drm/xe/xe_wa_oob.rules
-index ab5a4be2b..2c986715a 100644
+index a697bcbebee5..a115a32bd26c 100644
 --- a/drivers/gpu/drm/xe/xe_wa_oob.rules
 +++ b/drivers/gpu/drm/xe/xe_wa_oob.rules
 @@ -41,6 +41,8 @@

--- a/series
+++ b/series
@@ -74,6 +74,11 @@ backport/patches/base/0001-drm-xe-nvm-add-on-die-non-volatile-memory-device.patc
 backport/patches/base/0001-drm-xe-nvm-add-support-for-access-mode.patch
 backport/patches/base/0001-drm-xe-nvm-add-support-for-non-posted-erase.patch
 backport/patches/base/0001-drm-xe-xe_debugfs-Exposure-of-G-State-and-pcie-link-.patch
+backport/patches/base/0001-drm-xe-configfs-Drop-trailing-semicolons.patch
+backport/patches/base/0001-drm-xe-Convert-fused-off-messages-to-be-gt-based.patch
+backport/patches/base/0001-drm-xe-Allow-to-disable-engines.patch
+backport/patches/base/0001-drm-xe-configfs-Add-attribute-to-disable-engines.patch
+backport/patches/base/0001-drm-xe-configfs-Add-internal-API-to-documentation.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Introduce support to selectively disable engines for targeted debugging and
early enabling scenarios. Engines can now be disabled in software, in addition
to hardware fuse checks. A new configfs interface is added to allow userspace
to control which engines are enabled:

    echo 'rcs0,bcs0' > /sys/kernel/config/xe/<bdf>/engine_allowed

This enables only the specified engines, while others remain disabled. A '*'
can be used to enable all instances of a class.

Additionally:
 - Converted "fused off" messages to be GT-based for better multi-tile logging.
 - Added internal configfs API documentation and corrected header formatting.
 - Dropped unnecessary semicolons from dummy configfs implementations.

Included patches:
 - drm/xe/configfs: Add internal API to documentation
 - drm/xe/configfs: Add attribute to disable engines
 - drm/xe: Allow to disable engines
 - drm/xe: Convert "fused off" messages to be gt-based
 - drm/xe/configfs: Drop trailing semicolons

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>