### PR TITLE
backport/sriov: OA and VF/PF improvements

### DIFF
--- a/backport/patches/features/sriov/0001-drm-xe-Combine-PF-and-VF-device-data-into-union.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Combine-PF-and-VF-device-data-into-union.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Sun, 13 Jul 2025 12:36:19 +0200
+Subject: drm/xe: Combine PF and VF device data into union
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+There is no need to keep PF and VF data fields fully separate
+since we can be only in one mode at the time. Move them into
+a anonymous union to save few bytes.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://lore.kernel.org/r/20250713103625.1964-2-michal.wajdeczko@intel.com
+(cherry-picked from commit 7dcae5288a0967493ba1b15e8194cb6bfb1a23ca linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device_types.h | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index 69813b71edd1..7cd34399fbd4 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -398,10 +398,12 @@ struct xe_device {
+ 		/** @sriov.__mode: SR-IOV mode (Don't access directly!) */
+ 		enum xe_sriov_mode __mode;
+ 
+-		/** @sriov.pf: PF specific data */
+-		struct xe_device_pf pf;
+-		/** @sriov.vf: VF specific data */
+-		struct xe_device_vf vf;
++		union {
++			/** @sriov.pf: PF specific data */
++			struct xe_device_pf pf;
++			/** @sriov.vf: VF specific data */
++			struct xe_device_vf vf;
++		};
+ 
+ 		/** @sriov.wq: workqueue used by the virtualization workers */
+ 		struct workqueue_struct *wq;
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-Introduce-xe_gt_is_main_type-helper.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Introduce-xe_gt_is_main_type-helper.patch
@@ -1,0 +1,393 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Sun, 13 Jul 2025 12:36:22 +0200
+Subject: drm/xe: Introduce xe_gt_is_main_type helper
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Instead of checking for not being a media type GT provide a small
+helper to explicitly express our intentions.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://lore.kernel.org/r/20250713103625.1964-5-michal.wajdeczko@intel.com
+(backported from commit ffab82b062a8e75f8877de363c9e203be7a241a7 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_bb.c                  |  2 +-
+ drivers/gpu/drm/xe/xe_force_wake.c          |  2 +-
+ drivers/gpu/drm/xe/xe_gt.c                  | 12 ++++-----
+ drivers/gpu/drm/xe/xe_gt.h                  |  5 ++++
+ drivers/gpu/drm/xe/xe_gt_idle.c             |  2 +-
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c  | 30 ++++++++++-----------
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c |  4 +--
+ drivers/gpu/drm/xe/xe_gt_sriov_vf.c         |  9 ++++---
+ drivers/gpu/drm/xe/xe_irq.c                 |  4 +--
+ drivers/gpu/drm/xe/xe_oa.c                  |  6 ++---
+ 10 files changed, 41 insertions(+), 35 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_bb.c b/drivers/gpu/drm/xe/xe_bb.c
+index 9570672fce33..5ce0e26822f2 100644
+--- a/drivers/gpu/drm/xe/xe_bb.c
++++ b/drivers/gpu/drm/xe/xe_bb.c
+@@ -19,7 +19,7 @@ static int bb_prefetch(struct xe_gt *gt)
+ {
+ 	struct xe_device *xe = gt_to_xe(gt);
+ 
+-	if (GRAPHICS_VERx100(xe) >= 1250 && !xe_gt_is_media_type(gt))
++	if (GRAPHICS_VERx100(xe) >= 1250 && xe_gt_is_main_type(gt))
+ 		/*
+ 		 * RCS and CCS require 1K, although other engines would be
+ 		 * okay with 512.
+diff --git a/drivers/gpu/drm/xe/xe_force_wake.c b/drivers/gpu/drm/xe/xe_force_wake.c
+index 4f6784e5abf8..73ba94d7e9f8 100644
+--- a/drivers/gpu/drm/xe/xe_force_wake.c
++++ b/drivers/gpu/drm/xe/xe_force_wake.c
+@@ -70,7 +70,7 @@ void xe_force_wake_init_engines(struct xe_gt *gt, struct xe_force_wake *fw)
+ 	/* Assuming gen11+ so assert this assumption is correct */
+ 	xe_gt_assert(gt, GRAPHICS_VER(gt_to_xe(gt)) >= 11);
+ 
+-	if (!xe_gt_is_media_type(gt))
++	if (xe_gt_is_main_type(gt))
+ 		init_domain(fw, XE_FW_DOMAIN_ID_RENDER,
+ 			    FORCEWAKE_RENDER,
+ 			    FORCEWAKE_ACK_RENDER);
+diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
+index 7df902465eaf..b74fe5e5a7c6 100644
+--- a/drivers/gpu/drm/xe/xe_gt.c
++++ b/drivers/gpu/drm/xe/xe_gt.c
+@@ -111,7 +111,7 @@ static void xe_gt_enable_host_l2_vram(struct xe_gt *gt)
+ 	if (!fw_ref)
+ 		return;
+ 
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		reg = xe_gt_mcr_unicast_read_any(gt, XE2_GAMREQSTRM_CTRL);
+ 		reg |= CG_DIS_CNTLBUS;
+ 		xe_gt_mcr_multicast_write(gt, XE2_GAMREQSTRM_CTRL, reg);
+@@ -461,7 +461,7 @@ static int gt_fw_domain_init(struct xe_gt *gt)
+ 		goto err_hw_fence_irq;
+ 	}
+ 
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		err = xe_ggtt_init(gt_to_tile(gt)->mem.ggtt);
+ 		if (err)
+ 			goto err_force_wake;
+@@ -540,7 +540,7 @@ static int all_fw_domain_init(struct xe_gt *gt)
+ 	if (err)
+ 		goto err_force_wake;
+ 
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		/*
+ 		 * USM has its only SA pool to non-block behind user operations
+ 		 */
+@@ -556,7 +556,7 @@ static int all_fw_domain_init(struct xe_gt *gt)
+ 		}
+ 	}
+ 
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		struct xe_tile *tile = gt_to_tile(gt);
+ 
+ 		tile->migrate = xe_migrate_init(tile);
+@@ -576,7 +576,7 @@ static int all_fw_domain_init(struct xe_gt *gt)
+ 		xe_gt_apply_ccs_mode(gt);
+ 	}
+ 
+-	if (IS_SRIOV_PF(gt_to_xe(gt)) && !xe_gt_is_media_type(gt))
++	if (IS_SRIOV_PF(gt_to_xe(gt)) && xe_gt_is_main_type(gt))
+ 		xe_lmtt_init_hw(&gt_to_tile(gt)->sriov.pf.lmtt);
+ 
+ 	if (IS_SRIOV_PF(gt_to_xe(gt))) {
+@@ -792,7 +792,7 @@ static int do_gt_restart(struct xe_gt *gt)
+ 	if (err)
+ 		return err;
+ 
+-	if (IS_SRIOV_PF(gt_to_xe(gt)) && !xe_gt_is_media_type(gt))
++	if (IS_SRIOV_PF(gt_to_xe(gt)) && xe_gt_is_main_type(gt))
+ 		xe_lmtt_init_hw(&gt_to_tile(gt)->sriov.pf.lmtt);
+ 
+ 	if (IS_SRIOV_PF(gt_to_xe(gt)))
+diff --git a/drivers/gpu/drm/xe/xe_gt.h b/drivers/gpu/drm/xe/xe_gt.h
+index e504cc33ade4..b721a5175864 100644
+--- a/drivers/gpu/drm/xe/xe_gt.h
++++ b/drivers/gpu/drm/xe/xe_gt.h
+@@ -108,6 +108,11 @@ static inline bool xe_gt_has_indirect_ring_state(struct xe_gt *gt)
+ 	       xe_device_uc_enabled(gt_to_xe(gt));
+ }
+ 
++static inline bool xe_gt_is_main_type(struct xe_gt *gt)
++{
++	return gt->info.type == XE_GT_TYPE_MAIN;
++}
++
+ static inline bool xe_gt_is_media_type(struct xe_gt *gt)
+ {
+ 	return gt->info.type == XE_GT_TYPE_MEDIA;
+diff --git a/drivers/gpu/drm/xe/xe_gt_idle.c b/drivers/gpu/drm/xe/xe_gt_idle.c
+index fbbace7b0b12..be15b28a2277 100644
+--- a/drivers/gpu/drm/xe/xe_gt_idle.c
++++ b/drivers/gpu/drm/xe/xe_gt_idle.c
+@@ -121,7 +121,7 @@ void xe_gt_idle_enable_pg(struct xe_gt *gt)
+ 	if (vcs_mask || vecs_mask)
+ 		gtidle->powergate_enable = MEDIA_POWERGATE_ENABLE;
+ 
+-	if (!xe_gt_is_media_type(gt))
++	if (xe_gt_is_main_type(gt))
+ 		gtidle->powergate_enable |= RENDER_POWERGATE_ENABLE;
+ 
+ 	if (xe->info.platform != XE_DG1) {
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 7b44a162ac01..e142fea8041c 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -376,7 +376,7 @@ static u64 pf_get_spare_ggtt(struct xe_gt *gt)
+ {
+ 	u64 spare;
+ 
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
+@@ -388,7 +388,7 @@ static u64 pf_get_spare_ggtt(struct xe_gt *gt)
+ 
+ static int pf_set_spare_ggtt(struct xe_gt *gt, u64 size)
+ {
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
+@@ -443,7 +443,7 @@ static int pf_provision_vf_ggtt(struct xe_gt *gt, unsigned int vfid, u64 size)
+ 	int err;
+ 
+ 	xe_gt_assert(gt, vfid);
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+ 
+ 	size = round_up(size, alignment);
+@@ -492,7 +492,7 @@ static u64 pf_get_vf_config_ggtt(struct xe_gt *gt, unsigned int vfid)
+ 	struct xe_gt_sriov_config *config = pf_pick_vf_config(gt, vfid);
+ 	struct xe_ggtt_node *node = config->ggtt_region;
+ 
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 	return xe_ggtt_node_allocated(node) ? node->base.size : 0;
+ }
+ 
+@@ -560,7 +560,7 @@ int xe_gt_sriov_pf_config_set_ggtt(struct xe_gt *gt, unsigned int vfid, u64 size
+ {
+ 	int err;
+ 
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 
+ 	mutex_lock(xe_gt_sriov_pf_master_mutex(gt));
+ 	if (vfid)
+@@ -622,7 +622,7 @@ int xe_gt_sriov_pf_config_bulk_set_ggtt(struct xe_gt *gt, unsigned int vfid,
+ 	int err = 0;
+ 
+ 	xe_gt_assert(gt, vfid);
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 
+ 	if (!num_vfs)
+ 		return 0;
+@@ -693,7 +693,7 @@ int xe_gt_sriov_pf_config_set_fair_ggtt(struct xe_gt *gt, unsigned int vfid,
+ 
+ 	xe_gt_assert(gt, vfid);
+ 	xe_gt_assert(gt, num_vfs);
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 
+ 	mutex_lock(xe_gt_sriov_pf_master_mutex(gt));
+ 	fair = pf_estimate_fair_ggtt(gt, num_vfs);
+@@ -1406,7 +1406,7 @@ static int pf_update_vf_lmtt(struct xe_device *xe, unsigned int vfid)
+ static void pf_release_vf_config_lmem(struct xe_gt *gt, struct xe_gt_sriov_config *config)
+ {
+ 	xe_gt_assert(gt, IS_DGFX(gt_to_xe(gt)));
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
+ 	if (config->lmem_obj) {
+@@ -1425,7 +1425,7 @@ static int pf_provision_vf_lmem(struct xe_gt *gt, unsigned int vfid, u64 size)
+ 
+ 	xe_gt_assert(gt, vfid);
+ 	xe_gt_assert(gt, IS_DGFX(xe));
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 
+ 	size = round_up(size, pf_get_lmem_alignment(gt));
+ 
+@@ -1550,7 +1550,7 @@ int xe_gt_sriov_pf_config_bulk_set_lmem(struct xe_gt *gt, unsigned int vfid,
+ 	int err = 0;
+ 
+ 	xe_gt_assert(gt, vfid);
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 
+ 	if (!num_vfs)
+ 		return 0;
+@@ -1627,7 +1627,7 @@ int xe_gt_sriov_pf_config_set_fair_lmem(struct xe_gt *gt, unsigned int vfid,
+ 
+ 	xe_gt_assert(gt, vfid);
+ 	xe_gt_assert(gt, num_vfs);
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 
+ 	if (!IS_DGFX(gt_to_xe(gt)))
+ 		return 0;
+@@ -1661,7 +1661,7 @@ int xe_gt_sriov_pf_config_set_fair(struct xe_gt *gt, unsigned int vfid,
+ 	xe_gt_assert(gt, vfid);
+ 	xe_gt_assert(gt, num_vfs);
+ 
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		err = xe_gt_sriov_pf_config_set_fair_ggtt(gt, vfid, num_vfs);
+ 		result = result ?: err;
+ 		err = xe_gt_sriov_pf_config_set_fair_lmem(gt, vfid, num_vfs);
+@@ -1989,7 +1989,7 @@ static void pf_release_vf_config(struct xe_gt *gt, unsigned int vfid)
+ 	struct xe_gt_sriov_config *config = pf_pick_vf_config(gt, vfid);
+ 	struct xe_device *xe = gt_to_xe(gt);
+ 
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		pf_release_vf_config_ggtt(gt, config);
+ 		if (IS_DGFX(xe)) {
+ 			pf_release_vf_config_lmem(gt, config);
+@@ -2080,7 +2080,7 @@ static int pf_sanitize_vf_resources(struct xe_gt *gt, u32 vfid, long timeout)
+ 	 * Only GGTT and LMEM requires to be cleared by the PF.
+ 	 * GuC doorbell IDs and context IDs do not need any clearing.
+ 	 */
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		pf_sanitize_ggtt(config->ggtt_region, vfid);
+ 		if (IS_DGFX(xe))
+ 			err = pf_sanitize_lmem(tile, config->lmem_obj, timeout);
+@@ -2147,7 +2147,7 @@ static int pf_validate_vf_config(struct xe_gt *gt, unsigned int vfid)
+ {
+ 	struct xe_gt *primary_gt = gt_to_tile(gt)->primary_gt;
+ 	struct xe_device *xe = gt_to_xe(gt);
+-	bool is_primary = !xe_gt_is_media_type(gt);
++	bool is_primary = xe_gt_is_main_type(gt);
+ 	bool valid_ggtt, valid_ctxs, valid_dbs;
+ 	bool valid_any, valid_all;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c
+index 0fe47f41b63c..4cc68fa1a5d3 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c
+@@ -305,7 +305,7 @@ static void pf_add_config_attrs(struct xe_gt *gt, struct dentry *parent, unsigne
+ 	xe_gt_assert(gt, gt == extract_gt(parent));
+ 	xe_gt_assert(gt, vfid == extract_vfid(parent));
+ 
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		debugfs_create_file_unsafe(vfid ? "ggtt_quota" : "ggtt_spare",
+ 					   0644, parent, parent, &ggtt_fops);
+ 		if (IS_DGFX(gt_to_xe(gt)))
+@@ -554,7 +554,7 @@ void xe_gt_sriov_pf_debugfs_register(struct xe_gt *gt, struct dentry *root)
+ 	pfdentry->d_inode->i_private = gt;
+ 
+ 	drm_debugfs_create_files(pf_info, ARRAY_SIZE(pf_info), pfdentry, minor);
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		drm_debugfs_create_files(pf_ggtt_info,
+ 					 ARRAY_SIZE(pf_ggtt_info),
+ 					 pfdentry, minor);
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
+index a439261bf4d7..44c4693e4ba5 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
+@@ -510,7 +510,7 @@ int xe_gt_sriov_vf_query_config(struct xe_gt *gt)
+ 	if (unlikely(err))
+ 		return err;
+ 
+-	if (IS_DGFX(xe) && !xe_gt_is_media_type(gt)) {
++	if (IS_DGFX(xe) && xe_gt_is_main_type(gt)) {
+ 		err = vf_get_lmem_info(gt);
+ 		if (unlikely(err))
+ 			return err;
+@@ -587,8 +587,8 @@ static int vf_balloon_ggtt(struct xe_gt *gt)
+ 	struct xe_device *xe = gt_to_xe(gt);
+ 	u64 start, end;
+ 
+-	xe_gt_assert(gt, IS_SRIOV_VF(xe));
+-	xe_gt_assert(gt, !xe_gt_is_media_type(gt));
++	xe_gt_assert(gt, IS_SRIOV_VF(gt_to_xe(gt)));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
+ 
+ 	if (!config->ggtt_size)
+ 		return -ENODATA;
+@@ -1043,7 +1043,8 @@ void xe_gt_sriov_vf_print_config(struct xe_gt *gt, struct drm_printer *p)
+ 	string_get_size(config->ggtt_size, 1, STRING_UNITS_2, buf, sizeof(buf));
+ 	drm_printf(p, "GGTT size:\t%llu (%s)\n", config->ggtt_size, buf);
+ 
+-	if (IS_DGFX(xe) && !xe_gt_is_media_type(gt)) {
++
++	if (IS_DGFX(xe) && xe_gt_is_main_type(gt)) {
+ 		string_get_size(config->lmem_size, 1, STRING_UNITS_2, buf, sizeof(buf));
+ 		drm_printf(p, "LMEM size:\t%llu (%s)\n", config->lmem_size, buf);
+ 	}
+diff --git a/drivers/gpu/drm/xe/xe_irq.c b/drivers/gpu/drm/xe/xe_irq.c
+index c88eb10b23ce..306ed2d043a3 100644
+--- a/drivers/gpu/drm/xe/xe_irq.c
++++ b/drivers/gpu/drm/xe/xe_irq.c
+@@ -160,7 +160,7 @@ void xe_irq_enable_hwe(struct xe_gt *gt)
+ 	dmask = irqs << 16 | irqs;
+ 	smask = irqs << 16;
+ 
+-	if (!xe_gt_is_media_type(gt)) {
++	if (xe_gt_is_main_type(gt)) {
+ 		/* Enable interrupts for each engine class */
+ 		xe_mmio_write32(mmio, RENDER_COPY_INTR_ENABLE, dmask);
+ 		if (ccs_mask)
+@@ -251,7 +251,7 @@ gt_engine_identity(struct xe_device *xe,
+ static void
+ gt_other_irq_handler(struct xe_gt *gt, const u8 instance, const u16 iir)
+ {
+-	if (instance == OTHER_GUC_INSTANCE && !xe_gt_is_media_type(gt))
++	if (instance == OTHER_GUC_INSTANCE && xe_gt_is_main_type(gt))
+ 		return xe_guc_irq_handler(&gt->uc.guc, iir);
+ 	if (instance == OTHER_MEDIA_GUC_INSTANCE && xe_gt_is_media_type(gt))
+ 		return xe_guc_irq_handler(&gt->uc.guc, iir);
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index 36b432f89215..0bb3a60af5cc 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -2504,7 +2504,7 @@ void xe_oa_unregister(struct xe_device *xe)
+ 
+ static u32 num_oa_units_per_gt(struct xe_gt *gt)
+ {
+-	if (!xe_gt_is_media_type(gt) || GRAPHICS_VER(gt_to_xe(gt)) < 20)
++	if (xe_gt_is_main_type(gt) || GRAPHICS_VER(gt_to_xe(gt)) < 20)
+ 		return 1;
+ 	else if (!IS_DGFX(gt_to_xe(gt)))
+ 		return XE_OAM_UNIT_SCMI_0 + 1; /* SAG + SCMI_0 */
+@@ -2517,7 +2517,7 @@ static u32 __hwe_oam_unit(struct xe_hw_engine *hwe)
+ 	if (GRAPHICS_VERx100(gt_to_xe(hwe->gt)) < 1270)
+ 		return XE_OA_UNIT_INVALID;
+ 
+-	xe_gt_WARN_ON(hwe->gt, !xe_gt_is_media_type(hwe->gt));
++	xe_gt_WARN_ON(hwe->gt, xe_gt_is_main_type(hwe->gt));
+ 
+ 	if (GRAPHICS_VER(gt_to_xe(hwe->gt)) < 20)
+ 		return 0;
+@@ -2600,7 +2600,7 @@ static void __xe_oa_init_oa_units(struct xe_gt *gt)
+ 	for (i = 0; i < num_units; i++) {
+ 		struct xe_oa_unit *u = &gt->oa.oa_unit[i];
+ 
+-		if (!xe_gt_is_media_type(gt)) {
++		if (xe_gt_is_main_type(gt)) {
+ 			u->regs = __oag_regs();
+ 			u->type = DRM_XE_OA_UNIT_TYPE_OAG;
+ 		} else {
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-Introduce-xe_tile_is_root-helper.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Introduce-xe_tile_is_root-helper.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Sun, 13 Jul 2025 12:36:21 +0200
+Subject: drm/xe: Introduce xe_tile_is_root helper
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Instead of looking at the tile->id member provide a small helper
+to explicitly express our intentions.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://lore.kernel.org/r/20250713103625.1964-4-michal.wajdeczko@intel.com
+(backported from commit 76293a83a9db7fb52e48f5ee320c3c6708f05a8e linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gsc_proxy.c | 3 ++-
+ drivers/gpu/drm/xe/xe_irq.c       | 3 ++-
+ drivers/gpu/drm/xe/xe_tile.h      | 5 +++++
+ 3 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gsc_proxy.c b/drivers/gpu/drm/xe/xe_gsc_proxy.c
+index 76636da3d06c..a3966e809adf 100644
+--- a/drivers/gpu/drm/xe/xe_gsc_proxy.c
++++ b/drivers/gpu/drm/xe/xe_gsc_proxy.c
+@@ -23,6 +23,7 @@
+ #include "xe_map.h"
+ #include "xe_mmio.h"
+ #include "xe_pm.h"
++#include "xe_tile.h"
+ 
+ /*
+  * GSC proxy:
+@@ -455,7 +456,7 @@ int xe_gsc_proxy_init(struct xe_gsc *gsc)
+ 	}
+ 
+ 	/* no multi-tile devices with this feature yet */
+-	if (tile->id > 0) {
++	if (!xe_tile_is_root(tile)) {
+ 		xe_gt_err(gt, "unexpected GSC proxy init on tile %u\n", tile->id);
+ 		return -EINVAL;
+ 	}
+diff --git a/drivers/gpu/drm/xe/xe_irq.c b/drivers/gpu/drm/xe/xe_irq.c
+index 08552ee3fb94..c88eb10b23ce 100644
+--- a/drivers/gpu/drm/xe/xe_irq.c
++++ b/drivers/gpu/drm/xe/xe_irq.c
+@@ -21,6 +21,7 @@
+ #include "xe_memirq.h"
+ #include "xe_mmio.h"
+ #include "xe_sriov.h"
++#include "xe_tile.h"
+ 
+ /*
+  * Interrupt registers for a unit are always consecutive and ordered
+@@ -532,7 +533,7 @@ static void xelp_irq_reset(struct xe_tile *tile)
+ 
+ static void dg1_irq_reset(struct xe_tile *tile)
+ {
+-	if (tile->id == 0)
++	if (xe_tile_is_root(tile))
+ 		dg1_intr_disable(tile_to_xe(tile));
+ 
+ 	gt_irq_reset(tile);
+diff --git a/drivers/gpu/drm/xe/xe_tile.h b/drivers/gpu/drm/xe/xe_tile.h
+index eb939316d55b..b20bab82c460 100644
+--- a/drivers/gpu/drm/xe/xe_tile.h
++++ b/drivers/gpu/drm/xe/xe_tile.h
+@@ -16,4 +16,9 @@ int xe_tile_init(struct xe_tile *tile);
+ 
+ void xe_tile_migrate_wait(struct xe_tile *tile);
+ 
++static inline bool xe_tile_is_root(struct xe_tile *tile)
++{
++	return tile->id == 0;
++}
++
+ #endif
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-Move-PF-and-VF-device-types-to-separate-heade.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Move-PF-and-VF-device-types-to-separate-heade.patch
@@ -1,0 +1,163 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Sun, 13 Jul 2025 12:36:20 +0200
+Subject: drm/xe: Move PF and VF device types to separate headers
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We plan to add more PF and VF types and mixing them in a single
+file is not desired.  Move them out to new dedicated files.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Acked-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://lore.kernel.org/r/20250713103625.1964-3-michal.wajdeczko@intel.com
+(cherry-picked from commit 73c0e8054fcf36883c1a20d5e2e91fb8ed24d3ea linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device_types.h   |  2 ++
+ drivers/gpu/drm/xe/xe_sriov_pf_types.h | 29 +++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_sriov_types.h    | 36 --------------------------
+ drivers/gpu/drm/xe/xe_sriov_vf_types.h | 27 +++++++++++++++++++
+ 4 files changed, 58 insertions(+), 36 deletions(-)
+ create mode 100644 drivers/gpu/drm/xe/xe_sriov_pf_types.h
+ create mode 100644 drivers/gpu/drm/xe/xe_sriov_vf_types.h
+
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index 7cd34399fbd4..6173f46e6916 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -20,7 +20,9 @@
+ #include "xe_platform_types.h"
+ #include "xe_pmu_types.h"
+ #include "xe_pt_types.h"
++#include "xe_sriov_pf_types.h"
+ #include "xe_sriov_types.h"
++#include "xe_sriov_vf_types.h"
+ #include "xe_step_types.h"
+ #include "xe_survivability_mode_types.h"
+ 
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_types.h b/drivers/gpu/drm/xe/xe_sriov_pf_types.h
+new file mode 100644
+index 000000000000..918dc089eb1d
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_types.h
+@@ -0,0 +1,29 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023-2025 Intel Corporation
++ */
++
++#ifndef _XE_SRIOV_PF_TYPES_H_
++#define _XE_SRIOV_PF_TYPES_H_
++
++#include <linux/mutex.h>
++#include <linux/types.h>
++
++/**
++ * struct xe_device_pf - Xe PF related data
++ *
++ * The data in this structure is valid only if driver is running in the
++ * @XE_SRIOV_MODE_PF mode.
++ */
++struct xe_device_pf {
++	/** @device_total_vfs: Maximum number of VFs supported by the device. */
++	u16 device_total_vfs;
++
++	/** @driver_max_vfs: Maximum number of VFs supported by the driver. */
++	u16 driver_max_vfs;
++
++	/** @master_lock: protects all VFs configurations across GTs */
++	struct mutex master_lock;
++};
++
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_sriov_types.h b/drivers/gpu/drm/xe/xe_sriov_types.h
+index ca94382a721e..1a138108d139 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_types.h
++++ b/drivers/gpu/drm/xe/xe_sriov_types.h
+@@ -7,9 +7,6 @@
+ #define _XE_SRIOV_TYPES_H_
+ 
+ #include <linux/build_bug.h>
+-#include <linux/mutex.h>
+-#include <linux/types.h>
+-#include <linux/workqueue_types.h>
+ 
+ /**
+  * VFID - Virtual Function Identifier
+@@ -40,37 +37,4 @@ enum xe_sriov_mode {
+ };
+ static_assert(XE_SRIOV_MODE_NONE);
+ 
+-/**
+- * struct xe_device_pf - Xe PF related data
+- *
+- * The data in this structure is valid only if driver is running in the
+- * @XE_SRIOV_MODE_PF mode.
+- */
+-struct xe_device_pf {
+-	/** @device_total_vfs: Maximum number of VFs supported by the device. */
+-	u16 device_total_vfs;
+-
+-	/** @driver_max_vfs: Maximum number of VFs supported by the driver. */
+-	u16 driver_max_vfs;
+-
+-	/** @master_lock: protects all VFs configurations across GTs */
+-	struct mutex master_lock;
+-};
+-
+-/**
+- * struct xe_device_vf - Xe Virtual Function related data
+- *
+- * The data in this structure is valid only if driver is running in the
+- * @XE_SRIOV_MODE_VF mode.
+- */
+-struct xe_device_vf {
+-	/** @migration: VF Migration state data */
+-	struct {
+-		/** @migration.worker: VF migration recovery worker */
+-		struct work_struct worker;
+-		/** @migration.gt_flags: Per-GT request flags for VF migration recovery */
+-		unsigned long gt_flags;
+-	} migration;
+-};
+-
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_sriov_vf_types.h b/drivers/gpu/drm/xe/xe_sriov_vf_types.h
+new file mode 100644
+index 000000000000..55c2421d4b2e
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_sriov_vf_types.h
+@@ -0,0 +1,27 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023-2025 Intel Corporation
++ */
++
++#ifndef _XE_SRIOV_VF_TYPES_H_
++#define _XE_SRIOV_VF_TYPES_H_
++
++#include <linux/workqueue_types.h>
++
++/**
++ * struct xe_device_vf - Xe Virtual Function related data
++ *
++ * The data in this structure is valid only if driver is running in the
++ * @XE_SRIOV_MODE_VF mode.
++ */
++struct xe_device_vf {
++	/** @migration: VF Migration state data */
++	struct {
++		/** @migration.worker: VF migration recovery worker */
++		struct work_struct worker;
++		/** @migration.gt_flags: Per-GT request flags for VF migration recovery */
++		unsigned long gt_flags;
++	} migration;
++};
++
++#endif
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-oa-Assign-hwe-for-OAM_SAG.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-oa-Assign-hwe-for-OAM_SAG.patch
@@ -1,0 +1,122 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Date: Fri, 6 Jun 2025 12:26:16 -0700
+Subject: drm/xe/oa: Assign hwe for OAM_SAG
+
+Because OAM_SAG doesn't have an attached hwe, assign another hwe belonging
+to the same gt (and different OAM unit) to OAM_SAG. A hwe is needed for
+batch submissions to program OA HW.
+
+v2: Assign an engine with a valid OA unit for OAM_SAG (Umesh)
+
+Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Reviewed-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Link: https://lore.kernel.org/r/20250606192618.4133817-5-ashutosh.dixit@intel.com
+(cherry-picked from commit 10d42ef34bce5a3b60be6a492fc079f6ace871ce linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_oa.c       | 57 ++++++++++++++++++++------------
+ drivers/gpu/drm/xe/xe_oa_types.h |  3 ++
+ 2 files changed, 38 insertions(+), 22 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index 99508bac0016..b66e8019b8e9 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -1935,37 +1935,48 @@ u16 xe_oa_unit_id(struct xe_hw_engine *hwe)
+ 		hwe->oa_unit->oa_unit_id : U16_MAX;
+ }
+ 
++/* A hwe must be assigned to stream/oa_unit for batch submissions */
+ static int xe_oa_assign_hwe(struct xe_oa *oa, struct xe_oa_open_param *param)
+ {
+-	struct xe_gt *gt;
+-	int i, ret = 0;
++	struct xe_hw_engine *hwe;
++	enum xe_hw_engine_id id;
++	int ret = 0;
++
++	/* If not provided, OA unit defaults to OA unit 0 as per uapi */
++	if (!param->oa_unit)
++		param->oa_unit = &xe_device_get_gt(oa->xe, 0)->oa.oa_unit[0];
+ 
++	/* When we have an exec_q, get hwe from the exec_q */
+ 	if (param->exec_q) {
+-		/* When we have an exec_q, get hwe from the exec_q */
+ 		param->hwe = xe_gt_hw_engine(param->exec_q->gt, param->exec_q->class,
+ 					     param->engine_instance, true);
+-	} else {
+-		struct xe_hw_engine *hwe;
+-		enum xe_hw_engine_id id;
+-
+-		/* Else just get the first hwe attached to the oa unit */
+-		for_each_gt(gt, oa->xe, i) {
+-			for_each_hw_engine(hwe, gt, id) {
+-				if (hwe->oa_unit == param->oa_unit) {
+-					param->hwe = hwe;
+-					goto out;
+-				}
+-			}
+-		}
++		if (!param->hwe || param->hwe->oa_unit != param->oa_unit)
++			goto err;
++		goto out;
+ 	}
+-out:
+-	if (!param->hwe || param->hwe->oa_unit != param->oa_unit) {
+-		drm_dbg(&oa->xe->drm, "Unable to find hwe (%d, %d) for OA unit ID %d\n",
+-			param->exec_q ? param->exec_q->class : -1,
+-			param->engine_instance, param->oa_unit->oa_unit_id);
+-		ret = -EINVAL;
++
++	/* Else just get the first hwe attached to the oa unit */
++	for_each_hw_engine(hwe, param->oa_unit->gt, id) {
++		if (hwe->oa_unit == param->oa_unit) {
++			param->hwe = hwe;
++			goto out;
++		}
+ 	}
+ 
++	/* If we still didn't find a hwe, just get one with a valid oa_unit from the same gt */
++	for_each_hw_engine(hwe, param->oa_unit->gt, id) {
++		if (!hwe->oa_unit)
++			continue;
++
++		param->hwe = hwe;
++		goto out;
++	}
++err:
++	drm_dbg(&oa->xe->drm, "Unable to find hwe (%d, %d) for OA unit ID %d\n",
++		param->exec_q ? param->exec_q->class : -1,
++		param->engine_instance, param->oa_unit->oa_unit_id);
++	ret = -EINVAL;
++out:
+ 	return ret;
+ }
+ 
+@@ -2589,6 +2600,8 @@ static void __xe_oa_init_oa_units(struct xe_gt *gt)
+ 				DRM_XE_OA_UNIT_TYPE_OAM_SAG : DRM_XE_OA_UNIT_TYPE_OAM;
+ 		}
+ 
++		u->gt = gt;
++
+ 		xe_mmio_write32(&gt->mmio, u->regs.oa_ctrl, 0);
+ 
+ 		/* Ensure MMIO trigger remains disabled till there is a stream */
+diff --git a/drivers/gpu/drm/xe/xe_oa_types.h b/drivers/gpu/drm/xe/xe_oa_types.h
+index a01c85931e2a..2628f78c4e8d 100644
+--- a/drivers/gpu/drm/xe/xe_oa_types.h
++++ b/drivers/gpu/drm/xe/xe_oa_types.h
+@@ -95,6 +95,9 @@ struct xe_oa_unit {
+ 	/** @oa_unit_id: identifier for the OA unit */
+ 	u16 oa_unit_id;
+ 
++	/** @gt: gt associated with the OA unit */
++	struct xe_gt *gt;
++
+ 	/** @type: Type of OA unit - OAM, OAG etc. */
+ 	enum drm_xe_oa_unit_type type;
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-oa-Enable-OAM-latency-measurement.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-oa-Enable-OAM-latency-measurement.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Date: Fri, 6 Jun 2025 12:26:17 -0700
+Subject: drm/xe/oa: Enable OAM latency measurement
+
+Enable OAM latency measurement for Xe3+ platforms.
+
+Bspec: 58840
+
+v2: Introduce DRM_XE_OA_UNIT_TYPE_OAM_SAG
+v3: Also add LNCF_MISC_CONFIG_REGISTER0 needed by MDAPI
+
+Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Reviewed-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Link: https://lore.kernel.org/r/20250606192618.4133817-6-ashutosh.dixit@intel.com
+(cherry-picked from commit 82a4be88c89ae3f117b8b53d0a7c080eb68ab9f1 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_oa_regs.h |  3 +++
+ drivers/gpu/drm/xe/xe_oa.c           | 12 +++++++++++-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_oa_regs.h b/drivers/gpu/drm/xe/regs/xe_oa_regs.h
+index a79ad2da070c..e693a50706f8 100644
+--- a/drivers/gpu/drm/xe/regs/xe_oa_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_oa_regs.h
+@@ -97,4 +97,7 @@
+ #define OAM_STATUS(base)			XE_REG((base) + OAM_STATUS_OFFSET)
+ #define OAM_MMIO_TRG(base)			XE_REG((base) + OAM_MMIO_TRG_OFFSET)
+ 
++#define OAM_COMPRESSION_T3_CONTROL		XE_REG(0x1c2e00)
++#define  OAM_LAT_MEASURE_ENABLE			REG_BIT(4)
++
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index b66e8019b8e9..36b432f89215 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -844,6 +844,11 @@ static void xe_oa_disable_metric_set(struct xe_oa_stream *stream)
+ 
+ 	/* Reset PMON Enable to save power. */
+ 	xe_mmio_rmw32(mmio, XELPMP_SQCNT1, sqcnt1, 0);
++
++	if ((stream->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAM ||
++	     stream->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAM_SAG) &&
++	    GRAPHICS_VER(stream->oa->xe) >= 30)
++		xe_mmio_rmw32(mmio, OAM_COMPRESSION_T3_CONTROL, OAM_LAT_MEASURE_ENABLE, 0);
+ }
+ 
+ static void xe_oa_stream_destroy(struct xe_oa_stream *stream)
+@@ -1112,9 +1117,13 @@ static int xe_oa_enable_metric_set(struct xe_oa_stream *stream)
+ 	 */
+ 	sqcnt1 = SQCNT1_PMON_ENABLE |
+ 		 (HAS_OA_BPC_REPORTING(stream->oa->xe) ? SQCNT1_OABPC : 0);
+-
+ 	xe_mmio_rmw32(mmio, XELPMP_SQCNT1, 0, sqcnt1);
+ 
++	if ((stream->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAM ||
++	     stream->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAM_SAG) &&
++	    GRAPHICS_VER(stream->oa->xe) >= 30)
++		xe_mmio_rmw32(mmio, OAM_COMPRESSION_T3_CONTROL, 0, OAM_LAT_MEASURE_ENABLE);
++
+ 	/* Configure OAR/OAC */
+ 	if (stream->exec_q) {
+ 		ret = xe_oa_configure_oa_context(stream, true);
+@@ -2202,6 +2211,7 @@ static const struct xe_mmio_range gen12_oa_mux_regs[] = {
+ static const struct xe_mmio_range xe2_oa_mux_regs[] = {
+ 	{ .start = 0x5194, .end = 0x5194 },	/* SYS_MEM_LAT_MEASURE_MERTF_GRP_3D */
+ 	{ .start = 0x8704, .end = 0x8704 },	/* LMEM_LAT_MEASURE_MCFG_GRP */
++	{ .start = 0xB01C, .end = 0xB01C },	/* LNCF_MISC_CONFIG_REGISTER0 */
+ 	{ .start = 0xB1BC, .end = 0xB1BC },	/* L3_BANK_LAT_MEASURE_LBCF_GFX */
+ 	{ .start = 0xD0E0, .end = 0xD0F4 },	/* VISACTL */
+ 	{ .start = 0xE18C, .end = 0xE18C },	/* SAMPLER_MODE */
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-oa-Introduce-stream-oa_unit.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-oa-Introduce-stream-oa_unit.patch
@@ -1,0 +1,205 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Date: Fri, 6 Jun 2025 12:26:15 -0700
+Subject: drm/xe/oa: Introduce stream->oa_unit
+
+Previously, the oa_unit associated with an OA stream was derived from hwe
+associated with the stream (stream->hwe->oa_unit). This breaks with OAM_SAG
+since OAM_SAG does not have any attached hardware engines. Resolve this by
+introducing stream->oa_unit and stop depending on stream->hwe.
+
+Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Reviewed-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Link: https://lore.kernel.org/r/20250606192618.4133817-4-ashutosh.dixit@intel.com
+(cherry-picked from commit 2d1fcec0229c3180fc32fe11babfc428fc69b97d linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_oa.c       | 51 +++++++++++++++++++++-----------
+ drivers/gpu/drm/xe/xe_oa_types.h |  3 ++
+ 2 files changed, 37 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index 698cec778e69..99508bac0016 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -80,7 +80,7 @@ struct xe_oa_config {
+ 
+ struct xe_oa_open_param {
+ 	struct xe_file *xef;
+-	u32 oa_unit_id;
++	struct xe_oa_unit *oa_unit;
+ 	bool sample;
+ 	u32 metric_set;
+ 	enum xe_oa_format_name oa_format;
+@@ -197,7 +197,7 @@ static void free_oa_config_bo(struct xe_oa_config_bo *oa_bo, struct dma_fence *l
+ 
+ static const struct xe_oa_regs *__oa_regs(struct xe_oa_stream *stream)
+ {
+-	return &stream->hwe->oa_unit->regs;
++	return &stream->oa_unit->regs;
+ }
+ 
+ static u32 xe_oa_hw_tail_read(struct xe_oa_stream *stream)
+@@ -457,7 +457,7 @@ static u32 __oa_ccs_select(struct xe_oa_stream *stream)
+ 
+ static u32 __oactrl_used_bits(struct xe_oa_stream *stream)
+ {
+-	return stream->hwe->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAG ?
++	return stream->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAG ?
+ 		OAG_OACONTROL_USED_BITS : OAM_OACONTROL_USED_BITS;
+ }
+ 
+@@ -478,7 +478,7 @@ static void xe_oa_enable(struct xe_oa_stream *stream)
+ 		__oa_ccs_select(stream) | OAG_OACONTROL_OA_COUNTER_ENABLE;
+ 
+ 	if (GRAPHICS_VER(stream->oa->xe) >= 20 &&
+-	    stream->hwe->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAG)
++	    stream->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAG)
+ 		val |= OAG_OACONTROL_OA_PES_DISAG_EN;
+ 
+ 	xe_mmio_rmw32(&stream->gt->mmio, regs->oa_ctrl, __oactrl_used_bits(stream), val);
+@@ -848,7 +848,7 @@ static void xe_oa_disable_metric_set(struct xe_oa_stream *stream)
+ 
+ static void xe_oa_stream_destroy(struct xe_oa_stream *stream)
+ {
+-	struct xe_oa_unit *u = stream->hwe->oa_unit;
++	struct xe_oa_unit *u = stream->oa_unit;
+ 	struct xe_gt *gt = stream->hwe->gt;
+ 
+ 	if (WARN_ON(stream != u->exclusive_stream))
+@@ -1146,14 +1146,31 @@ static int decode_oa_format(struct xe_oa *oa, u64 fmt, enum xe_oa_format_name *n
+ 	return -EINVAL;
+ }
+ 
++static struct xe_oa_unit *xe_oa_lookup_oa_unit(struct xe_oa *oa, u32 oa_unit_id)
++{
++	struct xe_gt *gt;
++	int gt_id, i;
++
++	for_each_gt(gt, oa->xe, gt_id) {
++		for (i = 0; i < gt->oa.num_oa_units; i++) {
++			struct xe_oa_unit *u = &gt->oa.oa_unit[i];
++
++			if (u->oa_unit_id == oa_unit_id)
++				return u;
++		}
++	}
++
++	return NULL;
++}
++
+ static int xe_oa_set_prop_oa_unit_id(struct xe_oa *oa, u64 value,
+ 				     struct xe_oa_open_param *param)
+ {
+-	if (value >= oa->oa_unit_ids) {
++	param->oa_unit = xe_oa_lookup_oa_unit(oa, value);
++	if (!param->oa_unit) {
+ 		drm_dbg(&oa->xe->drm, "OA unit ID out of range %lld\n", value);
+ 		return -EINVAL;
+ 	}
+-	param->oa_unit_id = value;
+ 	return 0;
+ }
+ 
+@@ -1684,13 +1701,13 @@ static const struct file_operations xe_oa_fops = {
+ static int xe_oa_stream_init(struct xe_oa_stream *stream,
+ 			     struct xe_oa_open_param *param)
+ {
+-	struct xe_oa_unit *u = param->hwe->oa_unit;
+ 	struct xe_gt *gt = param->hwe->gt;
+ 	unsigned int fw_ref;
+ 	int ret;
+ 
+ 	stream->exec_q = param->exec_q;
+ 	stream->poll_period_ns = DEFAULT_POLL_PERIOD_NS;
++	stream->oa_unit = param->oa_unit;
+ 	stream->hwe = param->hwe;
+ 	stream->gt = stream->hwe->gt;
+ 	stream->oa_buffer.format = &stream->oa->oa_formats[param->oa_format];
+@@ -1711,7 +1728,7 @@ static int xe_oa_stream_init(struct xe_oa_stream *stream,
+ 	 * buffer whose size, circ_size, is a multiple of the report size
+ 	 */
+ 	if (GRAPHICS_VER(stream->oa->xe) >= 20 &&
+-	    stream->hwe->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAG && stream->sample)
++	    stream->oa_unit->type == DRM_XE_OA_UNIT_TYPE_OAG && stream->sample)
+ 		stream->oa_buffer.circ_size =
+ 			param->oa_buffer_size -
+ 			param->oa_buffer_size % stream->oa_buffer.format->size;
+@@ -1771,7 +1788,7 @@ static int xe_oa_stream_init(struct xe_oa_stream *stream,
+ 	drm_dbg(&stream->oa->xe->drm, "opening stream oa config uuid=%s\n",
+ 		stream->oa_config->uuid);
+ 
+-	WRITE_ONCE(u->exclusive_stream, stream);
++	WRITE_ONCE(stream->oa_unit->exclusive_stream, stream);
+ 
+ 	hrtimer_init(&stream->poll_check_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+ 	stream->poll_check_timer.function = xe_oa_poll_check_timer_cb;
+@@ -1807,7 +1824,7 @@ static int xe_oa_stream_open_ioctl_locked(struct xe_oa *oa,
+ 	int ret;
+ 
+ 	/* We currently only allow exclusive access */
+-	if (param->hwe->oa_unit->exclusive_stream) {
++	if (param->oa_unit->exclusive_stream) {
+ 		drm_dbg(&oa->xe->drm, "OA unit already in use\n");
+ 		ret = -EBUSY;
+ 		goto exit;
+@@ -1892,9 +1909,9 @@ static u64 oa_exponent_to_ns(struct xe_gt *gt, int exponent)
+ 	return div_u64(nom + den - 1, den);
+ }
+ 
+-static bool engine_supports_oa_format(const struct xe_hw_engine *hwe, int type)
++static bool oa_unit_supports_oa_format(struct xe_oa_open_param *param, int type)
+ {
+-	switch (hwe->oa_unit->type) {
++	switch (param->oa_unit->type) {
+ 	case DRM_XE_OA_UNIT_TYPE_OAG:
+ 		return type == DRM_XE_OA_FMT_TYPE_OAG || type == DRM_XE_OA_FMT_TYPE_OAR ||
+ 			type == DRM_XE_OA_FMT_TYPE_OAC || type == DRM_XE_OA_FMT_TYPE_PEC;
+@@ -1934,7 +1951,7 @@ static int xe_oa_assign_hwe(struct xe_oa *oa, struct xe_oa_open_param *param)
+ 		/* Else just get the first hwe attached to the oa unit */
+ 		for_each_gt(gt, oa->xe, i) {
+ 			for_each_hw_engine(hwe, gt, id) {
+-				if (xe_oa_unit_id(hwe) == param->oa_unit_id) {
++				if (hwe->oa_unit == param->oa_unit) {
+ 					param->hwe = hwe;
+ 					goto out;
+ 				}
+@@ -1942,10 +1959,10 @@ static int xe_oa_assign_hwe(struct xe_oa *oa, struct xe_oa_open_param *param)
+ 		}
+ 	}
+ out:
+-	if (!param->hwe || xe_oa_unit_id(param->hwe) != param->oa_unit_id) {
++	if (!param->hwe || param->hwe->oa_unit != param->oa_unit) {
+ 		drm_dbg(&oa->xe->drm, "Unable to find hwe (%d, %d) for OA unit ID %d\n",
+ 			param->exec_q ? param->exec_q->class : -1,
+-			param->engine_instance, param->oa_unit_id);
++			param->engine_instance, param->oa_unit->oa_unit_id);
+ 		ret = -EINVAL;
+ 	}
+ 
+@@ -2026,7 +2043,7 @@ int xe_oa_stream_open_ioctl(struct drm_device *dev, u64 data, struct drm_file *f
+ 
+ 	f = &oa->oa_formats[param.oa_format];
+ 	if (!param.oa_format || !f->size ||
+-	    !engine_supports_oa_format(param.hwe, f->type)) {
++	    !oa_unit_supports_oa_format(&param, f->type)) {
+ 		drm_dbg(&oa->xe->drm, "Invalid OA format %d type %d size %d for class %d\n",
+ 			param.oa_format, f->type, f->size, param.hwe->class);
+ 		ret = -EINVAL;
+diff --git a/drivers/gpu/drm/xe/xe_oa_types.h b/drivers/gpu/drm/xe/xe_oa_types.h
+index 52e33c37d5ee..a01c85931e2a 100644
+--- a/drivers/gpu/drm/xe/xe_oa_types.h
++++ b/drivers/gpu/drm/xe/xe_oa_types.h
+@@ -182,6 +182,9 @@ struct xe_oa_stream {
+ 	/** @gt: gt associated with the oa stream */
+ 	struct xe_gt *gt;
+ 
++	/** @oa_unit: oa unit for this stream */
++	struct xe_oa_unit *oa_unit;
++
+ 	/** @hwe: hardware engine associated with this oa stream */
+ 	struct xe_hw_engine *hwe;
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-oa-Print-hwe-to-OA-unit-mapping.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-oa-Print-hwe-to-OA-unit-mapping.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Date: Fri, 6 Jun 2025 12:26:14 -0700
+Subject: drm/xe/oa: Print hwe to OA unit mapping
+
+Print hwe to OA unit mapping to dmesg, to help debug for current and new
+platforms.
+
+v2: Separate out xe_oa_print_gt_oa_units() (Umesh)
+
+Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Reviewed-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Link: https://lore.kernel.org/r/20250606192618.4133817-3-ashutosh.dixit@intel.com
+(cherry-picked from commit f3a3fd2c6f87f0e7d225019d7ed34c6bddf573f9 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_oa.c | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index 670e1de22cb5..698cec778e69 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -2614,6 +2614,36 @@ static int xe_oa_init_gt(struct xe_gt *gt)
+ 	return 0;
+ }
+ 
++static void xe_oa_print_gt_oa_units(struct xe_gt *gt)
++{
++	enum xe_hw_engine_id hwe_id;
++	struct xe_hw_engine *hwe;
++	struct xe_oa_unit *u;
++	char buf[256];
++	int i, n;
++
++	for (i = 0; i < gt->oa.num_oa_units; i++) {
++		u = &gt->oa.oa_unit[i];
++		buf[0] = '\0';
++		n = 0;
++
++		for_each_hw_engine(hwe, gt, hwe_id)
++			if (xe_oa_unit_id(hwe) == u->oa_unit_id)
++				n += scnprintf(buf + n, sizeof(buf) - n, "%s ", hwe->name);
++
++		xe_gt_dbg(gt, "oa_unit %d, type %d, Engines: %s\n", u->oa_unit_id, u->type, buf);
++	}
++}
++
++static void xe_oa_print_oa_units(struct xe_oa *oa)
++{
++	struct xe_gt *gt;
++	int gt_id;
++
++	for_each_gt(gt, oa->xe, gt_id)
++		xe_oa_print_gt_oa_units(gt);
++}
++
+ static int xe_oa_init_oa_units(struct xe_oa *oa)
+ {
+ 	struct xe_gt *gt;
+@@ -2630,6 +2660,8 @@ static int xe_oa_init_oa_units(struct xe_oa *oa)
+ 			return ret;
+ 	}
+ 
++	xe_oa_print_oa_units(oa);
++
+ 	return 0;
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-oa-uapi-Expose-media-OA-units.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-oa-uapi-Expose-media-OA-units.patch
@@ -1,0 +1,207 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Date: Fri, 6 Jun 2025 12:26:13 -0700
+Subject: drm/xe/oa/uapi: Expose media OA units
+
+On Xe2+ platforms, media engines are attached to "SCMI" OA media (OAM)
+units. One or more SCMI OAM units might be present on a platform. In
+addition there is another OAM unit for global events, called
+OAM-SAG. Performance metrics for media workloads can be obtained from these
+OAM units, similar to OAG.
+
+Expose these OAM units for userspace to use. OAM-SAG is exposed as an OA
+unit without any attached engines.
+
+Bspec: 70819, 67103, 63844, 72572, 74476, 61284
+
+v2: Fix xe_gt_WARN_ON in __hwe_oam_unit for < 12.7 platforms
+v3: Return XE_OA_UNIT_INVALID for < 12.7 to indicate no OAM units
+v4: Move xe_oa_print_oa_units() to separate patch
+v5: Introduce DRM_XE_OA_UNIT_TYPE_OAM_SAG
+v6: Introduce DRM_XE_OA_CAPS_OAM
+
+Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Reviewed-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Link: https://lore.kernel.org/r/20250606192618.4133817-2-ashutosh.dixit@intel.com
+(cherry-picked from commit e04dac12cec853347908432b663a3f78e26d3b8d linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_oa.c    | 68 ++++++++++++++++++++++++++---------
+ drivers/gpu/drm/xe/xe_query.c |  4 +--
+ include/uapi/drm/xe_drm.h     |  4 +++
+ 3 files changed, 57 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index abf37d9ab221..670e1de22cb5 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -40,6 +40,12 @@
+ #define DEFAULT_POLL_PERIOD_NS (NSEC_PER_SEC / DEFAULT_POLL_FREQUENCY_HZ)
+ #define XE_OA_UNIT_INVALID U32_MAX
+ 
++enum xe_oam_unit_type {
++	XE_OAM_UNIT_SAG,
++	XE_OAM_UNIT_SCMI_0,
++	XE_OAM_UNIT_SCMI_1,
++};
++
+ enum xe_oa_submit_deps {
+ 	XE_OA_SUBMIT_NO_DEPS,
+ 	XE_OA_SUBMIT_ADD_DEPS,
+@@ -1893,6 +1899,7 @@ static bool engine_supports_oa_format(const struct xe_hw_engine *hwe, int type)
+ 		return type == DRM_XE_OA_FMT_TYPE_OAG || type == DRM_XE_OA_FMT_TYPE_OAR ||
+ 			type == DRM_XE_OA_FMT_TYPE_OAC || type == DRM_XE_OA_FMT_TYPE_PEC;
+ 	case DRM_XE_OA_UNIT_TYPE_OAM:
++	case DRM_XE_OA_UNIT_TYPE_OAM_SAG:
+ 		return type == DRM_XE_OA_FMT_TYPE_OAM || type == DRM_XE_OA_FMT_TYPE_OAM_MPEC;
+ 	default:
+ 		return false;
+@@ -2459,20 +2466,38 @@ void xe_oa_unregister(struct xe_device *xe)
+ 
+ static u32 num_oa_units_per_gt(struct xe_gt *gt)
+ {
+-	return 1;
++	if (!xe_gt_is_media_type(gt) || GRAPHICS_VER(gt_to_xe(gt)) < 20)
++		return 1;
++	else if (!IS_DGFX(gt_to_xe(gt)))
++		return XE_OAM_UNIT_SCMI_0 + 1; /* SAG + SCMI_0 */
++	else
++		return XE_OAM_UNIT_SCMI_1 + 1; /* SAG + SCMI_0 + SCMI_1 */
+ }
+ 
+ static u32 __hwe_oam_unit(struct xe_hw_engine *hwe)
+ {
+-	if (GRAPHICS_VERx100(gt_to_xe(hwe->gt)) >= 1270) {
+-		/*
+-		 * There's 1 SAMEDIA gt and 1 OAM per SAMEDIA gt. All media slices
+-		 * within the gt use the same OAM. All MTL/LNL SKUs list 1 SA MEDIA
+-		 */
+-		xe_gt_WARN_ON(hwe->gt, hwe->gt->info.type != XE_GT_TYPE_MEDIA);
++	if (GRAPHICS_VERx100(gt_to_xe(hwe->gt)) < 1270)
++		return XE_OA_UNIT_INVALID;
+ 
++	xe_gt_WARN_ON(hwe->gt, !xe_gt_is_media_type(hwe->gt));
++
++	if (GRAPHICS_VER(gt_to_xe(hwe->gt)) < 20)
+ 		return 0;
+-	}
++	/*
++	 * XE_OAM_UNIT_SAG has only GSCCS attached to it, but only on some platforms. Also
++	 * GSCCS cannot be used to submit batches to program the OAM unit. Therefore we don't
++	 * assign an OA unit to GSCCS. This means that XE_OAM_UNIT_SAG is exposed as an OA
++	 * unit without attached engines. Fused off engines can also result in oa_unit's with
++	 * num_engines == 0. OA streams can be opened on all OA units.
++	 */
++	else if (hwe->engine_id == XE_HW_ENGINE_GSCCS0)
++		return XE_OA_UNIT_INVALID;
++	else if (!IS_DGFX(gt_to_xe(hwe->gt)))
++		return XE_OAM_UNIT_SCMI_0;
++	else if (hwe->class == XE_ENGINE_CLASS_VIDEO_DECODE)
++		return (hwe->instance / 2 & 0x1) + 1;
++	else if (hwe->class == XE_ENGINE_CLASS_VIDEO_ENHANCE)
++		return (hwe->instance & 0x1) + 1;
+ 
+ 	return XE_OA_UNIT_INVALID;
+ }
+@@ -2486,6 +2511,7 @@ static u32 __hwe_oa_unit(struct xe_hw_engine *hwe)
+ 
+ 	case XE_ENGINE_CLASS_VIDEO_DECODE:
+ 	case XE_ENGINE_CLASS_VIDEO_ENHANCE:
++	case XE_ENGINE_CLASS_OTHER:
+ 		return __hwe_oam_unit(hwe);
+ 
+ 	default:
+@@ -2525,18 +2551,25 @@ static struct xe_oa_regs __oag_regs(void)
+ 
+ static void __xe_oa_init_oa_units(struct xe_gt *gt)
+ {
+-	const u32 mtl_oa_base[] = { 0x13000 };
++	/* Actual address is MEDIA_GT_GSI_OFFSET + oam_base_addr[i] */
++	const u32 oam_base_addr[] = {
++		[XE_OAM_UNIT_SAG]    = 0x13000,
++		[XE_OAM_UNIT_SCMI_0] = 0x14000,
++		[XE_OAM_UNIT_SCMI_1] = 0x14800,
++	};
+ 	int i, num_units = gt->oa.num_oa_units;
+ 
+ 	for (i = 0; i < num_units; i++) {
+ 		struct xe_oa_unit *u = &gt->oa.oa_unit[i];
+ 
+-		if (gt->info.type != XE_GT_TYPE_MEDIA) {
++		if (!xe_gt_is_media_type(gt)) {
+ 			u->regs = __oag_regs();
+ 			u->type = DRM_XE_OA_UNIT_TYPE_OAG;
+-		} else if (GRAPHICS_VERx100(gt_to_xe(gt)) >= 1270) {
+-			u->regs = __oam_regs(mtl_oa_base[i]);
+-			u->type = DRM_XE_OA_UNIT_TYPE_OAM;
++		} else {
++			xe_gt_assert(gt, GRAPHICS_VERx100(gt_to_xe(gt)) >= 1270);
++			u->regs = __oam_regs(oam_base_addr[i]);
++			u->type = i == XE_OAM_UNIT_SAG && GRAPHICS_VER(gt_to_xe(gt)) >= 20 ?
++				DRM_XE_OA_UNIT_TYPE_OAM_SAG : DRM_XE_OA_UNIT_TYPE_OAM;
+ 		}
+ 
+ 		xe_mmio_write32(&gt->mmio, u->regs.oa_ctrl, 0);
+@@ -2571,10 +2604,6 @@ static int xe_oa_init_gt(struct xe_gt *gt)
+ 		}
+ 	}
+ 
+-	/*
+-	 * Fused off engines can result in oa_unit's with num_engines == 0. These units
+-	 * will appear in OA unit query, but no OA streams can be opened on them.
+-	 */
+ 	gt->oa.num_oa_units = num_oa_units;
+ 	gt->oa.oa_unit = u;
+ 
+@@ -2590,6 +2619,11 @@ static int xe_oa_init_oa_units(struct xe_oa *oa)
+ 	struct xe_gt *gt;
+ 	int i, ret;
+ 
++	/* Needed for OAM implementation here */
++	BUILD_BUG_ON(XE_OAM_UNIT_SAG != 0);
++	BUILD_BUG_ON(XE_OAM_UNIT_SCMI_0 != 1);
++	BUILD_BUG_ON(XE_OAM_UNIT_SCMI_1 != 2);
++
+ 	for_each_gt(gt, oa->xe, i) {
+ 		ret = xe_oa_init_gt(gt);
+ 		if (ret)
+diff --git a/drivers/gpu/drm/xe/xe_query.c b/drivers/gpu/drm/xe/xe_query.c
+index dba504be3197..f43d05365ad2 100644
+--- a/drivers/gpu/drm/xe/xe_query.c
++++ b/drivers/gpu/drm/xe/xe_query.c
+@@ -678,8 +678,8 @@ static int query_oa_units(struct xe_device *xe,
+ 			du->oa_timestamp_freq = xe_oa_timestamp_frequency(gt);
+ 			du->capabilities = DRM_XE_OA_CAPS_BASE | DRM_XE_OA_CAPS_SYNCS |
+ 					   DRM_XE_OA_CAPS_OA_BUFFER_SIZE |
+-					   DRM_XE_OA_CAPS_WAIT_NUM_REPORTS;
+-
++					   DRM_XE_OA_CAPS_WAIT_NUM_REPORTS |
++					   DRM_XE_OA_CAPS_OAM;
+ 			j = 0;
+ 			for_each_hw_engine(hwe, gt, hwe_id) {
+ 				if (!xe_hw_engine_is_reserved(hwe) &&
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index e5551b5af98d..ee6db9344e05 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -1486,6 +1486,9 @@ enum drm_xe_oa_unit_type {
+ 
+ 	/** @DRM_XE_OA_UNIT_TYPE_OAM: OAM OA unit */
+ 	DRM_XE_OA_UNIT_TYPE_OAM,
++
++	/** @DRM_XE_OA_UNIT_TYPE_OAM_SAG: OAM_SAG OA unit */
++	DRM_XE_OA_UNIT_TYPE_OAM_SAG,
+ };
+ 
+ /**
+@@ -1507,6 +1510,7 @@ struct drm_xe_oa_unit {
+ #define DRM_XE_OA_CAPS_SYNCS		(1 << 1)
+ #define DRM_XE_OA_CAPS_OA_BUFFER_SIZE	(1 << 2)
+ #define DRM_XE_OA_CAPS_WAIT_NUM_REPORTS	(1 << 3)
++#define DRM_XE_OA_CAPS_OAM		(1 << 4)
+ 
+ 	/** @oa_timestamp_freq: OA timestamp freq */
+ 	__u64 oa_timestamp_freq;
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-pf-Drop-rounddown_pow_of_two-fair-LMEM-limita.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-pf-Drop-rounddown_pow_of_two-fair-LMEM-limita.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 11 Sep 2025 00:24:39 +0200
+Subject: drm/xe/pf: Drop rounddown_pow_of_two fair LMEM limitation
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This effectively reverts commit 4c3fe5eae46b ("drm/xe/pf: Limit
+fair VF LMEM provisioning") since we don't need it any more after
+non-contig VRAM allocations were fixed. This allows larger LMEM
+auto-provisioning for VFs, so instead:
+
+ [ ] GT0: PF: LMEM available(14096M) fair(1 x 8192M)
+ [ ] GT0: PF: VF1 provisioned with 8589934592 (8.00 GiB) LMEM
+or
+ [ ] GT0: PF: LMEM available(14096M) fair(2 x 4096M)
+ [ ] GT0: PF: VF1..VF2 provisioned with 4294967296 (4.00 GiB) LMEM
+
+we may get:
+
+ [ ] GT0: PF: LMEM available(14096M) fair(1 x 14096M)
+ [ ] GT0: PF: VF1 provisioned with 14780727296 (13.8 GiB) LMEM
+and
+ [ ] GT0: PF: LMEM available(14096M) fair(2 x 7048M)
+ [ ] GT0: PF: VF1..VF2 provisioned with 7390363648 (6.88 GiB) LMEM
+
+Fixes: 1e32ffbc9dc8 ("drm/xe/sriov: support non-contig VRAM provisioning")
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://lore.kernel.org/r/20250910222439.32869-1-michal.wajdeczko@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit fef8b64e48e836344574b85132a1c317f4260022 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index e142fea8041c..8a0645f3fd75 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1600,7 +1600,6 @@ static u64 pf_estimate_fair_lmem(struct xe_gt *gt, unsigned int num_vfs)
+ 	u64 fair;
+ 
+ 	fair = div_u64(available, num_vfs);
+-	fair = rounddown_pow_of_two(fair);	/* XXX: ttm_vram_mgr & drm_buddy limitation */
+ 	fair = ALIGN_DOWN(fair, alignment);
+ #ifdef MAX_FAIR_LMEM
+ 	fair = min_t(u64, MAX_FAIR_LMEM, fair);
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-pf-Expose-basic-info-about-VFs-in-debugfs.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-pf-Expose-basic-info-about-VFs-in-debugfs.patch
@@ -1,0 +1,133 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Sun, 13 Jul 2025 12:36:23 +0200
+Subject: drm/xe/pf: Expose basic info about VFs in debugfs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We already have function to print summary about VFs, but we missed
+to add debugfs attribute to make it visible. Do it now.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://lore.kernel.org/r/20250713103625.1964-6-michal.wajdeczko@intel.com
+(cherry-picked from commit d962178a882a1db2f56953e0f956685a12eeb83f linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_debugfs.c  |  4 +++
+ drivers/gpu/drm/xe/xe_sriov_pf.c | 43 ++++++++++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_sriov_pf.h |  6 +++++
+ 3 files changed, 53 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_debugfs.c b/drivers/gpu/drm/xe/xe_debugfs.c
+index e9e5c1f79303..5a5c15605a4b 100644
+--- a/drivers/gpu/drm/xe/xe_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_debugfs.c
+@@ -21,6 +21,7 @@
+ #include "xe_mmio.h"
+ #include "xe_pm.h"
+ #include "xe_sriov.h"
++#include "xe_sriov_pf.h"
+ #include "xe_step.h"
+ #include "xe_vsec.h"
+ 
+@@ -317,4 +318,7 @@ void xe_debugfs_register(struct xe_device *xe)
+ 		xe_gt_debugfs_register(gt);
+ 
+ 	fault_create_debugfs_attr("fail_gt_reset", root, &gt_reset_failure);
++
++	if (IS_SRIOV_PF(xe))
++		xe_sriov_pf_debugfs_register(xe, root);
+ }
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf.c b/drivers/gpu/drm/xe/xe_sriov_pf.c
+index 0f721ae17b26..331755843e10 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf.c
++++ b/drivers/gpu/drm/xe/xe_sriov_pf.c
+@@ -3,6 +3,8 @@
+  * Copyright © 2023-2024 Intel Corporation
+  */
+ 
++#include <linux/debugfs.h>
++#include <drm/drm_debugfs.h>
+ #include <drm/drm_managed.h>
+ 
+ #include "xe_assert.h"
+@@ -102,3 +104,44 @@ void xe_sriov_pf_print_vfs_summary(struct xe_device *xe, struct drm_printer *p)
+ 	drm_printf(p, "supported: %u\n", xe->sriov.pf.driver_max_vfs);
+ 	drm_printf(p, "enabled: %u\n", pci_num_vf(pdev));
+ }
++
++static int simple_show(struct seq_file *m, void *data)
++{
++	struct drm_printer p = drm_seq_file_printer(m);
++	struct drm_info_node *node = m->private;
++	struct dentry *parent = node->dent->d_parent;
++	struct xe_device *xe = parent->d_inode->i_private;
++	void (*print)(struct xe_device *, struct drm_printer *) = node->info_ent->data;
++
++	print(xe, &p);
++	return 0;
++}
++
++static const struct drm_info_list debugfs_list[] = {
++	{ .name = "vfs", .show = simple_show, .data = xe_sriov_pf_print_vfs_summary },
++};
++
++/**
++ * xe_sriov_pf_debugfs_register - Register PF debugfs attributes.
++ * @xe: the &xe_device
++ * @root: the root &dentry
++ *
++ * Prepare debugfs attributes exposed by the PF.
++ */
++void xe_sriov_pf_debugfs_register(struct xe_device *xe, struct dentry *root)
++{
++	struct drm_minor *minor = xe->drm.primary;
++	struct dentry *parent;
++
++	/*
++	 *      /sys/kernel/debug/dri/0/
++	 *      ├── pf
++	 *      │   ├── ...
++	 */
++	parent = debugfs_create_dir("pf", root);
++	if (IS_ERR(parent))
++		return;
++	parent->d_inode->i_private = xe;
++
++	drm_debugfs_create_files(debugfs_list, ARRAY_SIZE(debugfs_list), parent, minor);
++}
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf.h b/drivers/gpu/drm/xe/xe_sriov_pf.h
+index d1220e70e1c0..c392c3fcf085 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf.h
++++ b/drivers/gpu/drm/xe/xe_sriov_pf.h
+@@ -8,12 +8,14 @@
+ 
+ #include <linux/types.h>
+ 
++struct dentry;
+ struct drm_printer;
+ struct xe_device;
+ 
+ #ifdef CONFIG_PCI_IOV
+ bool xe_sriov_pf_readiness(struct xe_device *xe);
+ int xe_sriov_pf_init_early(struct xe_device *xe);
++void xe_sriov_pf_debugfs_register(struct xe_device *xe, struct dentry *root);
+ void xe_sriov_pf_print_vfs_summary(struct xe_device *xe, struct drm_printer *p);
+ #else
+ static inline bool xe_sriov_pf_readiness(struct xe_device *xe)
+@@ -25,6 +27,10 @@ static inline int xe_sriov_pf_init_early(struct xe_device *xe)
+ {
+ 	return 0;
+ }
++
++static inline void xe_sriov_pf_debugfs_register(struct xe_device *xe, struct dentry *root)
++{
++}
+ #endif
+ 
+ #endif
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-pf-Stop-requiring-VF-PF-version-negotiation-o.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-pf-Stop-requiring-VF-PF-version-negotiation-o.patch
@@ -1,0 +1,1171 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Sun, 13 Jul 2025 12:36:24 +0200
+Subject: drm/xe/pf: Stop requiring VF/PF version negotiation on every
+ GT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+While some VF/PF relay actions must be handled on the GT level,
+like query for runtime registers, it was clarified by the arch
+team that initial version negotiation can be done by the VF just
+once, by using any available GuC/GT.
+
+Move handling of the VF/PF ABI version negotiation on the PF side
+from the GT level functions to the device level functions.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Acked-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://lore.kernel.org/r/20250713103625.1964-7-michal.wajdeczko@intel.com
+(cherry-picked from commit a6c384b24f13bc3f315c226287601727b1e74969 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/Makefile                   |   3 +-
+ .../xe/tests/xe_gt_sriov_pf_service_test.c    | 232 ------------------
+ .../drm/xe/tests/xe_sriov_pf_service_kunit.c  | 227 +++++++++++++++++
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_control.c   |   7 +-
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c   |   5 -
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_service.c   | 166 +------------
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_service.h   |   2 -
+ drivers/gpu/drm/xe/xe_sriov_pf.c              |  18 +-
+ drivers/gpu/drm/xe/xe_sriov_pf_service.c      | 216 ++++++++++++++++
+ drivers/gpu/drm/xe/xe_sriov_pf_service.h      |  23 ++
+ .../gpu/drm/xe/xe_sriov_pf_service_types.h    |  36 +++
+ drivers/gpu/drm/xe/xe_sriov_pf_types.h        |  16 ++
+ 12 files changed, 548 insertions(+), 403 deletions(-)
+ delete mode 100644 drivers/gpu/drm/xe/tests/xe_gt_sriov_pf_service_test.c
+ create mode 100644 drivers/gpu/drm/xe/tests/xe_sriov_pf_service_kunit.c
+ create mode 100644 drivers/gpu/drm/xe/xe_sriov_pf_service.c
+ create mode 100644 drivers/gpu/drm/xe/xe_sriov_pf_service.h
+ create mode 100644 drivers/gpu/drm/xe/xe_sriov_pf_service_types.h
+
+diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
+index 17addeabf5f8..cc5873469dc7 100644
+--- a/drivers/gpu/drm/xe/Makefile
++++ b/drivers/gpu/drm/xe/Makefile
+@@ -149,7 +149,8 @@ xe-$(CONFIG_PCI_IOV) += \
+ 	xe_lmtt_2l.o \
+ 	xe_lmtt_ml.o \
+ 	xe_pci_sriov.o \
+-	xe_sriov_pf.o
++	xe_sriov_pf.o \
++	xe_sriov_pf_service.o
+ 
+ # include helpers for tests even when XE is built-in
+ ifdef CONFIG_DRM_XE_KUNIT_TEST
+diff --git a/drivers/gpu/drm/xe/tests/xe_gt_sriov_pf_service_test.c b/drivers/gpu/drm/xe/tests/xe_gt_sriov_pf_service_test.c
+deleted file mode 100644
+index b683585db852..000000000000
+--- a/drivers/gpu/drm/xe/tests/xe_gt_sriov_pf_service_test.c
++++ /dev/null
+@@ -1,232 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0 AND MIT
+-/*
+- * Copyright © 2024 Intel Corporation
+- */
+-
+-#include <kunit/test.h>
+-
+-#include "xe_device.h"
+-#include "xe_kunit_helpers.h"
+-#include "xe_pci_test.h"
+-
+-static int pf_service_test_init(struct kunit *test)
+-{
+-	struct xe_pci_fake_data fake = {
+-		.sriov_mode = XE_SRIOV_MODE_PF,
+-		.platform = XE_TIGERLAKE, /* some random platform */
+-		.subplatform = XE_SUBPLATFORM_NONE,
+-	};
+-	struct xe_device *xe;
+-	struct xe_gt *gt;
+-
+-	test->priv = &fake;
+-	xe_kunit_helper_xe_device_test_init(test);
+-
+-	xe = test->priv;
+-	KUNIT_ASSERT_EQ(test, xe_sriov_init(xe), 0);
+-
+-	gt = xe_device_get_gt(xe, 0);
+-	pf_init_versions(gt);
+-
+-	/*
+-	 * sanity check:
+-	 * - all supported platforms VF/PF ABI versions must be defined
+-	 * - base version can't be newer than latest
+-	 */
+-	KUNIT_ASSERT_NE(test, 0, gt->sriov.pf.service.version.base.major);
+-	KUNIT_ASSERT_NE(test, 0, gt->sriov.pf.service.version.latest.major);
+-	KUNIT_ASSERT_LE(test, gt->sriov.pf.service.version.base.major,
+-			gt->sriov.pf.service.version.latest.major);
+-	if (gt->sriov.pf.service.version.base.major == gt->sriov.pf.service.version.latest.major)
+-		KUNIT_ASSERT_LE(test, gt->sriov.pf.service.version.base.minor,
+-				gt->sriov.pf.service.version.latest.minor);
+-
+-	test->priv = gt;
+-	return 0;
+-}
+-
+-static void pf_negotiate_any(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt, VF2PF_HANDSHAKE_MAJOR_ANY,
+-					     VF2PF_HANDSHAKE_MINOR_ANY,
+-					     &major, &minor));
+-	KUNIT_ASSERT_EQ(test, major, gt->sriov.pf.service.version.latest.major);
+-	KUNIT_ASSERT_EQ(test, minor, gt->sriov.pf.service.version.latest.minor);
+-}
+-
+-static void pf_negotiate_base_match(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.base.major,
+-					     gt->sriov.pf.service.version.base.minor,
+-					     &major, &minor));
+-	KUNIT_ASSERT_EQ(test, major, gt->sriov.pf.service.version.base.major);
+-	KUNIT_ASSERT_EQ(test, minor, gt->sriov.pf.service.version.base.minor);
+-}
+-
+-static void pf_negotiate_base_newer(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.base.major,
+-					     gt->sriov.pf.service.version.base.minor + 1,
+-					     &major, &minor));
+-	KUNIT_ASSERT_EQ(test, major, gt->sriov.pf.service.version.base.major);
+-	KUNIT_ASSERT_GE(test, minor, gt->sriov.pf.service.version.base.minor);
+-	if (gt->sriov.pf.service.version.base.major == gt->sriov.pf.service.version.latest.major)
+-		KUNIT_ASSERT_LE(test, minor, gt->sriov.pf.service.version.latest.minor);
+-	else
+-		KUNIT_FAIL(test, "FIXME: don't know how to test multi-version yet!\n");
+-}
+-
+-static void pf_negotiate_base_next(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.base.major + 1, 0,
+-					     &major, &minor));
+-	KUNIT_ASSERT_GE(test, major, gt->sriov.pf.service.version.base.major);
+-	KUNIT_ASSERT_LE(test, major, gt->sriov.pf.service.version.latest.major);
+-	if (major == gt->sriov.pf.service.version.latest.major)
+-		KUNIT_ASSERT_LE(test, minor, gt->sriov.pf.service.version.latest.minor);
+-	else
+-		KUNIT_FAIL(test, "FIXME: don't know how to test multi-version yet!\n");
+-}
+-
+-static void pf_negotiate_base_older(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	if (!gt->sriov.pf.service.version.base.minor)
+-		kunit_skip(test, "no older minor\n");
+-
+-	KUNIT_ASSERT_NE(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.base.major,
+-					     gt->sriov.pf.service.version.base.minor - 1,
+-					     &major, &minor));
+-}
+-
+-static void pf_negotiate_base_prev(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	KUNIT_ASSERT_NE(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.base.major - 1, 1,
+-					     &major, &minor));
+-}
+-
+-static void pf_negotiate_latest_match(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.latest.major,
+-					     gt->sriov.pf.service.version.latest.minor,
+-					     &major, &minor));
+-	KUNIT_ASSERT_EQ(test, major, gt->sriov.pf.service.version.latest.major);
+-	KUNIT_ASSERT_EQ(test, minor, gt->sriov.pf.service.version.latest.minor);
+-}
+-
+-static void pf_negotiate_latest_newer(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.latest.major,
+-					     gt->sriov.pf.service.version.latest.minor + 1,
+-					     &major, &minor));
+-	KUNIT_ASSERT_EQ(test, major, gt->sriov.pf.service.version.latest.major);
+-	KUNIT_ASSERT_EQ(test, minor, gt->sriov.pf.service.version.latest.minor);
+-}
+-
+-static void pf_negotiate_latest_next(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.latest.major + 1, 0,
+-					     &major, &minor));
+-	KUNIT_ASSERT_EQ(test, major, gt->sriov.pf.service.version.latest.major);
+-	KUNIT_ASSERT_EQ(test, minor, gt->sriov.pf.service.version.latest.minor);
+-}
+-
+-static void pf_negotiate_latest_older(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	if (!gt->sriov.pf.service.version.latest.minor)
+-		kunit_skip(test, "no older minor\n");
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.latest.major,
+-					     gt->sriov.pf.service.version.latest.minor - 1,
+-					     &major, &minor));
+-	KUNIT_ASSERT_EQ(test, major, gt->sriov.pf.service.version.latest.major);
+-	KUNIT_ASSERT_EQ(test, minor, gt->sriov.pf.service.version.latest.minor - 1);
+-}
+-
+-static void pf_negotiate_latest_prev(struct kunit *test)
+-{
+-	struct xe_gt *gt = test->priv;
+-	u32 major, minor;
+-
+-	if (gt->sriov.pf.service.version.base.major == gt->sriov.pf.service.version.latest.major)
+-		kunit_skip(test, "no prev major");
+-
+-	KUNIT_ASSERT_EQ(test, 0,
+-			pf_negotiate_version(gt,
+-					     gt->sriov.pf.service.version.latest.major - 1,
+-					     gt->sriov.pf.service.version.base.minor + 1,
+-					     &major, &minor));
+-	KUNIT_ASSERT_EQ(test, major, gt->sriov.pf.service.version.latest.major - 1);
+-	KUNIT_ASSERT_GE(test, major, gt->sriov.pf.service.version.base.major);
+-}
+-
+-static struct kunit_case pf_service_test_cases[] = {
+-	KUNIT_CASE(pf_negotiate_any),
+-	KUNIT_CASE(pf_negotiate_base_match),
+-	KUNIT_CASE(pf_negotiate_base_newer),
+-	KUNIT_CASE(pf_negotiate_base_next),
+-	KUNIT_CASE(pf_negotiate_base_older),
+-	KUNIT_CASE(pf_negotiate_base_prev),
+-	KUNIT_CASE(pf_negotiate_latest_match),
+-	KUNIT_CASE(pf_negotiate_latest_newer),
+-	KUNIT_CASE(pf_negotiate_latest_next),
+-	KUNIT_CASE(pf_negotiate_latest_older),
+-	KUNIT_CASE(pf_negotiate_latest_prev),
+-	{}
+-};
+-
+-static struct kunit_suite pf_service_suite = {
+-	.name = "pf_service",
+-	.test_cases = pf_service_test_cases,
+-	.init = pf_service_test_init,
+-};
+-
+-kunit_test_suite(pf_service_suite);
+diff --git a/drivers/gpu/drm/xe/tests/xe_sriov_pf_service_kunit.c b/drivers/gpu/drm/xe/tests/xe_sriov_pf_service_kunit.c
+new file mode 100644
+index 000000000000..ba95e29b597d
+--- /dev/null
++++ b/drivers/gpu/drm/xe/tests/xe_sriov_pf_service_kunit.c
+@@ -0,0 +1,227 @@
++// SPDX-License-Identifier: GPL-2.0 AND MIT
++/*
++ * Copyright © 2024-2025 Intel Corporation
++ */
++
++#include <kunit/test.h>
++
++#include "xe_device.h"
++#include "xe_kunit_helpers.h"
++#include "xe_pci_test.h"
++
++static int pf_service_test_init(struct kunit *test)
++{
++	struct xe_pci_fake_data fake = {
++		.sriov_mode = XE_SRIOV_MODE_PF,
++		.platform = XE_TIGERLAKE, /* some random platform */
++		.subplatform = XE_SUBPLATFORM_NONE,
++	};
++	struct xe_device *xe;
++
++	test->priv = &fake;
++	xe_kunit_helper_xe_device_test_init(test);
++
++	xe = test->priv;
++	KUNIT_ASSERT_EQ(test, xe_sriov_init(xe), 0);
++
++	xe_sriov_pf_service_init(xe);
++	/*
++	 * sanity check:
++	 * - all supported platforms VF/PF ABI versions must be defined
++	 * - base version can't be newer than latest
++	 */
++	KUNIT_ASSERT_NE(test, 0, xe->sriov.pf.service.version.base.major);
++	KUNIT_ASSERT_NE(test, 0, xe->sriov.pf.service.version.latest.major);
++	KUNIT_ASSERT_LE(test, xe->sriov.pf.service.version.base.major,
++			xe->sriov.pf.service.version.latest.major);
++	if (xe->sriov.pf.service.version.base.major == xe->sriov.pf.service.version.latest.major)
++		KUNIT_ASSERT_LE(test, xe->sriov.pf.service.version.base.minor,
++				xe->sriov.pf.service.version.latest.minor);
++	return 0;
++}
++
++static void pf_negotiate_any(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe, VF2PF_HANDSHAKE_MAJOR_ANY,
++					     VF2PF_HANDSHAKE_MINOR_ANY,
++					     &major, &minor));
++	KUNIT_ASSERT_EQ(test, major, xe->sriov.pf.service.version.latest.major);
++	KUNIT_ASSERT_EQ(test, minor, xe->sriov.pf.service.version.latest.minor);
++}
++
++static void pf_negotiate_base_match(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.base.major,
++					     xe->sriov.pf.service.version.base.minor,
++					     &major, &minor));
++	KUNIT_ASSERT_EQ(test, major, xe->sriov.pf.service.version.base.major);
++	KUNIT_ASSERT_EQ(test, minor, xe->sriov.pf.service.version.base.minor);
++}
++
++static void pf_negotiate_base_newer(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.base.major,
++					     xe->sriov.pf.service.version.base.minor + 1,
++					     &major, &minor));
++	KUNIT_ASSERT_EQ(test, major, xe->sriov.pf.service.version.base.major);
++	KUNIT_ASSERT_GE(test, minor, xe->sriov.pf.service.version.base.minor);
++	if (xe->sriov.pf.service.version.base.major == xe->sriov.pf.service.version.latest.major)
++		KUNIT_ASSERT_LE(test, minor, xe->sriov.pf.service.version.latest.minor);
++	else
++		KUNIT_FAIL(test, "FIXME: don't know how to test multi-version yet!\n");
++}
++
++static void pf_negotiate_base_next(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.base.major + 1, 0,
++					     &major, &minor));
++	KUNIT_ASSERT_GE(test, major, xe->sriov.pf.service.version.base.major);
++	KUNIT_ASSERT_LE(test, major, xe->sriov.pf.service.version.latest.major);
++	if (major == xe->sriov.pf.service.version.latest.major)
++		KUNIT_ASSERT_LE(test, minor, xe->sriov.pf.service.version.latest.minor);
++	else
++		KUNIT_FAIL(test, "FIXME: don't know how to test multi-version yet!\n");
++}
++
++static void pf_negotiate_base_older(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	if (!xe->sriov.pf.service.version.base.minor)
++		kunit_skip(test, "no older minor\n");
++
++	KUNIT_ASSERT_NE(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.base.major,
++					     xe->sriov.pf.service.version.base.minor - 1,
++					     &major, &minor));
++}
++
++static void pf_negotiate_base_prev(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	KUNIT_ASSERT_NE(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.base.major - 1, 1,
++					     &major, &minor));
++}
++
++static void pf_negotiate_latest_match(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.latest.major,
++					     xe->sriov.pf.service.version.latest.minor,
++					     &major, &minor));
++	KUNIT_ASSERT_EQ(test, major, xe->sriov.pf.service.version.latest.major);
++	KUNIT_ASSERT_EQ(test, minor, xe->sriov.pf.service.version.latest.minor);
++}
++
++static void pf_negotiate_latest_newer(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.latest.major,
++					     xe->sriov.pf.service.version.latest.minor + 1,
++					     &major, &minor));
++	KUNIT_ASSERT_EQ(test, major, xe->sriov.pf.service.version.latest.major);
++	KUNIT_ASSERT_EQ(test, minor, xe->sriov.pf.service.version.latest.minor);
++}
++
++static void pf_negotiate_latest_next(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.latest.major + 1, 0,
++					     &major, &minor));
++	KUNIT_ASSERT_EQ(test, major, xe->sriov.pf.service.version.latest.major);
++	KUNIT_ASSERT_EQ(test, minor, xe->sriov.pf.service.version.latest.minor);
++}
++
++static void pf_negotiate_latest_older(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	if (!xe->sriov.pf.service.version.latest.minor)
++		kunit_skip(test, "no older minor\n");
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.latest.major,
++					     xe->sriov.pf.service.version.latest.minor - 1,
++					     &major, &minor));
++	KUNIT_ASSERT_EQ(test, major, xe->sriov.pf.service.version.latest.major);
++	KUNIT_ASSERT_EQ(test, minor, xe->sriov.pf.service.version.latest.minor - 1);
++}
++
++static void pf_negotiate_latest_prev(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	u32 major, minor;
++
++	if (xe->sriov.pf.service.version.base.major == xe->sriov.pf.service.version.latest.major)
++		kunit_skip(test, "no prev major");
++
++	KUNIT_ASSERT_EQ(test, 0,
++			pf_negotiate_version(xe,
++					     xe->sriov.pf.service.version.latest.major - 1,
++					     xe->sriov.pf.service.version.base.minor + 1,
++					     &major, &minor));
++	KUNIT_ASSERT_EQ(test, major, xe->sriov.pf.service.version.latest.major - 1);
++	KUNIT_ASSERT_GE(test, major, xe->sriov.pf.service.version.base.major);
++}
++
++static struct kunit_case pf_service_test_cases[] = {
++	KUNIT_CASE(pf_negotiate_any),
++	KUNIT_CASE(pf_negotiate_base_match),
++	KUNIT_CASE(pf_negotiate_base_newer),
++	KUNIT_CASE(pf_negotiate_base_next),
++	KUNIT_CASE(pf_negotiate_base_older),
++	KUNIT_CASE(pf_negotiate_base_prev),
++	KUNIT_CASE(pf_negotiate_latest_match),
++	KUNIT_CASE(pf_negotiate_latest_newer),
++	KUNIT_CASE(pf_negotiate_latest_next),
++	KUNIT_CASE(pf_negotiate_latest_older),
++	KUNIT_CASE(pf_negotiate_latest_prev),
++	{}
++};
++
++static struct kunit_suite pf_service_suite = {
++	.name = "pf_service",
++	.test_cases = pf_service_test_cases,
++	.init = pf_service_test_init,
++};
++
++kunit_test_suite(pf_service_suite);
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_control.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_control.c
+index 1f50aec3a059..4f7fff892bc0 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_control.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_control.c
+@@ -15,10 +15,11 @@
+ #include "xe_gt_sriov_pf_helpers.h"
+ #include "xe_gt_sriov_pf_migration.h"
+ #include "xe_gt_sriov_pf_monitor.h"
+-#include "xe_gt_sriov_pf_service.h"
+ #include "xe_gt_sriov_printk.h"
+ #include "xe_guc_ct.h"
+ #include "xe_sriov.h"
++#include "xe_sriov_pf_service.h"
++#include "xe_tile.h"
+ 
+ static const char *control_cmd_to_string(u32 cmd)
+ {
+@@ -1064,7 +1065,9 @@ static bool pf_exit_vf_flr_reset_data(struct xe_gt *gt, unsigned int vfid)
+ 	if (!pf_exit_vf_state(gt, vfid, XE_GT_SRIOV_STATE_FLR_RESET_DATA))
+ 		return false;
+ 
+-	xe_gt_sriov_pf_service_reset(gt, vfid);
++	if (xe_tile_is_root(gt->tile) && xe_gt_is_main_type(gt))
++		xe_sriov_pf_service_reset_vf(gt_to_xe(gt), vfid);
++
+ 	xe_gt_sriov_pf_monitor_flr(gt, vfid);
+ 
+ 	pf_enter_vf_flr_reset_mmio(gt, vfid);
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c
+index 4cc68fa1a5d3..27b3a6ff9d56 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_debugfs.c
+@@ -77,11 +77,6 @@ static const struct drm_info_list pf_info[] = {
+ 		.show = xe_gt_debugfs_simple_show,
+ 		.data = xe_gt_sriov_pf_service_print_runtime,
+ 	},
+-	{
+-		"negotiated_versions",
+-		.show = xe_gt_debugfs_simple_show,
+-		.data = xe_gt_sriov_pf_service_print_version,
+-	},
+ 	{
+ 		"adverse_events",
+ 		.show = xe_gt_debugfs_simple_show,
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_service.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_service.c
+index 821cfcc34e6b..a7d4941dea5a 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_service.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_service.c
+@@ -19,91 +19,7 @@
+ #include "xe_gt_sriov_pf_service_types.h"
+ #include "xe_guc_ct.h"
+ #include "xe_guc_hxg_helpers.h"
+-
+-static void pf_init_versions(struct xe_gt *gt)
+-{
+-	BUILD_BUG_ON(!GUC_RELAY_VERSION_BASE_MAJOR && !GUC_RELAY_VERSION_BASE_MINOR);
+-	BUILD_BUG_ON(GUC_RELAY_VERSION_BASE_MAJOR > GUC_RELAY_VERSION_LATEST_MAJOR);
+-
+-	/* base versions may differ between platforms */
+-	gt->sriov.pf.service.version.base.major = GUC_RELAY_VERSION_BASE_MAJOR;
+-	gt->sriov.pf.service.version.base.minor = GUC_RELAY_VERSION_BASE_MINOR;
+-
+-	/* latest version is same for all platforms */
+-	gt->sriov.pf.service.version.latest.major = GUC_RELAY_VERSION_LATEST_MAJOR;
+-	gt->sriov.pf.service.version.latest.minor = GUC_RELAY_VERSION_LATEST_MINOR;
+-}
+-
+-/* Return: 0 on success or a negative error code on failure. */
+-static int pf_negotiate_version(struct xe_gt *gt,
+-				u32 wanted_major, u32 wanted_minor,
+-				u32 *major, u32 *minor)
+-{
+-	struct xe_gt_sriov_pf_service_version base = gt->sriov.pf.service.version.base;
+-	struct xe_gt_sriov_pf_service_version latest = gt->sriov.pf.service.version.latest;
+-
+-	xe_gt_assert(gt, base.major);
+-	xe_gt_assert(gt, base.major <= latest.major);
+-	xe_gt_assert(gt, (base.major < latest.major) || (base.minor <= latest.minor));
+-
+-	/* VF doesn't care - return our latest  */
+-	if (wanted_major == VF2PF_HANDSHAKE_MAJOR_ANY &&
+-	    wanted_minor == VF2PF_HANDSHAKE_MINOR_ANY) {
+-		*major = latest.major;
+-		*minor = latest.minor;
+-		return 0;
+-	}
+-
+-	/* VF wants newer than our - return our latest  */
+-	if (wanted_major > latest.major) {
+-		*major = latest.major;
+-		*minor = latest.minor;
+-		return 0;
+-	}
+-
+-	/* VF wants older than min required - reject */
+-	if (wanted_major < base.major ||
+-	    (wanted_major == base.major && wanted_minor < base.minor)) {
+-		return -EPERM;
+-	}
+-
+-	/* previous major - return wanted, as we should still support it */
+-	if (wanted_major < latest.major) {
+-		/* XXX: we are not prepared for multi-versions yet */
+-		xe_gt_assert(gt, base.major == latest.major);
+-		return -ENOPKG;
+-	}
+-
+-	/* same major - return common minor */
+-	*major = wanted_major;
+-	*minor = min_t(u32, latest.minor, wanted_minor);
+-	return 0;
+-}
+-
+-static void pf_connect(struct xe_gt *gt, u32 vfid, u32 major, u32 minor)
+-{
+-	xe_gt_sriov_pf_assert_vfid(gt, vfid);
+-	xe_gt_assert(gt, major || minor);
+-
+-	gt->sriov.pf.vfs[vfid].version.major = major;
+-	gt->sriov.pf.vfs[vfid].version.minor = minor;
+-}
+-
+-static void pf_disconnect(struct xe_gt *gt, u32 vfid)
+-{
+-	xe_gt_sriov_pf_assert_vfid(gt, vfid);
+-
+-	gt->sriov.pf.vfs[vfid].version.major = 0;
+-	gt->sriov.pf.vfs[vfid].version.minor = 0;
+-}
+-
+-static bool pf_is_negotiated(struct xe_gt *gt, u32 vfid, u32 major, u32 minor)
+-{
+-	xe_gt_sriov_pf_assert_vfid(gt, vfid);
+-
+-	return major == gt->sriov.pf.vfs[vfid].version.major &&
+-	       minor <= gt->sriov.pf.vfs[vfid].version.minor;
+-}
++#include "xe_sriov_pf_service.h"
+ 
+ static const struct xe_reg tgl_runtime_regs[] = {
+ 	RPM_CONFIG0,			/* _MMIO(0x0d00) */
+@@ -285,8 +201,6 @@ int xe_gt_sriov_pf_service_init(struct xe_gt *gt)
+ {
+ 	int err;
+ 
+-	pf_init_versions(gt);
+-
+ 	err = pf_alloc_runtime_info(gt);
+ 	if (unlikely(err))
+ 		goto failed;
+@@ -311,47 +225,6 @@ void xe_gt_sriov_pf_service_update(struct xe_gt *gt)
+ 	pf_prepare_runtime_info(gt);
+ }
+ 
+-/**
+- * xe_gt_sriov_pf_service_reset - Reset a connection with the VF.
+- * @gt: the &xe_gt
+- * @vfid: the VF identifier
+- *
+- * Reset a VF driver negotiated VF/PF ABI version.
+- * After that point, the VF driver will have to perform new version handshake
+- * to continue use of the PF services again.
+- *
+- * This function can only be called on PF.
+- */
+-void xe_gt_sriov_pf_service_reset(struct xe_gt *gt, unsigned int vfid)
+-{
+-	pf_disconnect(gt, vfid);
+-}
+-
+-/* Return: 0 on success or a negative error code on failure. */
+-static int pf_process_handshake(struct xe_gt *gt, u32 vfid,
+-				u32 wanted_major, u32 wanted_minor,
+-				u32 *major, u32 *minor)
+-{
+-	int err;
+-
+-	xe_gt_sriov_dbg_verbose(gt, "VF%u wants ABI version %u.%u\n",
+-				vfid, wanted_major, wanted_minor);
+-
+-	err = pf_negotiate_version(gt, wanted_major, wanted_minor, major, minor);
+-
+-	if (err < 0) {
+-		xe_gt_sriov_notice(gt, "VF%u failed to negotiate ABI %u.%u (%pe)\n",
+-				   vfid, wanted_major, wanted_minor, ERR_PTR(err));
+-		pf_disconnect(gt, vfid);
+-	} else {
+-		xe_gt_sriov_dbg(gt, "VF%u negotiated ABI version %u.%u\n",
+-				vfid, *major, *minor);
+-		pf_connect(gt, vfid, *major, *minor);
+-	}
+-
+-	return 0;
+-}
+-
+ /* Return: length of the response message or a negative error code on failure. */
+ static int pf_process_handshake_msg(struct xe_gt *gt, u32 origin,
+ 				    const u32 *request, u32 len, u32 *response, u32 size)
+@@ -371,7 +244,8 @@ static int pf_process_handshake_msg(struct xe_gt *gt, u32 origin,
+ 	wanted_major = FIELD_GET(VF2PF_HANDSHAKE_REQUEST_MSG_1_MAJOR, request[1]);
+ 	wanted_minor = FIELD_GET(VF2PF_HANDSHAKE_REQUEST_MSG_1_MINOR, request[1]);
+ 
+-	err = pf_process_handshake(gt, origin, wanted_major, wanted_minor, &major, &minor);
++	err = xe_sriov_pf_service_handshake_vf(gt_to_xe(gt), origin, wanted_major, wanted_minor,
++					       &major, &minor);
+ 	if (err < 0)
+ 		return err;
+ 
+@@ -430,8 +304,10 @@ static int pf_process_runtime_query_msg(struct xe_gt *gt, u32 origin,
+ 	u32 remaining = 0;
+ 	int ret;
+ 
+-	if (!pf_is_negotiated(gt, origin, 1, 0))
++	/* this action is available from ABI 1.0 */
++	if (!xe_sriov_pf_service_is_negotiated(gt_to_xe(gt), origin, 1, 0))
+ 		return -EACCES;
++
+ 	if (unlikely(msg_len > VF2PF_QUERY_RUNTIME_REQUEST_MSG_LEN))
+ 		return -EMSGSIZE;
+ 	if (unlikely(msg_len < VF2PF_QUERY_RUNTIME_REQUEST_MSG_LEN))
+@@ -528,33 +404,3 @@ int xe_gt_sriov_pf_service_print_runtime(struct xe_gt *gt, struct drm_printer *p
+ 
+ 	return 0;
+ }
+-
+-/**
+- * xe_gt_sriov_pf_service_print_version - Print ABI versions negotiated with VFs.
+- * @gt: the &xe_gt
+- * @p: the &drm_printer
+- *
+- * This function is for PF use only.
+- */
+-int xe_gt_sriov_pf_service_print_version(struct xe_gt *gt, struct drm_printer *p)
+-{
+-	struct xe_device *xe = gt_to_xe(gt);
+-	unsigned int n, total_vfs = xe_sriov_pf_get_totalvfs(xe);
+-	struct xe_gt_sriov_pf_service_version *version;
+-
+-	xe_gt_assert(gt, IS_SRIOV_PF(xe));
+-
+-	for (n = 1; n <= total_vfs; n++) {
+-		version = &gt->sriov.pf.vfs[n].version;
+-		if (!version->major && !version->minor)
+-			continue;
+-
+-		drm_printf(p, "VF%u:\t%u.%u\n", n, version->major, version->minor);
+-	}
+-
+-	return 0;
+-}
+-
+-#if IS_BUILTIN(CONFIG_DRM_XE_KUNIT_TEST)
+-#include "tests/xe_gt_sriov_pf_service_test.c"
+-#endif
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_service.h b/drivers/gpu/drm/xe/xe_gt_sriov_pf_service.h
+index 56aaadf0360d..10b02c9b651c 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_service.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_service.h
+@@ -14,9 +14,7 @@ struct xe_gt;
+ 
+ int xe_gt_sriov_pf_service_init(struct xe_gt *gt);
+ void xe_gt_sriov_pf_service_update(struct xe_gt *gt);
+-void xe_gt_sriov_pf_service_reset(struct xe_gt *gt, unsigned int vfid);
+ 
+-int xe_gt_sriov_pf_service_print_version(struct xe_gt *gt, struct drm_printer *p);
+ int xe_gt_sriov_pf_service_print_runtime(struct xe_gt *gt, struct drm_printer *p);
+ 
+ #ifdef CONFIG_PCI_IOV
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf.c b/drivers/gpu/drm/xe/xe_sriov_pf.c
+index 331755843e10..afbdd894bd6e 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf.c
++++ b/drivers/gpu/drm/xe/xe_sriov_pf.c
+@@ -12,6 +12,8 @@
+ #include "xe_module.h"
+ #include "xe_sriov.h"
+ #include "xe_sriov_pf.h"
++#include "xe_sriov_pf_helpers.h"
++#include "xe_sriov_pf_service.h"
+ #include "xe_sriov_printk.h"
+ 
+ static unsigned int wanted_max_vfs(struct xe_device *xe)
+@@ -82,9 +84,22 @@ bool xe_sriov_pf_readiness(struct xe_device *xe)
+  */
+ int xe_sriov_pf_init_early(struct xe_device *xe)
+ {
++	int err;
++
+ 	xe_assert(xe, IS_SRIOV_PF(xe));
+ 
+-	return drmm_mutex_init(&xe->drm, &xe->sriov.pf.master_lock);
++	xe->sriov.pf.vfs = drmm_kcalloc(&xe->drm, 1 + xe_sriov_pf_get_totalvfs(xe),
++					sizeof(*xe->sriov.pf.vfs), GFP_KERNEL);
++	if (!xe->sriov.pf.vfs)
++		return -ENOMEM;
++
++	err = drmm_mutex_init(&xe->drm, &xe->sriov.pf.master_lock);
++	if (err)
++		return err;
++
++	xe_sriov_pf_service_init(xe);
++
++	return 0;
+ }
+ 
+ /**
+@@ -119,6 +134,7 @@ static int simple_show(struct seq_file *m, void *data)
+ 
+ static const struct drm_info_list debugfs_list[] = {
+ 	{ .name = "vfs", .show = simple_show, .data = xe_sriov_pf_print_vfs_summary },
++	{ .name = "versions", .show = simple_show, .data = xe_sriov_pf_service_print_versions },
+ };
+ 
+ /**
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_service.c b/drivers/gpu/drm/xe/xe_sriov_pf_service.c
+new file mode 100644
+index 000000000000..eee3b2a1ba41
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_service.c
+@@ -0,0 +1,216 @@
++// SPDX-License-Identifier: MIT
++/*
++ * Copyright © 2023-2025 Intel Corporation
++ */
++
++#include "abi/guc_relay_actions_abi.h"
++
++#include "xe_device_types.h"
++#include "xe_sriov.h"
++#include "xe_sriov_pf_helpers.h"
++#include "xe_sriov_printk.h"
++
++#include "xe_sriov_pf_service.h"
++#include "xe_sriov_pf_service_types.h"
++
++/**
++ * xe_sriov_pf_service_init - Early initialization of the SR-IOV PF service.
++ * @xe: the &xe_device to initialize
++ *
++ * Performs early initialization of the SR-IOV PF service.
++ *
++ * This function can only be called on PF.
++ */
++void xe_sriov_pf_service_init(struct xe_device *xe)
++{
++	BUILD_BUG_ON(!GUC_RELAY_VERSION_BASE_MAJOR && !GUC_RELAY_VERSION_BASE_MINOR);
++	BUILD_BUG_ON(GUC_RELAY_VERSION_BASE_MAJOR > GUC_RELAY_VERSION_LATEST_MAJOR);
++
++	xe_assert(xe, IS_SRIOV_PF(xe));
++
++	/* base versions may differ between platforms */
++	xe->sriov.pf.service.version.base.major = GUC_RELAY_VERSION_BASE_MAJOR;
++	xe->sriov.pf.service.version.base.minor = GUC_RELAY_VERSION_BASE_MINOR;
++
++	/* latest version is same for all platforms */
++	xe->sriov.pf.service.version.latest.major = GUC_RELAY_VERSION_LATEST_MAJOR;
++	xe->sriov.pf.service.version.latest.minor = GUC_RELAY_VERSION_LATEST_MINOR;
++}
++
++/* Return: 0 on success or a negative error code on failure. */
++static int pf_negotiate_version(struct xe_device *xe,
++				u32 wanted_major, u32 wanted_minor,
++				u32 *major, u32 *minor)
++{
++	struct xe_sriov_pf_service_version base = xe->sriov.pf.service.version.base;
++	struct xe_sriov_pf_service_version latest = xe->sriov.pf.service.version.latest;
++
++	xe_assert(xe, IS_SRIOV_PF(xe));
++	xe_assert(xe, base.major);
++	xe_assert(xe, base.major <= latest.major);
++	xe_assert(xe, (base.major < latest.major) || (base.minor <= latest.minor));
++
++	/* VF doesn't care - return our latest  */
++	if (wanted_major == VF2PF_HANDSHAKE_MAJOR_ANY &&
++	    wanted_minor == VF2PF_HANDSHAKE_MINOR_ANY) {
++		*major = latest.major;
++		*minor = latest.minor;
++		return 0;
++	}
++
++	/* VF wants newer than our - return our latest  */
++	if (wanted_major > latest.major) {
++		*major = latest.major;
++		*minor = latest.minor;
++		return 0;
++	}
++
++	/* VF wants older than min required - reject */
++	if (wanted_major < base.major ||
++	    (wanted_major == base.major && wanted_minor < base.minor)) {
++		return -EPERM;
++	}
++
++	/* previous major - return wanted, as we should still support it */
++	if (wanted_major < latest.major) {
++		/* XXX: we are not prepared for multi-versions yet */
++		xe_assert(xe, base.major == latest.major);
++		return -ENOPKG;
++	}
++
++	/* same major - return common minor */
++	*major = wanted_major;
++	*minor = min_t(u32, latest.minor, wanted_minor);
++	return 0;
++}
++
++static void pf_connect(struct xe_device *xe, u32 vfid, u32 major, u32 minor)
++{
++	xe_sriov_pf_assert_vfid(xe, vfid);
++	xe_assert(xe, major || minor);
++
++	xe->sriov.pf.vfs[vfid].version.major = major;
++	xe->sriov.pf.vfs[vfid].version.minor = minor;
++}
++
++static void pf_disconnect(struct xe_device *xe, u32 vfid)
++{
++	xe_sriov_pf_assert_vfid(xe, vfid);
++
++	xe->sriov.pf.vfs[vfid].version.major = 0;
++	xe->sriov.pf.vfs[vfid].version.minor = 0;
++}
++
++/**
++ * xe_sriov_pf_service_is_negotiated - Check if VF has negotiated given ABI version.
++ * @xe: the &xe_device
++ * @vfid: the VF identifier
++ * @major: the major version to check
++ * @minor: the minor version to check
++ *
++ * Performs early initialization of the SR-IOV PF service.
++ *
++ * This function can only be called on PF.
++ *
++ * Returns: true if VF can use given ABI version functionality.
++ */
++bool xe_sriov_pf_service_is_negotiated(struct xe_device *xe, u32 vfid, u32 major, u32 minor)
++{
++	xe_sriov_pf_assert_vfid(xe, vfid);
++
++	return major == xe->sriov.pf.vfs[vfid].version.major &&
++	       minor <= xe->sriov.pf.vfs[vfid].version.minor;
++}
++
++/**
++ * xe_sriov_pf_service_handshake_vf - Confirm a connection with the VF.
++ * @xe: the &xe_device
++ * @vfid: the VF identifier
++ * @wanted_major: the major service version expected by the VF
++ * @wanted_minor: the minor service version expected by the VF
++ * @major: the major service version to be used by the VF
++ * @minor: the minor service version to be used by the VF
++ *
++ * Negotiate a VF/PF ABI version to allow VF use the PF services.
++ *
++ * This function can only be called on PF.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_sriov_pf_service_handshake_vf(struct xe_device *xe, u32 vfid,
++				     u32 wanted_major, u32 wanted_minor,
++				     u32 *major, u32 *minor)
++{
++	int err;
++
++	xe_sriov_dbg_verbose(xe, "VF%u wants ABI version %u.%u\n",
++			     vfid, wanted_major, wanted_minor);
++
++	err = pf_negotiate_version(xe, wanted_major, wanted_minor, major, minor);
++
++	if (err < 0) {
++		xe_sriov_notice(xe, "VF%u failed to negotiate ABI %u.%u (%pe)\n",
++				vfid, wanted_major, wanted_minor, ERR_PTR(err));
++		pf_disconnect(xe, vfid);
++	} else {
++		xe_sriov_dbg(xe, "VF%u negotiated ABI version %u.%u\n",
++			     vfid, *major, *minor);
++		pf_connect(xe, vfid, *major, *minor);
++	}
++
++	return err;
++}
++
++/**
++ * xe_sriov_pf_service_reset_vf - Reset a connection with the VF.
++ * @xe: the &xe_device
++ * @vfid: the VF identifier
++ *
++ * Reset a VF driver negotiated VF/PF ABI version.
++ *
++ * After that point, the VF driver will have to perform new version handshake
++ * to continue use of the PF services again.
++ *
++ * This function can only be called on PF.
++ */
++void xe_sriov_pf_service_reset_vf(struct xe_device *xe, unsigned int vfid)
++{
++	pf_disconnect(xe, vfid);
++}
++
++static void print_pf_version(struct drm_printer *p, const char *name,
++			     const struct xe_sriov_pf_service_version *version)
++{
++	drm_printf(p, "%s:\t%u.%u\n", name, version->major, version->minor);
++}
++
++/**
++ * xe_sriov_pf_service_print_versions - Print ABI versions negotiated with VFs.
++ * @xe: the &xe_device
++ * @p: the &drm_printer
++ *
++ * This function is for PF use only.
++ */
++void xe_sriov_pf_service_print_versions(struct xe_device *xe, struct drm_printer *p)
++{
++	unsigned int n, total_vfs = xe_sriov_pf_get_totalvfs(xe);
++	struct xe_sriov_pf_service_version *version;
++	char name[8];
++
++	xe_assert(xe, IS_SRIOV_PF(xe));
++
++	print_pf_version(p, "base", &xe->sriov.pf.service.version.base);
++	print_pf_version(p, "latest", &xe->sriov.pf.service.version.latest);
++
++	for (n = 1; n <= total_vfs; n++) {
++		version = &xe->sriov.pf.vfs[n].version;
++		if (!version->major && !version->minor)
++			continue;
++
++		print_pf_version(p, xe_sriov_function_name(n, name, sizeof(name)), version);
++	}
++}
++
++#if IS_BUILTIN(CONFIG_DRM_XE_KUNIT_TEST)
++#include "tests/xe_sriov_pf_service_kunit.c"
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_service.h b/drivers/gpu/drm/xe/xe_sriov_pf_service.h
+new file mode 100644
+index 000000000000..d38c18f5ed10
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_service.h
+@@ -0,0 +1,23 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2025 Intel Corporation
++ */
++
++#ifndef _XE_SRIOV_PF_SERVICE_H_
++#define _XE_SRIOV_PF_SERVICE_H_
++
++#include <linux/types.h>
++
++struct drm_printer;
++struct xe_device;
++
++void xe_sriov_pf_service_init(struct xe_device *xe);
++void xe_sriov_pf_service_print_versions(struct xe_device *xe, struct drm_printer *p);
++
++int xe_sriov_pf_service_handshake_vf(struct xe_device *xe, u32 vfid,
++				     u32 wanted_major, u32 wanted_minor,
++				     u32 *major, u32 *minor);
++bool xe_sriov_pf_service_is_negotiated(struct xe_device *xe, u32 vfid, u32 major, u32 minor);
++void xe_sriov_pf_service_reset_vf(struct xe_device *xe, unsigned int vfid);
++
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_service_types.h b/drivers/gpu/drm/xe/xe_sriov_pf_service_types.h
+new file mode 100644
+index 000000000000..0835dde358c1
+--- /dev/null
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_service_types.h
+@@ -0,0 +1,36 @@
++/* SPDX-License-Identifier: MIT */
++/*
++ * Copyright © 2023-2025 Intel Corporation
++ */
++
++#ifndef _XE_SRIOV_PF_SERVICE_TYPES_H_
++#define _XE_SRIOV_PF_SERVICE_TYPES_H_
++
++#include <linux/types.h>
++
++/**
++ * struct xe_sriov_pf_service_version - VF/PF ABI Version.
++ * @major: the major version of the VF/PF ABI
++ * @minor: the minor version of the VF/PF ABI
++ *
++ * See `GuC Relay Communication`_.
++ */
++struct xe_sriov_pf_service_version {
++	u16 major;
++	u16 minor;
++};
++
++/**
++ * struct xe_sriov_pf_service - Data used by the PF service.
++ * @version: information about VF/PF ABI versions for current platform.
++ * @version.base: lowest VF/PF ABI version that could be negotiated with VF.
++ * @version.latest: latest VF/PF ABI version supported by the PF driver.
++ */
++struct xe_sriov_pf_service {
++	struct {
++		struct xe_sriov_pf_service_version base;
++		struct xe_sriov_pf_service_version latest;
++	} version;
++};
++
++#endif
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_types.h b/drivers/gpu/drm/xe/xe_sriov_pf_types.h
+index 918dc089eb1d..956a88f9f213 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_types.h
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_types.h
+@@ -9,6 +9,16 @@
+ #include <linux/mutex.h>
+ #include <linux/types.h>
+ 
++#include "xe_sriov_pf_service_types.h"
++
++/**
++ * struct xe_sriov_metadata - per-VF device level metadata
++ */
++struct xe_sriov_metadata {
++	/** @version: negotiated VF/PF ABI version */
++	struct xe_sriov_pf_service_version version;
++};
++
+ /**
+  * struct xe_device_pf - Xe PF related data
+  *
+@@ -24,6 +34,12 @@ struct xe_device_pf {
+ 
+ 	/** @master_lock: protects all VFs configurations across GTs */
+ 	struct mutex master_lock;
++
++	/** @service: device level service data. */
++	struct xe_sriov_pf_service service;
++
++	/** @vfs: metadata for all VFs. */
++	struct xe_sriov_metadata *vfs;
+ };
+ 
+ #endif
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-vf-Store-negotiated-VF-PF-ABI-version-at-devi.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-vf-Store-negotiated-VF-PF-ABI-version-at-devi.patch
@@ -1,0 +1,176 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Sun, 13 Jul 2025 12:36:25 +0200
+Subject: drm/xe/vf: Store negotiated VF/PF ABI version at device level
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+There is no need to maintain PF ABI version on per-GT level.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://lore.kernel.org/r/20250713103625.1964-8-michal.wajdeczko@intel.com
+(backported from commit b533b8e5a1f90aa15bb6e021cbf84cba2ea23e00 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_vf.c       | 31 +++++++++++++----------
+ drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h | 12 ---------
+ drivers/gpu/drm/xe/xe_sriov_vf_types.h    | 14 ++++++++++
+ 3 files changed, 32 insertions(+), 25 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
+index 44c4693e4ba5..3026b6a1510a 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
+@@ -694,21 +694,22 @@ static int relay_action_handshake(struct xe_gt *gt, u32 *major, u32 *minor)
+ 	return 0;
+ }
+ 
+-static void vf_connect_pf(struct xe_gt *gt, u16 major, u16 minor)
++static void vf_connect_pf(struct xe_device *xe, u16 major, u16 minor)
+ {
+-	xe_gt_assert(gt, IS_SRIOV_VF(gt_to_xe(gt)));
++	xe_assert(xe, IS_SRIOV_VF(xe));
+ 
+-	gt->sriov.vf.pf_version.major = major;
+-	gt->sriov.vf.pf_version.minor = minor;
++	xe->sriov.vf.pf_version.major = major;
++	xe->sriov.vf.pf_version.minor = minor;
+ }
+ 
+-static void vf_disconnect_pf(struct xe_gt *gt)
++static void vf_disconnect_pf(struct xe_device *xe)
+ {
+-	vf_connect_pf(gt, 0, 0);
++	vf_connect_pf(xe, 0, 0);
+ }
+ 
+ static int vf_handshake_with_pf(struct xe_gt *gt)
+ {
++	struct xe_device *xe = gt_to_xe(gt);
+ 	u32 major_wanted = GUC_RELAY_VERSION_LATEST_MAJOR;
+ 	u32 minor_wanted = GUC_RELAY_VERSION_LATEST_MINOR;
+ 	u32 major = major_wanted, minor = minor_wanted;
+@@ -724,13 +725,13 @@ static int vf_handshake_with_pf(struct xe_gt *gt)
+ 	}
+ 
+ 	xe_gt_sriov_dbg(gt, "using VF/PF ABI %u.%u\n", major, minor);
+-	vf_connect_pf(gt, major, minor);
++	vf_connect_pf(xe, major, minor);
+ 	return 0;
+ 
+ failed:
+ 	xe_gt_sriov_err(gt, "Unable to confirm VF/PF ABI version %u.%u (%pe)\n",
+ 			major, minor, ERR_PTR(err));
+-	vf_disconnect_pf(gt);
++	vf_disconnect_pf(xe);
+ 	return err;
+ }
+ 
+@@ -783,10 +784,12 @@ void xe_gt_sriov_vf_migrated_event_handler(struct xe_gt *gt)
+ 
+ static bool vf_is_negotiated(struct xe_gt *gt, u16 major, u16 minor)
+ {
+-	xe_gt_assert(gt, IS_SRIOV_VF(gt_to_xe(gt)));
++	struct xe_device *xe = gt_to_xe(gt);
+ 
+-	return major == gt->sriov.vf.pf_version.major &&
+-	       minor <= gt->sriov.vf.pf_version.minor;
++	xe_gt_assert(gt, IS_SRIOV_VF(xe));
++
++	return major == xe->sriov.vf.pf_version.major &&
++	       minor <= xe->sriov.vf.pf_version.minor;
+ }
+ 
+ static int vf_prepare_runtime_info(struct xe_gt *gt, unsigned int num_regs)
+@@ -972,9 +975,10 @@ u32 xe_gt_sriov_vf_read32(struct xe_gt *gt, struct xe_reg reg)
+ {
+ 	u32 addr = xe_mmio_adjusted_addr(&gt->mmio, reg.addr);
+ 	struct vf_runtime_reg *rr;
++	struct xe_device *xe = gt_to_xe(gt);
+ 
+ 	xe_gt_assert(gt, IS_SRIOV_VF(gt_to_xe(gt)));
+-	xe_gt_assert(gt, gt->sriov.vf.pf_version.major);
++	xe_gt_assert(gt, xe->sriov.vf.pf_version.major);
+ 	xe_gt_assert(gt, !reg.vf);
+ 
+ 	if (reg.addr == GMD_ID.addr) {
+@@ -1080,8 +1084,9 @@ void xe_gt_sriov_vf_print_runtime(struct xe_gt *gt, struct drm_printer *p)
+  */
+ void xe_gt_sriov_vf_print_version(struct xe_gt *gt, struct drm_printer *p)
+ {
++	struct xe_device *xe = gt_to_xe(gt);
+ 	struct xe_gt_sriov_vf_guc_version *guc_version = &gt->sriov.vf.guc_version;
+-	struct xe_gt_sriov_vf_relay_version *pf_version = &gt->sriov.vf.pf_version;
++	struct xe_sriov_vf_relay_version *pf_version = &xe->sriov.vf.pf_version;
+ 	u32 branch, major, minor;
+ 
+ 	xe_gt_assert(gt, IS_SRIOV_VF(gt_to_xe(gt)));
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
+index a57f13b5afcd..7df95f88f4f4 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
+@@ -22,16 +22,6 @@ struct xe_gt_sriov_vf_guc_version {
+ 	u8 patch;
+ };
+ 
+-/**
+- * struct xe_gt_sriov_vf_relay_version - PF ABI version details.
+- */
+-struct xe_gt_sriov_vf_relay_version {
+-	/** @major: major version. */
+-	u16 major;
+-	/** @minor: minor version. */
+-	u16 minor;
+-};
+-
+ /**
+  * struct xe_gt_sriov_vf_selfconfig - VF configuration data.
+  */
+@@ -75,8 +65,6 @@ struct xe_gt_sriov_vf {
+ 	struct xe_gt_sriov_vf_guc_version guc_version;
+ 	/** @self_config: resource configurations. */
+ 	struct xe_gt_sriov_vf_selfconfig self_config;
+-	/** @pf_version: negotiated VF/PF ABI version. */
+-	struct xe_gt_sriov_vf_relay_version pf_version;
+ 	/** @runtime: runtime data retrieved from the PF. */
+ 	struct xe_gt_sriov_vf_runtime runtime;
+ };
+diff --git a/drivers/gpu/drm/xe/xe_sriov_vf_types.h b/drivers/gpu/drm/xe/xe_sriov_vf_types.h
+index 55c2421d4b2e..8300416a6226 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_vf_types.h
++++ b/drivers/gpu/drm/xe/xe_sriov_vf_types.h
+@@ -6,8 +6,19 @@
+ #ifndef _XE_SRIOV_VF_TYPES_H_
+ #define _XE_SRIOV_VF_TYPES_H_
+ 
++#include <linux/types.h>
+ #include <linux/workqueue_types.h>
+ 
++/**
++ * struct xe_sriov_vf_relay_version - PF ABI version details.
++ */
++struct xe_sriov_vf_relay_version {
++	/** @major: major version. */
++	u16 major;
++	/** @minor: minor version. */
++	u16 minor;
++};
++
+ /**
+  * struct xe_device_vf - Xe Virtual Function related data
+  *
+@@ -15,6 +26,9 @@
+  * @XE_SRIOV_MODE_VF mode.
+  */
+ struct xe_device_vf {
++	/** @pf_version: negotiated VF/PF ABI version. */
++	struct xe_sriov_vf_relay_version pf_version;
++
+ 	/** @migration: VF Migration state data */
+ 	struct {
+ 		/** @migration.worker: VF migration recovery worker */
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -129,6 +129,19 @@ backport/patches/features/sriov/0001-drm-xe-Add-MI_MATH-and-ALU-instruction-defi
 backport/patches/features/sriov/0001-drm-xe-Avoid-reading-RMW-registers-in-emit_wa_job.patch
 backport/patches/features/sriov/0001-drm-xe-vf-Disable-CSC-support-on-VF.patch
 backport/patches/features/sriov/0001-drm-xe-vf-Fix-guc_info-debugfs-for-VFs.patch
+backport/patches/features/sriov/0001-drm-xe-oa-uapi-Expose-media-OA-units.patch
+backport/patches/features/sriov/0001-drm-xe-oa-Print-hwe-to-OA-unit-mapping.patch
+backport/patches/features/sriov/0001-drm-xe-oa-Introduce-stream-oa_unit.patch
+backport/patches/features/sriov/0001-drm-xe-oa-Assign-hwe-for-OAM_SAG.patch
+backport/patches/features/sriov/0001-drm-xe-oa-Enable-OAM-latency-measurement.patch
+backport/patches/features/sriov/0001-drm-xe-Combine-PF-and-VF-device-data-into-union.patch
+backport/patches/features/sriov/0001-drm-xe-Move-PF-and-VF-device-types-to-separate-heade.patch
+backport/patches/features/sriov/0001-drm-xe-Introduce-xe_tile_is_root-helper.patch
+backport/patches/features/sriov/0001-drm-xe-Introduce-xe_gt_is_main_type-helper.patch
+backport/patches/features/sriov/0001-drm-xe-pf-Expose-basic-info-about-VFs-in-debugfs.patch
+backport/patches/features/sriov/0001-drm-xe-pf-Stop-requiring-VF-PF-version-negotiation-o.patch
+backport/patches/features/sriov/0001-drm-xe-vf-Store-negotiated-VF-PF-ABI-version-at-devi.patch
+backport/patches/features/sriov/0001-drm-xe-pf-Drop-rounddown_pow_of_two-fair-LMEM-limita.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Expose OAM units (SCMI, SAG) for media workloads and enable latency
measurement on Xe3+. Add helpers for GT/tile checks, improve stream
handling with oa_unit, and assign hwe for OAM_SAG. Print hwe→OA mappings
for debug. Relax VF/PF version negotiation by unifying PF/VF data,
splitting headers, moving negotiation to device level, exposing VF info
in debugfs, and dropping LMEM fair rounddown limit.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>