### PR TITLE
backport/base: Add CPU address mirror VMAs

### DIFF
--- a/backport/patches/base/0001-drm-xe-uapi-Add-DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR.patch
+++ b/backport/patches/base/0001-drm-xe-uapi-Add-DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR.patch
@@ -1,0 +1,690 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Wed, 5 Mar 2025 17:26:33 -0800
+Subject: [PATCH] drm/xe/uapi: Add DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add the DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR flag, which is used to
+create unpopulated virtual memory areas (VMAs) without memory backing or
+GPU page tables. These VMAs are referred to as CPU address mirror VMAs.
+The idea is that upon a page fault or prefetch, the memory backing and
+GPU page tables will be populated.
+
+CPU address mirror VMAs only update GPUVM state; they do not have an
+internal page table (PT) state, nor do they have GPU mappings.
+
+It is expected that CPU address mirror VMAs will be mixed with buffer
+object (BO) VMAs within a single VM. In other words, system allocations
+and runtime allocations can be mixed within a single user-mode driver
+(UMD) program.
+
+Expected usage:
+
+- Bind the entire virtual address (VA) space upon program load using the
+  DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR flag.
+- If a buffer object (BO) requires GPU mapping (runtime allocation),
+  allocate a CPU address using mmap(PROT_NONE), bind the BO to the
+  mmapped address using existing bind IOCTLs. If a CPU map of the BO is
+  needed, mmap it again to the same CPU address using mmap(MAP_FIXED)
+- If a BO no longer requires GPU mapping, munmap it from the CPU address
+  space and them bind the mapping address with the
+  DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR flag.
+- Any malloc'd or mmapped CPU address accessed by the GPU will be
+  faulted in via the SVM implementation (system allocation).
+- Upon freeing any mmapped or malloc'd data, the SVM implementation will
+  remove GPU mappings.
+
+Only supporting 1 to 1 mapping between user address space and GPU
+address space at the moment as that is the expected use case. uAPI
+defines interface for non 1 to 1 but enforces 1 to 1, this restriction
+can be lifted if use cases arrise for non 1 to 1 mappings.
+
+This patch essentially short-circuits the code in the existing VM bind
+paths to avoid populating page tables when the
+DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR flag is set.
+
+v3:
+ - Call vm_bind_ioctl_ops_fini on -ENODATA
+ - Don't allow DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR on non-faulting VMs
+ - s/DRM_XE_VM_BIND_FLAG_SYSTEM_ALLOCATOR/DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR (Thomas)
+ - Rework commit message for expected usage (Thomas)
+ - Describe state of code after patch in commit message (Thomas)
+v4:
+ - Fix alignment (Checkpatch)
+
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250306012657.3505757-9-matthew.brost@intel.com
+(backported from commit b43e864af0d4e74636c0e1dee857ce3275a84829 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pt.c       |  76 +++++++++++++----
+ drivers/gpu/drm/xe/xe_vm.c       | 142 ++++++++++++++++++-------------
+ drivers/gpu/drm/xe/xe_vm.h       |   8 +-
+ drivers/gpu/drm/xe/xe_vm_types.h |   3 +
+ include/uapi/drm/xe_drm.h        |  19 ++++-
+ 5 files changed, 174 insertions(+), 74 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pt.c b/drivers/gpu/drm/xe/xe_pt.c
+index 148d90611eeb..fb7f26353b8f 100644
+--- a/drivers/gpu/drm/xe/xe_pt.c
++++ b/drivers/gpu/drm/xe/xe_pt.c
+@@ -1104,6 +1104,11 @@ static int op_add_deps(struct xe_vm *vm, struct xe_vma_op *op,
+ {
+ 	int err = 0;
+ 
++	/*
++	 * No need to check for is_cpu_addr_mirror here as vma_add_deps is a
++	 * NOP if VMA is_cpu_addr_mirror
++	 */
++
+ 	switch (op->base.op) {
+ 	case DRM_GPUVA_OP_MAP:
+ 		if (!op->map.immediate && xe_vm_in_fault_mode(vm))
+@@ -1662,6 +1667,7 @@ static int bind_op_prepare(struct xe_vm *vm, struct xe_tile *tile,
+ 	struct xe_vm_pgtable_update_op *pt_op = &pt_update_ops->ops[current_op];
+ 	int err;
+ 
++	xe_tile_assert(tile, !xe_vma_is_cpu_addr_mirror(vma));
+ 	xe_bo_assert_held(xe_vma_bo(vma));
+ 
+ 	vm_dbg(&xe_vma_vm(vma)->xe->drm,
+@@ -1729,6 +1735,7 @@ static int unbind_op_prepare(struct xe_tile *tile,
+ 	if (!((vma->tile_present | vma->tile_staged) & BIT(tile->id)))
+ 		return 0;
+ 
++	xe_tile_assert(tile, !xe_vma_is_cpu_addr_mirror(vma));
+ 	xe_bo_assert_held(xe_vma_bo(vma));
+ 
+ 	vm_dbg(&xe_vma_vm(vma)->xe->drm,
+@@ -1775,15 +1782,21 @@ static int op_prepare(struct xe_vm *vm,
+ 
+ 	switch (op->base.op) {
+ 	case DRM_GPUVA_OP_MAP:
+-		if (!op->map.immediate && xe_vm_in_fault_mode(vm))
++		if ((!op->map.immediate && xe_vm_in_fault_mode(vm)) ||
++		    op->map.is_cpu_addr_mirror)
+ 			break;
+ 
+ 		err = bind_op_prepare(vm, tile, pt_update_ops, op->map.vma);
+ 		pt_update_ops->wait_vm_kernel = true;
+ 		break;
+ 	case DRM_GPUVA_OP_REMAP:
+-		err = unbind_op_prepare(tile, pt_update_ops,
+-					gpuva_to_vma(op->base.remap.unmap->va));
++	{
++		struct xe_vma *old = gpuva_to_vma(op->base.remap.unmap->va);
++
++		if (xe_vma_is_cpu_addr_mirror(old))
++			break;
++
++		err = unbind_op_prepare(tile, pt_update_ops, old);
+ 
+ 		if (!err && op->remap.prev) {
+ 			err = bind_op_prepare(vm, tile, pt_update_ops,
+@@ -1796,15 +1809,28 @@ static int op_prepare(struct xe_vm *vm,
+ 			pt_update_ops->wait_vm_bookkeep = true;
+ 		}
+ 		break;
++	}
+ 	case DRM_GPUVA_OP_UNMAP:
+-		err = unbind_op_prepare(tile, pt_update_ops,
+-					gpuva_to_vma(op->base.unmap.va));
++	{
++		struct xe_vma *vma = gpuva_to_vma(op->base.unmap.va);
++
++		if (xe_vma_is_cpu_addr_mirror(vma))
++			break;
++
++		err = unbind_op_prepare(tile, pt_update_ops, vma);
+ 		break;
++	}
+ 	case DRM_GPUVA_OP_PREFETCH:
+-		err = bind_op_prepare(vm, tile, pt_update_ops,
+-				      gpuva_to_vma(op->base.prefetch.va));
++	{
++		struct xe_vma *vma = gpuva_to_vma(op->base.prefetch.va);
++
++		if (xe_vma_is_cpu_addr_mirror(vma))
++			break;
++
++		err = bind_op_prepare(vm, tile, pt_update_ops, vma);
+ 		pt_update_ops->wait_vm_kernel = true;
+ 		break;
++	}
+ 	default:
+ 		drm_warn(&vm->xe->drm, "NOT POSSIBLE");
+ 	}
+@@ -1874,6 +1900,8 @@ static void bind_op_commit(struct xe_vm *vm, struct xe_tile *tile,
+ 			   struct xe_vma *vma, struct dma_fence *fence,
+ 			   struct dma_fence *fence2)
+ {
++	xe_tile_assert(tile, !xe_vma_is_cpu_addr_mirror(vma));
++
+ 	if (!xe_vma_has_no_bo(vma) && !xe_vma_bo(vma)->vm) {
+ 		dma_resv_add_fence(xe_vma_bo(vma)->ttm.base.resv, fence,
+ 				   pt_update_ops->wait_vm_bookkeep ?
+@@ -1907,6 +1935,8 @@ static void unbind_op_commit(struct xe_vm *vm, struct xe_tile *tile,
+ 			     struct xe_vma *vma, struct dma_fence *fence,
+ 			     struct dma_fence *fence2)
+ {
++	xe_tile_assert(tile, !xe_vma_is_cpu_addr_mirror(vma));
++
+ 	if (!xe_vma_has_no_bo(vma) && !xe_vma_bo(vma)->vm) {
+ 		dma_resv_add_fence(xe_vma_bo(vma)->ttm.base.resv, fence,
+ 				   pt_update_ops->wait_vm_bookkeep ?
+@@ -1941,16 +1971,21 @@ static void op_commit(struct xe_vm *vm,
+ 
+ 	switch (op->base.op) {
+ 	case DRM_GPUVA_OP_MAP:
+-		if (!op->map.immediate && xe_vm_in_fault_mode(vm))
++		if ((!op->map.immediate && xe_vm_in_fault_mode(vm)) ||
++		    op->map.is_cpu_addr_mirror)
+ 			break;
+ 
+ 		bind_op_commit(vm, tile, pt_update_ops, op->map.vma, fence,
+ 			       fence2);
+ 		break;
+ 	case DRM_GPUVA_OP_REMAP:
+-		unbind_op_commit(vm, tile, pt_update_ops,
+-				 gpuva_to_vma(op->base.remap.unmap->va), fence,
+-				 fence2);
++	{
++		struct xe_vma *old = gpuva_to_vma(op->base.remap.unmap->va);
++
++		if (xe_vma_is_cpu_addr_mirror(old))
++			break;
++
++		unbind_op_commit(vm, tile, pt_update_ops, old, fence, fence2);
+ 
+ 		if (op->remap.prev)
+ 			bind_op_commit(vm, tile, pt_update_ops, op->remap.prev,
+@@ -1959,14 +1994,25 @@ static void op_commit(struct xe_vm *vm,
+ 			bind_op_commit(vm, tile, pt_update_ops, op->remap.next,
+ 				       fence, fence2);
+ 		break;
++	}
+ 	case DRM_GPUVA_OP_UNMAP:
+-		unbind_op_commit(vm, tile, pt_update_ops,
+-				 gpuva_to_vma(op->base.unmap.va), fence, fence2);
++	{
++		struct xe_vma *vma = gpuva_to_vma(op->base.unmap.va);
++
++		if (!xe_vma_is_cpu_addr_mirror(vma))
++			unbind_op_commit(vm, tile, pt_update_ops, vma, fence,
++					 fence2);
+ 		break;
++	}
+ 	case DRM_GPUVA_OP_PREFETCH:
+-		bind_op_commit(vm, tile, pt_update_ops,
+-			       gpuva_to_vma(op->base.prefetch.va), fence, fence2);
++	{
++		struct xe_vma *vma = gpuva_to_vma(op->base.prefetch.va);
++
++		if (!xe_vma_is_cpu_addr_mirror(vma))
++			bind_op_commit(vm, tile, pt_update_ops, vma, fence,
++				       fence2);
+ 		break;
++	}
+ 	default:
+ 		drm_warn(&vm->xe->drm, "NOT POSSIBLE");
+ 	}
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 785b8960050b..2d9ed73f4c36 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -956,9 +956,10 @@ static void xe_vma_free(struct xe_vma *vma)
+ 		kfree(vma);
+ }
+ 
+-#define VMA_CREATE_FLAG_READ_ONLY	BIT(0)
+-#define VMA_CREATE_FLAG_IS_NULL		BIT(1)
+-#define VMA_CREATE_FLAG_DUMPABLE	BIT(2)
++#define VMA_CREATE_FLAG_READ_ONLY		BIT(0)
++#define VMA_CREATE_FLAG_IS_NULL			BIT(1)
++#define VMA_CREATE_FLAG_DUMPABLE		BIT(2)
++#define VMA_CREATE_FLAG_IS_SYSTEM_ALLOCATOR	BIT(3)
+ 
+ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+ 				    struct xe_bo *bo,
+@@ -972,6 +973,8 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+ 	bool read_only = (flags & VMA_CREATE_FLAG_READ_ONLY);
+ 	bool is_null = (flags & VMA_CREATE_FLAG_IS_NULL);
+ 	bool dumpable = (flags & VMA_CREATE_FLAG_DUMPABLE);
++	bool is_cpu_addr_mirror =
++		(flags & VMA_CREATE_FLAG_IS_SYSTEM_ALLOCATOR);
+ 
+ 	xe_assert(vm->xe, start < end);
+ 	xe_assert(vm->xe, end < vm->size);
+@@ -980,7 +983,7 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+ 	 * Allocate and ensure that the xe_vma_is_userptr() return
+ 	 * matches what was allocated.
+ 	 */
+-	if (!bo && !is_null) {
++	if (!bo && !is_null && !is_cpu_addr_mirror) {
+ 		struct xe_userptr_vma *uvma = kzalloc(sizeof(*uvma), GFP_KERNEL);
+ 
+ 		if (!uvma)
+@@ -992,6 +995,8 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+ 		if (!vma)
+ 			return ERR_PTR(-ENOMEM);
+ 
++		if (is_cpu_addr_mirror)
++			vma->gpuva.flags |= XE_VMA_SYSTEM_ALLOCATOR;
+ 		if (is_null)
+ 			vma->gpuva.flags |= DRM_GPUVA_SPARSE;
+ 		if (bo)
+@@ -1034,7 +1039,7 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+ 		drm_gpuva_link(&vma->gpuva, vm_bo);
+ 		drm_gpuvm_bo_put(vm_bo);
+ 	} else /* userptr or null */ {
+-		if (!is_null) {
++		if (!is_null && !is_cpu_addr_mirror) {
+ 			struct xe_userptr *userptr = &to_userptr_vma(vma)->userptr;
+ 			u64 size = end - start + 1;
+ 			int err;
+@@ -1086,7 +1091,7 @@ static void xe_vma_destroy_late(struct xe_vma *vma)
+ 		mmu_interval_notifier_remove(&userptr->notifier);
+ 		mutex_destroy(&userptr->unmap_mutex);
+ 		xe_vm_put(vm);
+-	} else if (xe_vma_is_null(vma)) {
++	} else if (xe_vma_is_null(vma) || xe_vma_is_cpu_addr_mirror(vma)) {
+ 		xe_vm_put(vm);
+ 	} else {
+ 		xe_bo_put(xe_vma_bo(vma));
+@@ -1126,7 +1131,7 @@ static void xe_vma_destroy(struct xe_vma *vma, struct dma_fence *fence)
+ 		xe_assert(vm->xe, list_empty(&to_userptr_vma(vma)->userptr.repin_link));
+ 		list_del(&to_userptr_vma(vma)->userptr.invalidate_link);
+ 		spin_unlock(&vm->userptr.invalidated_lock);
+-	} else if (!xe_vma_is_null(vma)) {
++	} else if (!xe_vma_is_null(vma) && !xe_vma_is_cpu_addr_mirror(vma)) {
+ 		xe_bo_assert_held(xe_vma_bo(vma));
+ 
+ 		drm_gpuva_unlink(&vma->gpuva);
+@@ -2054,6 +2059,8 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_bo *bo,
+ 			op->map.read_only =
+ 				flags & DRM_XE_VM_BIND_FLAG_READONLY;
+ 			op->map.is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
++			op->map.is_cpu_addr_mirror = flags &
++				DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR;
+ 			op->map.dumpable = flags & DRM_XE_VM_BIND_FLAG_DUMPABLE;
+ 			op->map.pat_index = pat_index;
+ 		} else if (__op->op == DRM_GPUVA_OP_PREFETCH) {
+@@ -2246,6 +2253,8 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 				VMA_CREATE_FLAG_IS_NULL : 0;
+ 			flags |= op->map.dumpable ?
+ 				VMA_CREATE_FLAG_DUMPABLE : 0;
++			flags |= op->map.is_cpu_addr_mirror ?
++				VMA_CREATE_FLAG_IS_SYSTEM_ALLOCATOR : 0;
+ 
+ 			vma = new_vma(vm, &op->base.map, op->map.pat_index,
+ 				      flags);
+@@ -2253,7 +2262,8 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 				return PTR_ERR(vma);
+ 
+ 			op->map.vma = vma;
+-			if (op->map.immediate || !xe_vm_in_fault_mode(vm))
++			if ((op->map.immediate || !xe_vm_in_fault_mode(vm)) &&
++			    !op->map.is_cpu_addr_mirror)
+ 				xe_vma_ops_incr_pt_update_ops(vops,
+ 							      op->tile_mask);
+ 			break;
+@@ -2262,21 +2272,24 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 		{
+ 			struct xe_vma *old =
+ 				gpuva_to_vma(op->base.remap.unmap->va);
++			bool skip = xe_vma_is_cpu_addr_mirror(old);
+ 
+ 			op->remap.start = xe_vma_start(old);
+ 			op->remap.range = xe_vma_size(old);
+ 
+-			if (op->base.remap.prev) {
+-				flags |= op->base.remap.unmap->va->flags &
+-					XE_VMA_READ_ONLY ?
+-					VMA_CREATE_FLAG_READ_ONLY : 0;
+-				flags |= op->base.remap.unmap->va->flags &
+-					DRM_GPUVA_SPARSE ?
+-					VMA_CREATE_FLAG_IS_NULL : 0;
+-				flags |= op->base.remap.unmap->va->flags &
+-					XE_VMA_DUMPABLE ?
+-					VMA_CREATE_FLAG_DUMPABLE : 0;
++			flags |= op->base.remap.unmap->va->flags &
++				XE_VMA_READ_ONLY ?
++				VMA_CREATE_FLAG_READ_ONLY : 0;
++			flags |= op->base.remap.unmap->va->flags &
++				DRM_GPUVA_SPARSE ?
++				VMA_CREATE_FLAG_IS_NULL : 0;
++			flags |= op->base.remap.unmap->va->flags &
++				XE_VMA_DUMPABLE ?
++				VMA_CREATE_FLAG_DUMPABLE : 0;
++			flags |= xe_vma_is_cpu_addr_mirror(old) ?
++				VMA_CREATE_FLAG_IS_SYSTEM_ALLOCATOR : 0;
+ 
++			if (op->base.remap.prev) {
+ 				vma = new_vma(vm, op->base.remap.prev,
+ 					      old->pat_index, flags);
+ 				if (IS_ERR(vma))
+@@ -2288,9 +2301,10 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 				 * Userptr creates a new SG mapping so
+ 				 * we must also rebind.
+ 				 */
+-				op->remap.skip_prev = !xe_vma_is_userptr(old) &&
++				op->remap.skip_prev = skip ||
++					(!xe_vma_is_userptr(old) &&
+ 					IS_ALIGNED(xe_vma_end(vma),
+-						   xe_vma_max_pte_size(old));
++						   xe_vma_max_pte_size(old)));
+ 				if (op->remap.skip_prev) {
+ 					xe_vma_set_pte_size(vma, xe_vma_max_pte_size(old));
+ 					op->remap.range -=
+@@ -2306,16 +2320,6 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 			}
+ 
+ 			if (op->base.remap.next) {
+-				flags |= op->base.remap.unmap->va->flags &
+-					XE_VMA_READ_ONLY ?
+-					VMA_CREATE_FLAG_READ_ONLY : 0;
+-				flags |= op->base.remap.unmap->va->flags &
+-					DRM_GPUVA_SPARSE ?
+-					VMA_CREATE_FLAG_IS_NULL : 0;
+-				flags |= op->base.remap.unmap->va->flags &
+-					XE_VMA_DUMPABLE ?
+-					VMA_CREATE_FLAG_DUMPABLE : 0;
+-
+ 				vma = new_vma(vm, op->base.remap.next,
+ 					      old->pat_index, flags);
+ 				if (IS_ERR(vma))
+@@ -2327,9 +2331,10 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 				 * Userptr creates a new SG mapping so
+ 				 * we must also rebind.
+ 				 */
+-				op->remap.skip_next = !xe_vma_is_userptr(old) &&
++				op->remap.skip_next = skip ||
++					(!xe_vma_is_userptr(old) &&
+ 					IS_ALIGNED(xe_vma_start(vma),
+-						   xe_vma_max_pte_size(old));
++						   xe_vma_max_pte_size(old)));
+ 				if (op->remap.skip_next) {
+ 					xe_vma_set_pte_size(vma, xe_vma_max_pte_size(old));
+ 					op->remap.range -=
+@@ -2342,11 +2347,15 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 					xe_vma_ops_incr_pt_update_ops(vops, op->tile_mask);
+ 				}
+ 			}
+-			xe_vma_ops_incr_pt_update_ops(vops, op->tile_mask);
++			if (!skip)
++				xe_vma_ops_incr_pt_update_ops(vops, op->tile_mask);
+ 			break;
+ 		}
+ 		case DRM_GPUVA_OP_UNMAP:
+-			xe_vma_ops_incr_pt_update_ops(vops, op->tile_mask);
++			vma = gpuva_to_vma(op->base.unmap.va);
++
++			if (!xe_vma_is_cpu_addr_mirror(vma))
++				xe_vma_ops_incr_pt_update_ops(vops, op->tile_mask);
+ 			break;
+ 		case DRM_GPUVA_OP_PREFETCH:
+ 			vma = gpuva_to_vma(op->base.prefetch.va);
+@@ -2357,7 +2366,8 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 					return err;
+ 			}
+ 
+-			xe_vma_ops_incr_pt_update_ops(vops, op->tile_mask);
++			if (!xe_vma_is_cpu_addr_mirror(vma))
++				xe_vma_ops_incr_pt_update_ops(vops, op->tile_mask);
+ 			break;
+ 		default:
+ 			drm_warn(&vm->xe->drm, "NOT POSSIBLE");
+@@ -2760,9 +2770,11 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+ 	}
+ 	if (ufence)
+ 		xe_sync_ufence_put(ufence);
+-	for (i = 0; i < vops->num_syncs; i++)
+-		xe_sync_entry_signal(vops->syncs + i, fence);
+-	xe_exec_queue_last_fence_set(wait_exec_queue, vm, fence);
++	if (fence) {
++		for (i = 0; i < vops->num_syncs; i++)
++			xe_sync_entry_signal(vops->syncs + i, fence);
++		xe_exec_queue_last_fence_set(wait_exec_queue, vm, fence);
++	}
+ 	dma_fence_put(fence);
+ }
+ 
+@@ -2786,6 +2798,8 @@ static int vm_bind_ioctl_ops_execute(struct xe_vm *vm,
+ 		fence = ops_execute(vm, vops);
+ 		if (IS_ERR(fence)) {
+ 			err = PTR_ERR(fence);
++			if (PTR_ERR(fence) == -ENODATA)
++				vm_bind_ioctl_ops_fini(vm, vops, NULL);
+ 			goto unlock;
+ 		}
+ 
+@@ -2802,7 +2816,8 @@ ALLOW_ERROR_INJECTION(vm_bind_ioctl_ops_execute, ERRNO);
+ 	(DRM_XE_VM_BIND_FLAG_READONLY | \
+ 	 DRM_XE_VM_BIND_FLAG_IMMEDIATE | \
+ 	 DRM_XE_VM_BIND_FLAG_NULL | \
+-	 DRM_XE_VM_BIND_FLAG_DUMPABLE)
++	 DRM_XE_VM_BIND_FLAG_DUMPABLE | \
++	 DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR)
+ 
+ #ifdef TEST_VM_OPS_ERROR
+ #define SUPPORTED_FLAGS	(SUPPORTED_FLAGS_STUB | FORCE_OP_ERROR)
+@@ -2813,7 +2828,7 @@ ALLOW_ERROR_INJECTION(vm_bind_ioctl_ops_execute, ERRNO);
+ #define XE_64K_PAGE_MASK 0xffffull
+ #define ALL_DRM_XE_SYNCS_FLAGS (DRM_XE_SYNCS_FLAG_WAIT_FOR_OP)
+ 
+-static int vm_bind_ioctl_check_args(struct xe_device *xe,
++static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
+ 				    struct drm_xe_vm_bind *args,
+ 				    struct drm_xe_vm_bind_op **bind_ops)
+ {
+@@ -2858,9 +2873,23 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe,
+ 		u64 obj_offset = (*bind_ops)[i].obj_offset;
+ 		u32 prefetch_region = (*bind_ops)[i].prefetch_mem_region_instance;
+ 		bool is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
++		bool is_cpu_addr_mirror = flags &
++			DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR;
+ 		u16 pat_index = (*bind_ops)[i].pat_index;
+ 		u16 coh_mode;
+ 
++		/* FIXME: Disabling CPU address mirror for now */
++		if (XE_IOCTL_DBG(xe, is_cpu_addr_mirror)) {
++			err = -EOPNOTSUPP;
++			goto free_bind_ops;
++		}
++
++		if (XE_IOCTL_DBG(xe, is_cpu_addr_mirror &&
++				 !xe_vm_in_fault_mode(vm))) {
++			err = -EINVAL;
++			goto free_bind_ops;
++		}
++
+ 		if (XE_IOCTL_DBG(xe, pat_index >= xe->pat.n_entries)) {
+ 			err = -EINVAL;
+ 			goto free_bind_ops;
+@@ -2881,13 +2910,14 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe,
+ 
+ 		if (XE_IOCTL_DBG(xe, op > DRM_XE_VM_BIND_OP_PREFETCH) ||
+ 		    XE_IOCTL_DBG(xe, flags & ~SUPPORTED_FLAGS) ||
+-		    XE_IOCTL_DBG(xe, obj && is_null) ||
+-		    XE_IOCTL_DBG(xe, obj_offset && is_null) ||
++		    XE_IOCTL_DBG(xe, obj && (is_null || is_cpu_addr_mirror)) ||
++		    XE_IOCTL_DBG(xe, obj_offset && (is_null ||
++						    is_cpu_addr_mirror)) ||
+ 		    XE_IOCTL_DBG(xe, op != DRM_XE_VM_BIND_OP_MAP &&
+-				 is_null) ||
++				 (is_null || is_cpu_addr_mirror)) ||
+ 		    XE_IOCTL_DBG(xe, !obj &&
+ 				 op == DRM_XE_VM_BIND_OP_MAP &&
+-				 !is_null) ||
++				 !is_null && !is_cpu_addr_mirror) ||
+ 		    XE_IOCTL_DBG(xe, !obj &&
+ 				 op == DRM_XE_VM_BIND_OP_UNMAP_ALL) ||
+ 		    XE_IOCTL_DBG(xe, addr &&
+@@ -3029,15 +3059,19 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 	int err;
+ 	int i;
+ 
+-	err = vm_bind_ioctl_check_args(xe, args, &bind_ops);
++	vm = xe_vm_lookup(xef, args->vm_id);
++	if (XE_IOCTL_DBG(xe, !vm))
++		return -EINVAL;
++
++	err = vm_bind_ioctl_check_args(xe, vm, args, &bind_ops);
+ 	if (err)
+-		return err;
++		goto put_vm;
+ 
+ 	if (args->exec_queue_id) {
+ 		q = xe_exec_queue_lookup(xef, args->exec_queue_id);
+ 		if (XE_IOCTL_DBG(xe, !q)) {
+ 			err = -ENOENT;
+-			goto free_objs;
++			goto put_vm;
+ 		}
+ 
+ 		if (XE_IOCTL_DBG(xe, !(q->flags & EXEC_QUEUE_FLAG_VM))) {
+@@ -3046,15 +3080,9 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		}
+ 	}
+ 
+-	vm = xe_vm_lookup(xef, args->vm_id);
+-	if (XE_IOCTL_DBG(xe, !vm)) {
+-		err = -EINVAL;
+-		goto put_exec_queue;
+-	}
+-
+ 	err = down_write_killable(&vm->lock);
+ 	if (err)
+-		goto put_vm;
++		goto put_exec_queue;
+ 
+ 	if (XE_IOCTL_DBG(xe, xe_vm_is_closed_or_banned(vm))) {
+ 		err = -ENOENT;
+@@ -3211,12 +3239,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		xe_bo_put(bos[i]);
+ release_vm_lock:
+ 	up_write(&vm->lock);
+-put_vm:
+-	xe_vm_put(vm);
+ put_exec_queue:
+ 	if (q)
+ 		xe_exec_queue_put(q);
+-free_objs:
++put_vm:
++	xe_vm_put(vm);
+ 	kvfree(bos);
+ 	kvfree(ops);
+ 	if (args->num_binds > 1)
+@@ -3273,6 +3300,7 @@ int xe_vm_invalidate_vma(struct xe_vma *vma)
+ 	int ret = 0;
+ 
+ 	xe_assert(xe, !xe_vma_is_null(vma));
++	xe_assert(xe, !xe_vma_is_cpu_addr_mirror(vma));
+ 	trace_xe_vma_invalidate(vma);
+ 
+ 	vm_dbg(&xe_vma_vm(vma)->xe->drm,
+diff --git a/drivers/gpu/drm/xe/xe_vm.h b/drivers/gpu/drm/xe/xe_vm.h
+index b882bfb31bd0..3f59077dfd28 100644
+--- a/drivers/gpu/drm/xe/xe_vm.h
++++ b/drivers/gpu/drm/xe/xe_vm.h
+@@ -150,6 +150,11 @@ static inline bool xe_vma_is_null(struct xe_vma *vma)
+ 	return vma->gpuva.flags & DRM_GPUVA_SPARSE;
+ }
+ 
++static inline bool xe_vma_is_cpu_addr_mirror(struct xe_vma *vma)
++{
++	return vma->gpuva.flags & XE_VMA_SYSTEM_ALLOCATOR;
++}
++
+ static inline bool xe_vma_has_no_bo(struct xe_vma *vma)
+ {
+ 	return !xe_vma_bo(vma);
+@@ -157,7 +162,8 @@ static inline bool xe_vma_has_no_bo(struct xe_vma *vma)
+ 
+ static inline bool xe_vma_is_userptr(struct xe_vma *vma)
+ {
+-	return xe_vma_has_no_bo(vma) && !xe_vma_is_null(vma);
++	return xe_vma_has_no_bo(vma) && !xe_vma_is_null(vma) &&
++		!xe_vma_is_cpu_addr_mirror(vma);
+ }
+ 
+ /**
+diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
+index a4b4091cfd0d..33b0f704bcd6 100644
+--- a/drivers/gpu/drm/xe/xe_vm_types.h
++++ b/drivers/gpu/drm/xe/xe_vm_types.h
+@@ -42,6 +42,7 @@ struct xe_vm_pgtable_update_op;
+ #define XE_VMA_PTE_64K		(DRM_GPUVA_USERBITS << 6)
+ #define XE_VMA_PTE_COMPACT	(DRM_GPUVA_USERBITS << 7)
+ #define XE_VMA_DUMPABLE		(DRM_GPUVA_USERBITS << 8)
++#define XE_VMA_SYSTEM_ALLOCATOR	(DRM_GPUVA_USERBITS << 9)
+ 
+ /** struct xe_userptr - User pointer */
+ struct xe_userptr {
+@@ -298,6 +299,8 @@ struct xe_vma_op_map {
+ 	bool read_only;
+ 	/** @is_null: is NULL binding */
+ 	bool is_null;
++	/** @is_cpu_addr_mirror: is CPU address mirror binding */
++	bool is_cpu_addr_mirror;
+ 	/** @dumpable: whether BO is dumped on GPU hang */
+ 	bool dumpable;
+ 	/** @pat_index: The pat index to use for this operation. */
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index e5551b5af98d..96c3a946c2d0 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -909,6 +909,12 @@ struct drm_xe_vm_destroy {
+  *    will only be valid for DRM_XE_VM_BIND_OP_MAP operations, the BO
+  *    handle MBZ, and the BO offset MBZ. This flag is intended to
+  *    implement VK sparse bindings.
++ *  - %DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR - When the CPU address mirror flag is
++ *    set, no mappings are created rather the range is reserved for CPU address
++ *    mirroring which will be populated on GPU page faults or prefetches. Only
++ *    valid on VMs with DRM_XE_VM_CREATE_FLAG_FAULT_MODE set. The CPU address
++ *    mirror flag are only valid for DRM_XE_VM_BIND_OP_MAP operations, the BO
++ *    handle MBZ, and the BO offset MBZ.
+  */
+ struct drm_xe_vm_bind_op {
+ 	/** @extensions: Pointer to the first extension struct, if any */
+@@ -961,7 +967,9 @@ struct drm_xe_vm_bind_op {
+ 	 * on the @pat_index. For such mappings there is no actual memory being
+ 	 * mapped (the address in the PTE is invalid), so the various PAT memory
+ 	 * attributes likely do not apply.  Simply leaving as zero is one
+-	 * option (still a valid pat_index).
++	 * option (still a valid pat_index). Same applies to
++	 * DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR bindings as for such mapping
++	 * there is no actual memory being mapped.
+ 	 */
+ 	__u16 pat_index;
+ 
+@@ -977,6 +985,14 @@ struct drm_xe_vm_bind_op {
+ 
+ 		/** @userptr: user pointer to bind on */
+ 		__u64 userptr;
++
++		/**
++		 * @cpu_addr_mirror_offset: Offset from GPU @addr to create
++		 * CPU address mirror mappings. MBZ with current level of
++		 * support (e.g. 1 to 1 mapping between GPU and CPU mappings
++		 * only supported).
++		 */
++		__s64 cpu_addr_mirror_offset;
+ 	};
+ 
+ 	/**
+@@ -999,6 +1015,7 @@ struct drm_xe_vm_bind_op {
+ #define DRM_XE_VM_BIND_FLAG_IMMEDIATE	(1 << 1)
+ #define DRM_XE_VM_BIND_FLAG_NULL	(1 << 2)
+ #define DRM_XE_VM_BIND_FLAG_DUMPABLE	(1 << 3)
++#define DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR	(1 << 5)
+ 	/** @flags: Bind flags */
+ 	__u32 flags;
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-Attach-debug-metadata-to-vma.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Attach-debug-metadata-to-vma.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
 Date: Sun, 17 Sep 2023 12:53:47 +0200
-Subject: drm/xe: Attach debug metadata to vma
+Subject: [PATCH] drm/xe: Attach debug metadata to vma
 
 Introduces a vm_bind_op extension, enabling users to attach metadata objects
 to each [OP_MAP|OP_MAP_USERPTR] operation. This interface will be utilized
@@ -19,10 +19,10 @@ Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
 ---
  drivers/gpu/drm/xe/xe_debug_metadata.c | 120 +++++++++++++++++++++++++
  drivers/gpu/drm/xe/xe_debug_metadata.h |  48 ++++++++++
- drivers/gpu/drm/xe/xe_vm.c             |  99 +++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_vm.c             |  96 +++++++++++++++++++-
  drivers/gpu/drm/xe/xe_vm_types.h       |  27 ++++++
- include/uapi/drm/xe_drm.h              |  19 ++++
- 5 files changed, 309 insertions(+), 4 deletions(-)
+ include/uapi/drm/xe_drm.h              |  18 ++++
+ 5 files changed, 307 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.c b/drivers/gpu/drm/xe/xe_debug_metadata.c
 index 1dfed9aed285..b045bdd77235 100644
@@ -249,7 +249,7 @@ index 3266c25e657e..13b763ee06e1 100644
  
  
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index 6b9d1d69293d..dad6cdf4d862 100644
+index 2e8c07b8738a..f040fe826ff2 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
 @@ -24,6 +24,7 @@
@@ -260,7 +260,7 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  #include "xe_device.h"
  #include "xe_drm_client.h"
  #include "xe_eudebug.h"
-@@ -940,6 +941,9 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+@@ -1004,6 +1005,9 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
  			vma->gpuva.gem.obj = &bo->ttm.base;
  	}
  
@@ -270,7 +270,7 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  	INIT_LIST_HEAD(&vma->combined_links.rebind);
  
  	INIT_LIST_HEAD(&vma->gpuva.gem.entry);
-@@ -1032,6 +1036,7 @@ static void xe_vma_destroy_late(struct xe_vma *vma)
+@@ -1098,6 +1102,7 @@ static void xe_vma_destroy_late(struct xe_vma *vma)
  		xe_bo_put(xe_vma_bo(vma));
  	}
  
@@ -278,8 +278,8 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  	xe_vma_free(vma);
  }
  
-@@ -1994,6 +1999,9 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_bo *bo,
- 			op->map.is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
+@@ -2072,6 +2077,9 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_bo *bo,
+ 				DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR;
  			op->map.dumpable = flags & DRM_XE_VM_BIND_FLAG_DUMPABLE;
  			op->map.pat_index = pat_index;
 +#if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
@@ -288,23 +288,17 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  		} else if (__op->op == DRM_GPUVA_OP_PREFETCH) {
  			op->prefetch.region = prefetch_region;
  		}
-@@ -2184,11 +2192,13 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
- 			flags |= op->map.dumpable ?
- 				VMA_CREATE_FLAG_DUMPABLE : 0;
- 
--			vma = new_vma(vm, &op->base.map, op->map.pat_index,
--				      flags);
-+			vma = new_vma(vm, &op->base.map, op->map.pat_index, flags);
+@@ -2270,6 +2278,9 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
  			if (IS_ERR(vma))
  				return PTR_ERR(vma);
  
 +			xe_eudebug_move_vma_metadata(&op->map.eudebug.metadata,
-+						     &vma->eudebug.metadata);
++					&vma->eudebug.metadata);
 +
  			op->map.vma = vma;
- 			if (op->map.immediate || !xe_vm_in_fault_mode(vm))
- 				xe_vma_ops_incr_pt_update_ops(vops,
-@@ -2219,6 +2229,9 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 			if ((op->map.immediate || !xe_vm_in_fault_mode(vm)) &&
+ 			    !op->map.is_cpu_addr_mirror)
+@@ -2304,6 +2315,9 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
  				if (IS_ERR(vma))
  					return PTR_ERR(vma);
  
@@ -314,7 +308,7 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  				op->remap.prev = vma;
  
  				/*
-@@ -2258,6 +2271,16 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+@@ -2334,6 +2348,16 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
  				if (IS_ERR(vma))
  					return PTR_ERR(vma);
  
@@ -331,7 +325,7 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  				op->remap.next = vma;
  
  				/*
-@@ -2308,6 +2331,7 @@ static void xe_vma_op_unwind(struct xe_vm *vm, struct xe_vma_op *op,
+@@ -2399,6 +2423,7 @@ static void xe_vma_op_unwind(struct xe_vm *vm, struct xe_vma_op *op,
  	switch (op->base.op) {
  	case DRM_GPUVA_OP_MAP:
  		if (op->map.vma) {
@@ -339,7 +333,7 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  			prep_vma_destroy(vm, op->map.vma, post_commit);
  			xe_vma_destroy_unlocked(op->map.vma);
  		}
-@@ -2546,6 +2570,58 @@ static int vm_ops_setup_tile_args(struct xe_vm *vm, struct xe_vma_ops *vops)
+@@ -2639,6 +2664,58 @@ static int vm_ops_setup_tile_args(struct xe_vm *vm, struct xe_vma_ops *vops)
  	}
  
  	return number_tiles;
@@ -398,23 +392,23 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  }
  
  static struct dma_fence *ops_execute(struct xe_vm *vm,
-@@ -2742,6 +2818,7 @@ unlock:
+@@ -2841,6 +2918,7 @@ ALLOW_ERROR_INJECTION(vm_bind_ioctl_ops_execute, ERRNO);
  #define ALL_DRM_XE_SYNCS_FLAGS (DRM_XE_SYNCS_FLAG_WAIT_FOR_OP)
  
- static int vm_bind_ioctl_check_args(struct xe_device *xe,
+ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
 +				    struct xe_file *xef,
  				    struct drm_xe_vm_bind *args,
  				    struct drm_xe_vm_bind_op **bind_ops)
  {
-@@ -2785,6 +2862,7 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe,
+@@ -2885,6 +2963,7 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
  		u64 obj_offset = (*bind_ops)[i].obj_offset;
  		u32 prefetch_region = (*bind_ops)[i].prefetch_mem_region_instance;
  		bool is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
 +		u64 extensions = (*bind_ops)[i].extensions;
+ 		bool is_cpu_addr_mirror = flags &
+ 			DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR;
  		u16 pat_index = (*bind_ops)[i].pat_index;
- 		u16 coh_mode;
- 
-@@ -2845,6 +2923,13 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe,
+@@ -2960,6 +3039,13 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
  			err = -EINVAL;
  			goto free_bind_ops;
  		}
@@ -428,16 +422,16 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  	}
  
  	return 0;
-@@ -2956,7 +3041,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
- 	int err;
- 	int i;
+@@ -3075,7 +3161,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 	if (XE_IOCTL_DBG(xe, !vm))
+ 		return -EINVAL;
  
--	err = vm_bind_ioctl_check_args(xe, args, &bind_ops);
-+	err = vm_bind_ioctl_check_args(xe, xef, args, &bind_ops);
+-	err = vm_bind_ioctl_check_args(xe, vm, args, &bind_ops);
++	err = vm_bind_ioctl_check_args(xe, vm, xef, args, &bind_ops);
  	if (err)
- 		return err;
+ 		goto put_vm;
  
-@@ -3083,11 +3168,17 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3198,11 +3284,17 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		u64 obj_offset = bind_ops[i].obj_offset;
  		u32 prefetch_region = bind_ops[i].prefetch_mem_region_instance;
  		u16 pat_index = bind_ops[i].pat_index;
@@ -457,10 +451,10 @@ index 6b9d1d69293d..dad6cdf4d862 100644
  			ops[i] = NULL;
  			goto unwind_ops;
 diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
-index 557b047ebdd7..1c5776194e54 100644
+index 4908f12e98bd..aa4c9a24d73c 100644
 --- a/drivers/gpu/drm/xe/xe_vm_types.h
 +++ b/drivers/gpu/drm/xe/xe_vm_types.h
-@@ -70,6 +70,14 @@ struct xe_userptr {
+@@ -75,6 +75,14 @@ struct xe_userptr {
  #endif
  };
  
@@ -475,7 +469,7 @@ index 557b047ebdd7..1c5776194e54 100644
  struct xe_vma {
  	/** @gpuva: Base GPUVA object */
  	struct drm_gpuva gpuva;
-@@ -121,6 +129,11 @@ struct xe_vma {
+@@ -126,6 +134,11 @@ struct xe_vma {
  	 * Needs to be signalled before UNMAP can be processed.
  	 */
  	struct xe_user_fence *ufence;
@@ -487,7 +481,7 @@ index 557b047ebdd7..1c5776194e54 100644
  };
  
  /**
-@@ -311,6 +324,10 @@ struct xe_vma_op_map {
+@@ -318,6 +331,10 @@ struct xe_vma_op_map {
  	bool dumpable;
  	/** @pat_index: The pat index to use for this operation. */
  	u16 pat_index;
@@ -498,7 +492,7 @@ index 557b047ebdd7..1c5776194e54 100644
  };
  
  /** struct xe_vma_op_remap - VMA remap operation */
-@@ -388,4 +405,14 @@ struct xe_vma_ops {
+@@ -395,4 +412,14 @@ struct xe_vma_ops {
  #endif
  };
  
@@ -514,10 +508,10 @@ index 557b047ebdd7..1c5776194e54 100644
 +
  #endif
 diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
-index 0d75a072b838..2416971fbf2d 100644
+index da9a64d9a9f4..55b645eb88d5 100644
 --- a/include/uapi/drm/xe_drm.h
 +++ b/include/uapi/drm/xe_drm.h
-@@ -886,6 +886,23 @@ struct drm_xe_vm_destroy {
+@@ -891,6 +891,23 @@ struct drm_xe_vm_destroy {
  	__u64 reserved[2];
  };
  
@@ -541,16 +535,14 @@ index 0d75a072b838..2416971fbf2d 100644
  /**
   * struct drm_xe_vm_bind_op - run bind operations
   *
-@@ -910,7 +927,9 @@ struct drm_xe_vm_destroy {
-  *    handle MBZ, and the BO offset MBZ. This flag is intended to
-  *    implement VK sparse bindings.
+@@ -922,6 +939,7 @@ struct drm_xe_vm_destroy {
+  *    handle MBZ, and the BO offset MBZ.
   */
-+
  struct drm_xe_vm_bind_op {
-+#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG 0
++#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG	0
  	/** @extensions: Pointer to the first extension struct, if any */
  	__u64 extensions;
  
 -- 
-2.25.1
+2.43.0
 

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-vm-bind-and-vm-bind-ops.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-vm-bind-and-vm-bind-ops.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christoph Manszewski <christoph.manszewski@intel.com>
 Date: Mon, 2 Oct 2023 13:03:05 +0200
-Subject: drm/xe/eudebug: Add vm bind and vm bind ops
+Subject: [PATCH] drm/xe/eudebug: Add vm bind and vm bind ops
 
 Add events dedicated to track vma bind and vma unbind operations. The
 events are generated for operations performed on xe_vma MAP and UNMAP
@@ -27,7 +27,7 @@ Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
  6 files changed, 449 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
-index 5915f4318e65..c61530d50699 100644
+index 81d03a860b7f..f544f60d7d6b 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.c
 +++ b/drivers/gpu/drm/xe/xe_eudebug.c
 @@ -792,7 +792,7 @@ static struct xe_eudebug_event *
@@ -458,10 +458,10 @@ index e1d4e31b32ec..cbc316ec3593 100644
 +
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index c545a9d43750..3bfc105726e5 100644
+index 704fd03199dd..35b671493050 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
-@@ -1411,6 +1411,8 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags)
+@@ -1476,6 +1476,8 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags)
  	for_each_tile(tile, xe, id)
  		xe_range_fence_tree_init(&vm->rftree[id]);
  
@@ -470,7 +470,7 @@ index c545a9d43750..3bfc105726e5 100644
  	vm->pt_ops = &xelp_pt_ops;
  
  	/*
-@@ -1650,6 +1652,8 @@ static void vm_destroy_work_func(struct work_struct *w)
+@@ -1735,6 +1737,8 @@ static void vm_destroy_work_func(struct work_struct *w)
  	struct xe_tile *tile;
  	u8 id;
  
@@ -479,7 +479,7 @@ index c545a9d43750..3bfc105726e5 100644
  	/* xe_vm_close_and_put was not called? */
  	xe_assert(xe, !vm->size);
  
-@@ -2665,7 +2669,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -2758,7 +2762,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
  				   struct dma_fence *fence)
  {
  	struct xe_exec_queue *wait_exec_queue = to_wait_exec_queue(vm, vops->q);
@@ -488,7 +488,7 @@ index c545a9d43750..3bfc105726e5 100644
  	struct xe_vma_op *op;
  	int i;
  
-@@ -2680,6 +2684,9 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -2773,6 +2777,9 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
  			xe_vma_destroy(gpuva_to_vma(op->base.remap.unmap->va),
  				       fence);
  	}
@@ -497,8 +497,8 @@ index c545a9d43750..3bfc105726e5 100644
 +
  	if (ufence)
  		xe_sync_ufence_put(ufence);
- 	for (i = 0; i < vops->num_syncs; i++)
-@@ -3088,6 +3095,8 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 	if (fence) {
+@@ -3203,6 +3210,8 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		if (err)
  			goto unwind_ops;
  
@@ -507,7 +507,7 @@ index c545a9d43750..3bfc105726e5 100644
  #ifdef TEST_VM_OPS_ERROR
  		if (flags & FORCE_OP_ERROR) {
  			vops.inject_error = true;
-@@ -3111,8 +3120,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3226,8 +3235,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  	err = vm_bind_ioctl_ops_execute(vm, &vops);
  
  unwind_ops:
@@ -521,10 +521,10 @@ index c545a9d43750..3bfc105726e5 100644
  	for (i = args->num_binds - 1; i >= 0; --i)
  		if (ops[i])
 diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
-index 7f9a303e51d8..557b047ebdd7 100644
+index 33b0f704bcd6..4908f12e98bd 100644
 --- a/drivers/gpu/drm/xe/xe_vm_types.h
 +++ b/drivers/gpu/drm/xe/xe_vm_types.h
-@@ -282,6 +282,19 @@ struct xe_vm {
+@@ -287,6 +287,19 @@ struct xe_vm {
  	bool batch_invalidate_tlb;
  	/** @xef: XE file handle for tracking this VM's drm client */
  	struct xe_file *xef;
@@ -627,5 +627,5 @@ index ccfbe976c509..cc34c522fa4d 100644
  }
  #endif
 -- 
-2.25.1
+2.43.0
 

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dominik Grzegorzek <dominik.grzegorzek@intel.com>
 Date: Thu, 5 Dec 2024 00:46:18 +0530
-Subject: drm/xe/eudebug: Prelim rework for Xe EU debug
+Subject: [PATCH] drm/xe/eudebug: Prelim rework for Xe EU debug
 
 Moved all xe_eudebug declarations and definitions to xe_drm_prelim.h
 Removed xe_drm_eudebug.h Moved eudebug related files into prelim/ directory
@@ -54,7 +54,7 @@ Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
  delete mode 100644 include/uapi/drm/xe_drm_eudebug.h
 
 diff --git a/drivers/gpu/drm/xe/Kconfig b/drivers/gpu/drm/xe/Kconfig
-index 950acf0a6..33729983d 100644
+index 950acf0a6b0b..33729983db03 100644
 --- a/drivers/gpu/drm/xe/Kconfig
 +++ b/drivers/gpu/drm/xe/Kconfig
 @@ -87,7 +87,7 @@ config DRM_XE_FORCE_PROBE
@@ -67,7 +67,7 @@ index 950acf0a6..33729983d 100644
  	depends on DRM_XE
  	default y
 diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
-index 6e2a04135..fddabeeed 100644
+index 594515915a83..a4e20b31da57 100644
 --- a/drivers/gpu/drm/xe/Makefile
 +++ b/drivers/gpu/drm/xe/Makefile
 @@ -48,7 +48,7 @@ xe-y += xe_bb.o \
@@ -79,7 +79,7 @@ index 6e2a04135..fddabeeed 100644
  	xe_gt_mcr.o \
  	xe_gt_pagefault.o \
  	xe_gt_sysfs.o \
-@@ -119,8 +119,8 @@ xe-y += xe_bb.o \
+@@ -121,8 +121,8 @@ xe-y += xe_bb.o \
  	xe_wa.o \
  	xe_wopcm.o
  
@@ -94,7 +94,7 @@ diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.c b/drivers/gpu/drm/xe/prelim/
 similarity index 76%
 rename from drivers/gpu/drm/xe/xe_debug_metadata.c
 rename to drivers/gpu/drm/xe/prelim/xe_debug_metadata.c
-index 172fe2b33..243232efa 100644
+index 172fe2b33557..243232efa436 100644
 --- a/drivers/gpu/drm/xe/xe_debug_metadata.c
 +++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata.c
 @@ -9,7 +9,7 @@
@@ -232,7 +232,7 @@ diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.h b/drivers/gpu/drm/xe/prelim/
 similarity index 70%
 rename from drivers/gpu/drm/xe/xe_debug_metadata.h
 rename to drivers/gpu/drm/xe/prelim/xe_debug_metadata.h
-index 13b763ee0..68a8c05e9 100644
+index 13b763ee06e1..68a8c05e9e9f 100644
 --- a/drivers/gpu/drm/xe/xe_debug_metadata.h
 +++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata.h
 @@ -12,19 +12,19 @@ struct drm_device;
@@ -292,7 +292,7 @@ diff --git a/drivers/gpu/drm/xe/xe_debug_metadata_types.h b/drivers/gpu/drm/xe/p
 similarity index 92%
 rename from drivers/gpu/drm/xe/xe_debug_metadata_types.h
 rename to drivers/gpu/drm/xe/prelim/xe_debug_metadata_types.h
-index 624852920..7d3db6a00 100644
+index 624852920f58..7d3db6a004ff 100644
 --- a/drivers/gpu/drm/xe/xe_debug_metadata_types.h
 +++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata_types.h
 @@ -8,7 +8,7 @@
@@ -308,7 +308,7 @@ diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/prelim/xe_eude
 similarity index 87%
 rename from drivers/gpu/drm/xe/xe_eudebug.c
 rename to drivers/gpu/drm/xe/prelim/xe_eudebug.c
-index 4736803de..1655c4182 100644
+index 4736803de001..1655c4182d1e 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.c
 +++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.c
 @@ -23,8 +23,8 @@
@@ -1642,7 +1642,7 @@ index 4736803de..1655c4182 100644
  	if (!send_event) {
 diff --git a/drivers/gpu/drm/xe/prelim/xe_eudebug.c.rej b/drivers/gpu/drm/xe/prelim/xe_eudebug.c.rej
 new file mode 100644
-index 000000000..ec4aed930
+index 000000000000..ec4aed930789
 --- /dev/null
 +++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.c.rej
 @@ -0,0 +1,10 @@
@@ -1658,7 +1658,7 @@ index 000000000..ec4aed930
 + 
 diff --git a/drivers/gpu/drm/xe/prelim/xe_eudebug.h b/drivers/gpu/drm/xe/prelim/xe_eudebug.h
 new file mode 100644
-index 000000000..6c4423952
+index 000000000000..6c442395228c
 --- /dev/null
 +++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.h
 @@ -0,0 +1,106 @@
@@ -1772,7 +1772,7 @@ diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/prelim/x
 similarity index 99%
 rename from drivers/gpu/drm/xe/xe_eudebug_types.h
 rename to drivers/gpu/drm/xe/prelim/xe_eudebug_types.h
-index 00853dacd..e3a028973 100644
+index 00853dacd477..e3a028973469 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug_types.h
 +++ b/drivers/gpu/drm/xe/prelim/xe_eudebug_types.h
 @@ -4,6 +4,7 @@
@@ -1787,7 +1787,7 @@ diff --git a/drivers/gpu/drm/xe/xe_gt_debug.c b/drivers/gpu/drm/xe/prelim/xe_gt_
 similarity index 77%
 rename from drivers/gpu/drm/xe/xe_gt_debug.c
 rename to drivers/gpu/drm/xe/prelim/xe_gt_debug.c
-index 5dcc12ea5..1a17a8dd2 100644
+index 5dcc12ea5a11..1a17a8dd2377 100644
 --- a/drivers/gpu/drm/xe/xe_gt_debug.c
 +++ b/drivers/gpu/drm/xe/prelim/xe_gt_debug.c
 @@ -14,7 +14,7 @@
@@ -1911,7 +1911,7 @@ diff --git a/drivers/gpu/drm/xe/xe_gt_debug.h b/drivers/gpu/drm/xe/prelim/xe_gt_
 similarity index 52%
 rename from drivers/gpu/drm/xe/xe_gt_debug.h
 rename to drivers/gpu/drm/xe/prelim/xe_gt_debug.h
-index 3e3fb501e..619a94fee 100644
+index 3e3fb501eedd..619a94feed29 100644
 --- a/drivers/gpu/drm/xe/xe_gt_debug.h
 +++ b/drivers/gpu/drm/xe/prelim/xe_gt_debug.h
 @@ -6,34 +6,34 @@
@@ -1960,7 +1960,7 @@ index 3e3fb501e..619a94fee 100644
  			      const unsigned int settle_time_ms);
  
 diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
-index e55d9a362..ccad9b1ff 100644
+index e091af110258..d2b17ea30527 100644
 --- a/drivers/gpu/drm/xe/xe_device.c
 +++ b/drivers/gpu/drm/xe/xe_device.c
 @@ -27,11 +27,10 @@
@@ -1976,7 +1976,7 @@ index e55d9a362..ccad9b1ff 100644
  #include "xe_exec.h"
  #include "xe_exec_queue.h"
  #include "xe_force_wake.h"
-@@ -65,6 +64,7 @@
+@@ -68,6 +67,7 @@
  #include "xe_wait_user_fence.h"
  #include "xe_wa.h"
  
@@ -1984,7 +1984,7 @@ index e55d9a362..ccad9b1ff 100644
  #include <generated/xe_wa_oob.h>
  
  static int xe_file_open(struct drm_device *dev, struct drm_file *file)
-@@ -105,7 +105,7 @@ static int xe_file_open(struct drm_device *dev, struct drm_file *file)
+@@ -108,7 +108,7 @@ static int xe_file_open(struct drm_device *dev, struct drm_file *file)
  		put_task_struct(task);
  	}
  
@@ -1993,7 +1993,7 @@ index e55d9a362..ccad9b1ff 100644
  
  	return 0;
  }
-@@ -160,7 +160,7 @@ static void xe_file_close(struct drm_device *dev, struct drm_file *file)
+@@ -163,7 +163,7 @@ static void xe_file_close(struct drm_device *dev, struct drm_file *file)
  
  	xe_pm_runtime_get(xe);
  
@@ -2002,7 +2002,7 @@ index e55d9a362..ccad9b1ff 100644
  
  	/*
  	 * No need for exec_queue.lock here as there is no contention for it
-@@ -208,10 +208,10 @@ static const struct drm_ioctl_desc xe_ioctls[] = {
+@@ -211,10 +211,10 @@ static const struct drm_ioctl_desc xe_ioctls[] = {
  	DRM_IOCTL_DEF_DRV(XE_WAIT_USER_FENCE, xe_wait_user_fence_ioctl,
  			  DRM_RENDER_ALLOW),
  	DRM_IOCTL_DEF_DRV(XE_OBSERVATION, xe_observation_ioctl, DRM_RENDER_ALLOW),
@@ -2016,7 +2016,7 @@ index e55d9a362..ccad9b1ff 100644
  			  DRM_RENDER_ALLOW),
  };
  
-@@ -308,7 +308,7 @@ static void xe_device_destroy(struct drm_device *dev, void *dummy)
+@@ -311,7 +311,7 @@ static void xe_device_destroy(struct drm_device *dev, void *dummy)
  {
  	struct xe_device *xe = to_xe_device(dev);
  
@@ -2025,7 +2025,7 @@ index e55d9a362..ccad9b1ff 100644
  
  	if (xe->preempt_fence_wq)
  		destroy_workqueue(xe->preempt_fence_wq);
-@@ -382,7 +382,7 @@ struct xe_device *xe_device_create(struct pci_dev *pdev,
+@@ -385,7 +385,7 @@ struct xe_device *xe_device_create(struct pci_dev *pdev,
  	if (err)
  		goto err;
  
@@ -2035,7 +2035,7 @@ index e55d9a362..ccad9b1ff 100644
  	xe->preempt_fence_wq = alloc_ordered_workqueue("xe-preempt-fence-wq",
  						       WQ_MEM_RECLAIM);
 diff --git a/drivers/gpu/drm/xe/xe_device.h b/drivers/gpu/drm/xe/xe_device.h
-index 7e0611c63..7713396aa 100644
+index 7e0611c63c85..7713396aad6f 100644
 --- a/drivers/gpu/drm/xe/xe_device.h
 +++ b/drivers/gpu/drm/xe/xe_device.h
 @@ -210,7 +210,7 @@ void xe_file_put(struct xe_file *xef);
@@ -2069,10 +2069,10 @@ index 7e0611c63..7713396aa 100644
  
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
-index f3db5b4db..6e56e8ec2 100644
+index a8a4e42bf0e0..e9c2ef52b428 100644
 --- a/drivers/gpu/drm/xe/xe_device_types.h
 +++ b/drivers/gpu/drm/xe/xe_device_types.h
-@@ -400,7 +400,7 @@ struct xe_device {
+@@ -407,7 +407,7 @@ struct xe_device {
  		struct workqueue_struct *wq;
  	} sriov;
  
@@ -2081,7 +2081,7 @@ index f3db5b4db..6e56e8ec2 100644
  	/** @clients: eudebug clients info */
  	struct {
  		/** @clients.lock: Protects client list */
-@@ -566,7 +566,7 @@ struct xe_device {
+@@ -576,7 +576,7 @@ struct xe_device {
  	u8 vm_inject_error_position;
  #endif
  
@@ -2090,7 +2090,7 @@ index f3db5b4db..6e56e8ec2 100644
  	/** @debugger connection list and globals for device */
  	struct {
  		/** @lock: protects the list of connections */
-@@ -714,7 +714,7 @@ struct xe_file {
+@@ -724,7 +724,7 @@ struct xe_file {
  	/** @refcount: ref count of this xe file */
  	struct kref refcount;
  
@@ -2101,7 +2101,7 @@ index f3db5b4db..6e56e8ec2 100644
  		struct list_head client_link;
 diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
 deleted file mode 100644
-index 5f6f58ed7..000000000
+index 5f6f58ed70d4..000000000000
 --- a/drivers/gpu/drm/xe/xe_eudebug.h
 +++ /dev/null
 @@ -1,106 +0,0 @@
@@ -2212,7 +2212,7 @@ index 5f6f58ed7..000000000
 -
 -#endif
 diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
-index c8b76a972..0220c1c6e 100644
+index c8b76a97257d..0220c1c6e55a 100644
 --- a/drivers/gpu/drm/xe/xe_exec_queue.c
 +++ b/drivers/gpu/drm/xe/xe_exec_queue.c
 @@ -25,7 +25,7 @@
@@ -2292,7 +2292,7 @@ index c8b76a972..0220c1c6e 100644
  	xe_exec_queue_kill(q);
  
 diff --git a/drivers/gpu/drm/xe/xe_gt_pagefault.c b/drivers/gpu/drm/xe/xe_gt_pagefault.c
-index bb8f881b5..cbfa051f2 100644
+index bb8f881b5503..cbfa051f274a 100644
 --- a/drivers/gpu/drm/xe/xe_gt_pagefault.c
 +++ b/drivers/gpu/drm/xe/xe_gt_pagefault.c
 @@ -13,7 +13,7 @@
@@ -2339,7 +2339,7 @@ index bb8f881b5..cbfa051f2 100644
  	xe_vm_put(vm);
  }
 diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
-index b6de03128..042aba206 100644
+index b6de0312894f..042aba206509 100644
 --- a/drivers/gpu/drm/xe/xe_hw_engine.c
 +++ b/drivers/gpu/drm/xe/xe_hw_engine.c
 @@ -16,7 +16,7 @@
@@ -2352,7 +2352,7 @@ index b6de03128..042aba206 100644
  #include "xe_force_wake.h"
  #include "xe_gsc.h"
 diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
-index 498fc272f..180ec7785 100644
+index 498fc272fe96..180ec778584f 100644
 --- a/drivers/gpu/drm/xe/xe_sync.c
 +++ b/drivers/gpu/drm/xe/xe_sync.c
 @@ -15,7 +15,7 @@
@@ -2396,7 +2396,7 @@ index 498fc272f..180ec7785 100644
  		xe_sync_ufence_signal(ufence);
  
 diff --git a/drivers/gpu/drm/xe/xe_sync_types.h b/drivers/gpu/drm/xe/xe_sync_types.h
-index dcd3165e6..63807cfe5 100644
+index dcd3165e66a7..63807cfe5ba2 100644
 --- a/drivers/gpu/drm/xe/xe_sync_types.h
 +++ b/drivers/gpu/drm/xe/xe_sync_types.h
 @@ -21,7 +21,7 @@ struct xe_user_fence {
@@ -2409,7 +2409,7 @@ index dcd3165e6..63807cfe5 100644
  		spinlock_t lock;
  		struct xe_eudebug *debugger;
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index 5425e3167..8516ae4bf 100644
+index d0e2f471377b..432fecdb5977 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
 @@ -24,10 +24,10 @@
@@ -2425,7 +2425,7 @@ index 5425e3167..8516ae4bf 100644
  #include "xe_exec_queue.h"
  #include "xe_gt_pagefault.h"
  #include "xe_gt_tlb_invalidation.h"
-@@ -1000,7 +1000,7 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+@@ -1005,7 +1005,7 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
  			vma->gpuva.gem.obj = &bo->ttm.base;
  	}
  
@@ -2434,7 +2434,7 @@ index 5425e3167..8516ae4bf 100644
  	INIT_LIST_HEAD(&vma->eudebug.metadata.list);
  #endif
  	INIT_LIST_HEAD(&vma->combined_links.rebind);
-@@ -1476,7 +1476,7 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags)
+@@ -1481,7 +1481,7 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags)
  	for_each_tile(tile, xe, id)
  		xe_range_fence_tree_init(&vm->rftree[id]);
  
@@ -2443,7 +2443,7 @@ index 5425e3167..8516ae4bf 100644
  
  	vm->pt_ops = &xelp_pt_ops;
  
-@@ -1737,7 +1737,7 @@ static void vm_destroy_work_func(struct work_struct *w)
+@@ -1742,7 +1742,7 @@ static void vm_destroy_work_func(struct work_struct *w)
  	struct xe_tile *tile;
  	u8 id;
  
@@ -2452,7 +2452,7 @@ index 5425e3167..8516ae4bf 100644
  
  	/* xe_vm_close_and_put was not called? */
  	xe_assert(xe, !vm->size);
-@@ -1893,7 +1893,7 @@ int xe_vm_create_ioctl(struct drm_device *dev, void *data,
+@@ -1898,7 +1898,7 @@ int xe_vm_create_ioctl(struct drm_device *dev, void *data,
  
  	args->vm_id = id;
  
@@ -2461,7 +2461,7 @@ index 5425e3167..8516ae4bf 100644
  
  	return 0;
  
-@@ -1927,7 +1927,7 @@ int xe_vm_destroy_ioctl(struct drm_device *dev, void *data,
+@@ -1932,7 +1932,7 @@ int xe_vm_destroy_ioctl(struct drm_device *dev, void *data,
  	mutex_unlock(&xef->vm.lock);
  
  	if (!err) {
@@ -2470,8 +2470,8 @@ index 5425e3167..8516ae4bf 100644
  		xe_vm_close_and_put(vm);
  	}
  
-@@ -2070,7 +2070,7 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_bo *bo,
- 			op->map.is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
+@@ -2077,7 +2077,7 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_bo *bo,
+ 				DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR;
  			op->map.dumpable = flags & DRM_XE_VM_BIND_FLAG_DUMPABLE;
  			op->map.pat_index = pat_index;
 -#if IS_ENABLED(CONFIG_DRM_XE_EUDEBUG)
@@ -2479,7 +2479,7 @@ index 5425e3167..8516ae4bf 100644
  			INIT_LIST_HEAD(&op->map.eudebug.metadata.list);
  #endif
  		} else if (__op->op == DRM_GPUVA_OP_PREFETCH) {
-@@ -2661,7 +2661,7 @@ typedef int (*xe_vm_bind_op_user_extension_fn)(struct xe_device *xe,
+@@ -2672,7 +2672,7 @@ typedef int (*xe_vm_bind_op_user_extension_fn)(struct xe_device *xe,
  					       u32 operation, u64 extension);
  
  static const xe_vm_bind_op_user_extension_fn vm_bind_op_extension_funcs[] = {
@@ -2488,7 +2488,7 @@ index 5425e3167..8516ae4bf 100644
  };
  
  #define MAX_USER_EXTENSIONS	16
-@@ -2844,7 +2844,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -2855,7 +2855,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
  				       fence);
  	}
  
@@ -2497,7 +2497,7 @@ index 5425e3167..8516ae4bf 100644
  
  	if (ufence)
  		xe_sync_ufence_put(ufence);
-@@ -3219,7 +3219,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3248,7 +3248,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		}
  	}
  
@@ -2506,7 +2506,7 @@ index 5425e3167..8516ae4bf 100644
  
  	syncs_user = u64_to_user_ptr(args->syncs);
  	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
-@@ -3275,7 +3275,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3304,7 +3304,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		if (err)
  			goto unwind_ops;
  
@@ -2515,7 +2515,7 @@ index 5425e3167..8516ae4bf 100644
  
  #ifdef TEST_VM_OPS_ERROR
  		if (flags & FORCE_OP_ERROR) {
-@@ -3301,7 +3301,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3330,7 +3330,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  
  unwind_ops:
  	if (err && err != -ENODATA) {
@@ -2525,10 +2525,10 @@ index 5425e3167..8516ae4bf 100644
  	}
  
 diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
-index ad220388b..e9836aff7 100644
+index aa4c9a24d73c..8606392b455a 100644
 --- a/drivers/gpu/drm/xe/xe_vm_types.h
 +++ b/drivers/gpu/drm/xe/xe_vm_types.h
-@@ -74,7 +74,7 @@ struct xe_userptr {
+@@ -75,7 +75,7 @@ struct xe_userptr {
  #endif
  };
  
@@ -2537,7 +2537,7 @@ index ad220388b..e9836aff7 100644
  struct xe_eudebug_vma_metadata {
  	struct list_head list;
  };
-@@ -300,7 +300,7 @@ struct xe_vm {
+@@ -301,7 +301,7 @@ struct xe_vm {
  	/** @xef: XE file handle for tracking this VM's drm client */
  	struct xe_file *xef;
  
@@ -2547,7 +2547,7 @@ index ad220388b..e9836aff7 100644
  		/** @lock: Lock for eudebug_bind members */
  		spinlock_t lock;
 diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
-index cc0fff0f4..332116740 100644
+index f33fe5af5027..22e20153e4dc 100644
 --- a/include/uapi/drm/xe_drm.h
 +++ b/include/uapi/drm/xe_drm.h
 @@ -102,9 +102,6 @@ extern "C" {
@@ -2594,15 +2594,15 @@ index cc0fff0f4..332116740 100644
  /**
   * struct drm_xe_vm_bind_op - run bind operations
   *
-@@ -934,7 +911,6 @@ struct drm_xe_vm_bind_op_ext_attach_debug {
+@@ -939,7 +916,6 @@ struct drm_xe_vm_bind_op_ext_attach_debug {
+  *    handle MBZ, and the BO offset MBZ.
   */
- 
  struct drm_xe_vm_bind_op {
--#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG 0
+-#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG	0
  	/** @extensions: Pointer to the first extension struct, if any */
  	__u64 extensions;
  
-@@ -1152,8 +1128,6 @@ struct drm_xe_exec_queue_create {
+@@ -1168,8 +1144,6 @@ struct drm_xe_exec_queue_create {
  #define DRM_XE_EXEC_QUEUE_EXTENSION_SET_PROPERTY		0
  #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY		0
  #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE		1
@@ -2611,7 +2611,7 @@ index cc0fff0f4..332116740 100644
  	/** @extensions: Pointer to the first extension struct, if any */
  	__u64 extensions;
  
-@@ -1773,72 +1747,6 @@ struct drm_xe_oa_stream_info {
+@@ -1789,72 +1763,6 @@ struct drm_xe_oa_stream_info {
  	__u64 reserved[3];
  };
  
@@ -2686,7 +2686,7 @@ index cc0fff0f4..332116740 100644
  #if defined(__cplusplus)
 diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
 deleted file mode 100644
-index e43576c7b..000000000
+index e43576c7bc5e..000000000000
 --- a/include/uapi/drm/xe_drm_eudebug.h
 +++ /dev/null
 @@ -1,256 +0,0 @@
@@ -2947,7 +2947,7 @@ index e43576c7b..000000000
 -
 -#endif
 diff --git a/include/uapi/drm/xe_drm_prelim.h b/include/uapi/drm/xe_drm_prelim.h
-index 9c86f5969..d5f794b0f 100644
+index 9c86f5969500..d5f794b0f567 100644
 --- a/include/uapi/drm/xe_drm_prelim.h
 +++ b/include/uapi/drm/xe_drm_prelim.h
 @@ -70,4 +70,344 @@

--- a/series
+++ b/series
@@ -76,6 +76,7 @@ backport/patches/base/0001-drm-xe-nvm-add-support-for-non-posted-erase.patch
 backport/patches/base/0001-drm-xe-xe_debugfs-Exposure-of-G-State-and-pcie-link-.patch
 backport/patches/base/0001-drm-xe-debugfs-Don-t-expose-dgfx-residencies-attribu.patch
 backport/patches/base/0001-drm-xe-pcode-Initialize-data0-for-pcode-read-routine.patch
+backport/patches/base/0001-drm-xe-uapi-Add-DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR.patch
 # sriov
 backport/patches/features/sriov/0001-drm-xe-sa-Drop-redundant-NULL-assignments.patch
 backport/patches/features/sriov/0001-drm-xe-sa-Improve-error-message-on-init-failure.patch


### PR DESCRIPTION
Introduce DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR to support unpopulated
VMAs that update GPUVM state without page tables or mappings. These
VMAs act as CPU address mirrors, populated only on fault or prefetch.
Initial support enforces 1:1 user/GPU address mapping.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>