### PR TITLE
backport/base: Initialize data0 in pcode read routine

### DIFF
--- a/backport/patches/base/0001-drm-xe-pcode-Initialize-data0-for-pcode-read-routine.patch
+++ b/backport/patches/base/0001-drm-xe-pcode-Initialize-data0-for-pcode-read-routine.patch
@@ -1,0 +1,134 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stuart Summers <stuart.summers@intel.com>
+Date: Tue, 19 Aug 2025 20:10:54 +0000
+Subject: drm/xe/pcode: Initialize data0 for pcode read routine
+
+There are two registers filled in when reading data from
+pcode besides the mailbox itself. Currently, we allow a NULL
+value for the second of these two (data1) and assume the first
+is defined. However, many of the routines that are calling
+this function assume that pcode will ignore the value being
+passed in and so leave that first value (data0) defined but
+uninitialized. To be safe, make sure this value is always
+initialized to something (0 generally) in the event pcode
+behavior changes and starts using this value.
+
+v2: Fix sob/author
+
+Signed-off-by: Stuart Summers <stuart.summers@intel.com>
+Reviewed-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Link: https://lore.kernel.org/r/20250819201054.393220-1-stuart.summers@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit 2515d2b9ab4108c11a0b23935e68de27abb8b2a7 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device_sysfs.c | 8 ++++----
+ drivers/gpu/drm/xe/xe_hwmon.c        | 8 ++++----
+ drivers/gpu/drm/xe/xe_vram_freq.c    | 4 ++--
+ 3 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device_sysfs.c b/drivers/gpu/drm/xe/xe_device_sysfs.c
+index c83c5fda5583..0edd334ba8f4 100644
+--- a/drivers/gpu/drm/xe/xe_device_sysfs.c
++++ b/drivers/gpu/drm/xe/xe_device_sysfs.c
+@@ -76,7 +76,7 @@ lb_fan_control_version_show(struct device *dev, struct device_attribute *attr, c
+ {
+ 	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
+ 	struct xe_tile *root = xe_device_get_root_tile(xe);
+-	u32 cap, ver_low = FAN_TABLE, ver_high = FAN_TABLE;
++	u32 cap = 0, ver_low = FAN_TABLE, ver_high = FAN_TABLE;
+ 	u16 major = 0, minor = 0, hotfix = 0, build = 0;
+ 	int ret;
+ 
+@@ -115,7 +115,7 @@ lb_voltage_regulator_version_show(struct device *dev, struct device_attribute *a
+ {
+ 	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
+ 	struct xe_tile *root = xe_device_get_root_tile(xe);
+-	u32 cap, ver_low = VR_CONFIG, ver_high = VR_CONFIG;
++	u32 cap = 0, ver_low = VR_CONFIG, ver_high = VR_CONFIG;
+ 	u16 major = 0, minor = 0, hotfix = 0, build = 0;
+ 	int ret;
+ 
+@@ -153,7 +153,7 @@ static int late_bind_create_files(struct device *dev)
+ {
+ 	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
+ 	struct xe_tile *root = xe_device_get_root_tile(xe);
+-	u32 cap;
++	u32 cap = 0;
+ 	int ret;
+ 
+ 	xe_pm_runtime_get(xe);
+@@ -186,7 +186,7 @@ static void late_bind_remove_files(struct device *dev)
+ {
+ 	struct xe_device *xe = pdev_to_xe_device(to_pci_dev(dev));
+ 	struct xe_tile *root = xe_device_get_root_tile(xe);
+-	u32 cap;
++	u32 cap = 0;
+ 	int ret;
+ 
+ 	xe_pm_runtime_get(xe);
+diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
+index f2e4f4d1500c..3e87a2badf05 100644
+--- a/drivers/gpu/drm/xe/xe_hwmon.c
++++ b/drivers/gpu/drm/xe/xe_hwmon.c
+@@ -176,7 +176,7 @@ static int xe_hwmon_pcode_rmw_power_limit(const struct xe_hwmon *hwmon, u32 attr
+ 					  u32 clr, u32 set)
+ {
+ 	struct xe_tile *root_tile = xe_device_get_root_tile(hwmon->xe);
+-	u32 val0, val1;
++	u32 val0 = 0, val1 = 0;
+ 	int ret = 0;
+ 
+ 	ret = xe_pcode_read(root_tile, PCODE_MBOX(PCODE_POWER_SETUP,
+@@ -718,7 +718,7 @@ static int xe_hwmon_power_curr_crit_read(struct xe_hwmon *hwmon, int channel,
+ 					 long *value, u32 scale_factor)
+ {
+ 	int ret;
+-	u32 uval;
++	u32 uval = 0;
+ 
+ 	mutex_lock(&hwmon->hwmon_lock);
+ 
+@@ -872,7 +872,7 @@ xe_hwmon_power_write(struct xe_hwmon *hwmon, u32 attr, int channel, long val)
+ static umode_t
+ xe_hwmon_curr_is_visible(const struct xe_hwmon *hwmon, u32 attr, int channel)
+ {
+-	u32 uval;
++	u32 uval = 0;
+ 
+ 	/* hwmon sysfs attribute of current available only for package */
+ 	if (channel != CHANNEL_PKG)
+@@ -974,7 +974,7 @@ xe_hwmon_energy_read(struct xe_hwmon *hwmon, u32 attr, int channel, long *val)
+ static umode_t
+ xe_hwmon_fan_is_visible(struct xe_hwmon *hwmon, u32 attr, int channel)
+ {
+-	u32 uval;
++	u32 uval = 0;
+ 
+ 	if (!hwmon->xe->info.has_fan_control)
+ 		return 0;
+diff --git a/drivers/gpu/drm/xe/xe_vram_freq.c b/drivers/gpu/drm/xe/xe_vram_freq.c
+index b26e26d73dae..17bc84da4cdc 100644
+--- a/drivers/gpu/drm/xe/xe_vram_freq.c
++++ b/drivers/gpu/drm/xe/xe_vram_freq.c
+@@ -34,7 +34,7 @@ static ssize_t max_freq_show(struct device *dev, struct device_attribute *attr,
+ 			     char *buf)
+ {
+ 	struct xe_tile *tile = dev_to_tile(dev);
+-	u32 val, mbox;
++	u32 val = 0, mbox;
+ 	int err;
+ 
+ 	mbox = REG_FIELD_PREP(PCODE_MB_COMMAND, PCODE_FREQUENCY_CONFIG)
+@@ -56,7 +56,7 @@ static ssize_t min_freq_show(struct device *dev, struct device_attribute *attr,
+ 			     char *buf)
+ {
+ 	struct xe_tile *tile = dev_to_tile(dev);
+-	u32 val, mbox;
++	u32 val = 0, mbox;
+ 	int err;
+ 
+ 	mbox = REG_FIELD_PREP(PCODE_MB_COMMAND, PCODE_FREQUENCY_CONFIG)
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -75,6 +75,7 @@ backport/patches/base/0001-drm-xe-nvm-add-support-for-access-mode.patch
 backport/patches/base/0001-drm-xe-nvm-add-support-for-non-posted-erase.patch
 backport/patches/base/0001-drm-xe-xe_debugfs-Exposure-of-G-State-and-pcie-link-.patch
 backport/patches/base/0001-drm-xe-debugfs-Don-t-expose-dgfx-residencies-attribu.patch
+backport/patches/base/0001-drm-xe-pcode-Initialize-data0-for-pcode-read-routine.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Ensure data0 is always initialized to 0 before reading from pcode,
avoiding potential issues if pcode starts using this value.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>