### PR TITLE
drm/xe: Fix suspend handling and allow pinned external VRAM BOs

### DIFF
--- a/backport/patches/base/0001-drm-ttm-test-private-resv-obj-on-release-destroy.patch
+++ b/backport/patches/base/0001-drm-ttm-test-private-resv-obj-on-release-destroy.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20K=C3=B6nig?= <christian.koenig@amd.com>
+Date: Wed, 29 Jan 2025 16:28:48 +0100
+Subject: drm/ttm: test private resv obj on release/destroy
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Test the fences in the private dma_resv object instead of the pointer to
+a potentially shared dma_resv object.
+
+This only matters for imported BOs with an SG table since those don't
+get their dma_resv pointer replaced on release.
+
+Signed-off-by: Christian König <christian.koenig@amd.com>
+Signed-off-by: James Zhu <James.Zhu@amd.com>
+Reviewed-by: James Zhu <James.Zhu@amd.com>
+Tested-by: James Zhu <James.Zhu@amd.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250129152849.15777-1-christian.koenig@amd.com
+(cherry-picked from commit fa0af721bd1f983c5c9c109815a154bd1cb29c75 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/ttm/ttm_bo.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
+index 72c675191..0c88019bc 100644
+--- a/drivers/gpu/drm/ttm/ttm_bo.c
++++ b/drivers/gpu/drm/ttm/ttm_bo.c
+@@ -235,7 +235,7 @@ static void ttm_bo_delayed_delete(struct work_struct *work)
+ 
+ 	bo = container_of(work, typeof(*bo), delayed_delete);
+ 
+-	dma_resv_wait_timeout(bo->base.resv, DMA_RESV_USAGE_BOOKKEEP, false,
++	dma_resv_wait_timeout(&bo->base._resv, DMA_RESV_USAGE_BOOKKEEP, false,
+ 			      MAX_SCHEDULE_TIMEOUT);
+ 	dma_resv_lock(bo->base.resv, NULL);
+ 	ttm_bo_cleanup_memtype_use(bo);
+@@ -270,7 +270,7 @@ static void ttm_bo_release(struct kref *kref)
+ 		drm_vma_offset_remove(bdev->vma_manager, &bo->base.vma_node);
+ 		ttm_mem_io_free(bdev, bo->resource);
+ 
+-		if (!dma_resv_test_signaled(bo->base.resv,
++		if (!dma_resv_test_signaled(&bo->base._resv,
+ 					    DMA_RESV_USAGE_BOOKKEEP) ||
+ 		    (want_init_on_free() && (bo->ttm != NULL)) ||
+ 		    bo->type == ttm_bo_type_sg ||
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Drop-preempt-fences-when-destroying-imported-.patch
+++ b/backport/patches/base/0001-drm-xe-Drop-preempt-fences-when-destroying-imported-.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Hellstr=C3=B6m?= <thomas.hellstrom@linux.intel.com>
+Date: Wed, 17 Dec 2025 10:34:41 +0100
+Subject: drm/xe: Drop preempt-fences when destroying imported
+ dma-bufs.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When imported dma-bufs are destroyed, TTM is not fully
+individualizing the dma-resv, but it *is* copying the fences that
+need to be waited for before declaring idle. So in the case where
+the bo->resv != bo->_resv we can still drop the preempt-fences, but
+make sure we do that on bo->_resv which contains the fence-pointer
+copy.
+
+In the case where the copying fails, bo->_resv will typically not
+contain any fences pointers at all, so there will be nothing to
+drop. In that case, TTM would have ensured all fences that would
+have been copied are signaled, including any remaining preempt
+fences.
+
+Fixes: dd08ebf6c352 ("drm/xe: Introduce a new DRM driver for Intel GPUs")
+Fixes: fa0af721bd1f ("drm/ttm: test private resv obj on release/destroy")
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: <stable@vger.kernel.org> # v6.16+
+Signed-off-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Tested-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Link: https://patch.msgid.link/20251217093441.5073-1-thomas.hellstrom@linux.intel.com
+(cherry picked from commit 425fe550fb513b567bd6d01f397d274092a9c274 linux-next)
+Signed-off-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_bo.c | 15 ++++-----------
+ 1 file changed, 4 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
+index 0de8613d1..27455d95d 100644
+--- a/drivers/gpu/drm/xe/xe_bo.c
++++ b/drivers/gpu/drm/xe/xe_bo.c
+@@ -1302,7 +1302,7 @@ static bool xe_ttm_bo_lock_in_destructor(struct ttm_buffer_object *ttm_bo)
+ 	 * always succeed here, as long as we hold the lru lock.
+ 	 */
+ 	spin_lock(&ttm_bo->bdev->lru_lock);
+-	locked = dma_resv_trylock(ttm_bo->base.resv);
++	locked = dma_resv_trylock(&ttm_bo->base._resv);
+ 	spin_unlock(&ttm_bo->bdev->lru_lock);
+ 	xe_assert(xe, locked);
+ 
+@@ -1322,13 +1322,6 @@ static void xe_ttm_bo_release_notify(struct ttm_buffer_object *ttm_bo)
+ 	bo = ttm_to_xe_bo(ttm_bo);
+ 	xe_assert(xe_bo_device(bo), !(bo->created && kref_read(&ttm_bo->base.refcount)));
+ 
+-	/*
+-	 * Corner case where TTM fails to allocate memory and this BOs resv
+-	 * still points the VMs resv
+-	 */
+-	if (ttm_bo->base.resv != &ttm_bo->base._resv)
+-		return;
+-
+ 	if (!xe_ttm_bo_lock_in_destructor(ttm_bo))
+ 		return;
+ 
+@@ -1338,14 +1331,14 @@ static void xe_ttm_bo_release_notify(struct ttm_buffer_object *ttm_bo)
+ 	 * TODO: Don't do this for external bos once we scrub them after
+ 	 * unbind.
+ 	 */
+-	dma_resv_for_each_fence(&cursor, ttm_bo->base.resv,
++	dma_resv_for_each_fence(&cursor, &ttm_bo->base._resv,
+ 				DMA_RESV_USAGE_BOOKKEEP, fence) {
+ 		if (xe_fence_is_xe_preempt(fence) &&
+ 		    !dma_fence_is_signaled(fence)) {
+ 			if (!replacement)
+ 				replacement = dma_fence_get_stub();
+ 
+-			dma_resv_replace_fences(ttm_bo->base.resv,
++			dma_resv_replace_fences(&ttm_bo->base._resv,
+ 						fence->context,
+ 						replacement,
+ 						DMA_RESV_USAGE_BOOKKEEP);
+@@ -1353,7 +1346,7 @@ static void xe_ttm_bo_release_notify(struct ttm_buffer_object *ttm_bo)
+ 	}
+ 	dma_fence_put(replacement);
+ 
+-	dma_resv_unlock(ttm_bo->base.resv);
++	dma_resv_unlock(&ttm_bo->base._resv);
+ }
+ 
+ static void xe_ttm_bo_delete_mem_notify(struct ttm_buffer_object *ttm_bo)
+-- 
+2.43.0
+

--- a/backport/patches/features/multigpu/0001-drm-xe-Don-t-copy-pinned-kernel-bos-twice-on-suspend.patch
+++ b/backport/patches/features/multigpu/0001-drm-xe-Don-t-copy-pinned-kernel-bos-twice-on-suspend.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Hellstr=C3=B6m?= <thomas.hellstrom@linux.intel.com>
+Date: Thu, 18 Sep 2025 11:22:05 +0200
+Subject: drm/xe: Don't copy pinned kernel bos twice on suspend
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We were copying the bo content the bos on the list
+"xe->pinned.late.kernel_bo_present" twice on suspend.
+
+Presumingly the intent is to copy the pinned external bos on
+the first pass.
+
+This is harmless since we (currently) should have no pinned
+external bos needing copy since
+a) exernal system bos don't have compressed content,
+b) We do not (yet) allow pinning of VRAM bos.
+
+Still, fix this up so that we copy pinned external bos on
+the first pass. We're about to allow bos pinned in VRAM.
+
+Fixes: c6a4d46ec1d7 ("drm/xe: evict user memory in PM notifier")
+Cc: Matthew Auld <matthew.auld@intel.com>
+Cc: <stable@vger.kernel.org> # v6.16+
+Signed-off-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://lore.kernel.org/r/20250918092207.54472-2-thomas.hellstrom@linux.intel.com
+(cherry picked from commit 9e69bafece43dcefec864f00b3ec7e088aa7fcbc linux-next)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_bo_evict.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo_evict.c b/drivers/gpu/drm/xe/xe_bo_evict.c
+index 7484ce55a..d5dbc51e8 100644
+--- a/drivers/gpu/drm/xe/xe_bo_evict.c
++++ b/drivers/gpu/drm/xe/xe_bo_evict.c
+@@ -158,8 +158,8 @@ int xe_bo_evict_all(struct xe_device *xe)
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = xe_bo_apply_to_pinned(xe, &xe->pinned.late.kernel_bo_present,
+-				    &xe->pinned.late.evicted, xe_bo_evict_pinned);
++	ret = xe_bo_apply_to_pinned(xe, &xe->pinned.late.external,
++				    &xe->pinned.late.external, xe_bo_evict_pinned);
+ 
+ 	if (!ret)
+ 		ret = xe_bo_apply_to_pinned(xe, &xe->pinned.late.kernel_bo_present,
+-- 
+2.43.0
+

--- a/backport/patches/features/multigpu/0001-drm-xe-Pre-allocate-system-memory-for-pinned-externa.patch
+++ b/backport/patches/features/multigpu/0001-drm-xe-Pre-allocate-system-memory-for-pinned-externa.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Hellstr=C3=B6m?= <thomas.hellstrom@linux.intel.com>
+Date: Thu, 18 Sep 2025 11:22:06 +0200
+Subject: drm/xe: Pre-allocate system memory for pinned external bos in
+ the pm notfier
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Similarly to what we do for other pinned bos, pre-allocate
+system memory for pinned external bos in the pm notifier,
+where swapping is still possible.
+
+This hasn't been needed until now when we're about to allow
+pinning of exernal VRAM bos.
+
+Cc: Matthew Auld <matthew.auld@intel.com>
+Signed-off-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://lore.kernel.org/r/20250918092207.54472-3-thomas.hellstrom@linux.intel.com
+(cherry-picked from commit 8b3dfa6fcf2603ef24cd501433f26f5d184d3732 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_bo_evict.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo_evict.c b/drivers/gpu/drm/xe/xe_bo_evict.c
+index d5dbc51e8..1a12675b2 100644
+--- a/drivers/gpu/drm/xe/xe_bo_evict.c
++++ b/drivers/gpu/drm/xe/xe_bo_evict.c
+@@ -73,6 +73,11 @@ int xe_bo_notifier_prepare_all_pinned(struct xe_device *xe)
+ 					    &xe->pinned.late.kernel_bo_present,
+ 					    xe_bo_notifier_prepare_pinned);
+ 
++	if (!ret)
++		ret = xe_bo_apply_to_pinned(xe, &xe->pinned.late.external,
++					    &xe->pinned.late.external,
++					    xe_bo_notifier_prepare_pinned);
++
+ 	return ret;
+ }
+ 
+@@ -93,6 +98,10 @@ void xe_bo_notifier_unprepare_all_pinned(struct xe_device *xe)
+ 	(void)xe_bo_apply_to_pinned(xe, &xe->pinned.late.kernel_bo_present,
+ 				    &xe->pinned.late.kernel_bo_present,
+ 				    xe_bo_notifier_unprepare_pinned);
++
++	(void)xe_bo_apply_to_pinned(xe, &xe->pinned.late.external,
++				    &xe->pinned.late.external,
++				    xe_bo_notifier_unprepare_pinned);
+ }
+ 
+ /**
+-- 
+2.43.0
+

--- a/backport/patches/features/multigpu/0001-drm-xe-dma-buf-Allow-pinning-of-p2p-dma-buf.patch
+++ b/backport/patches/features/multigpu/0001-drm-xe-dma-buf-Allow-pinning-of-p2p-dma-buf.patch
@@ -1,0 +1,171 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Hellstr=C3=B6m?= <thomas.hellstrom@linux.intel.com>
+Date: Thu, 18 Sep 2025 11:22:07 +0200
+Subject: drm/xe/dma-buf: Allow pinning of p2p dma-buf
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+RDMA NICs typically requires the VRAM dma-bufs to be pinned in
+VRAM for pcie-p2p communication, since they don't fully support
+the move_notify() scheme. We would like to support that.
+
+However allowing unaccounted pinning of VRAM creates a DOS vector
+so up until now we haven't allowed it.
+
+However with cgroups support in TTM, the amount of VRAM allocated
+to a cgroup can be limited, and since also the pinned memory is
+accounted as allocated VRAM we should be safe.
+
+An analogy with system memory can be made if we observe the
+similarity with kernel system memory that is allocated as the
+result of user-space action and that is accounted using __GFP_ACCOUNT.
+
+Ideally, to be more flexible, we would add a "pinned_memory",
+or possibly "kernel_memory" limit to the dmem cgroups controller,
+that would additionally limit the memory that is pinned in this way.
+If we let that limit default to the dmem::max limit we can
+introduce that without needing to care about regressions.
+
+Considering that we already pin VRAM in this way for at least
+page-table memory and LRC memory, and the above path to greater
+flexibility, allow this also for dma-bufs.
+
+v2:
+- Update comments about pinning in the dma-buf kunit test
+  (Niranjana Vishwanathapura)
+
+Cc: Dave Airlie <airlied@gmail.com>
+Cc: Simona Vetter <simona.vetter@ffwll.ch>
+Cc: Joonas Lahtinen <joonas.lahtinen@linux.intel.com>
+Cc: Maarten Lankhorst <maarten.lankhorst@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Cc: Lucas De Marchi <lucas.demarchi@intel.com>
+Cc: Niranjana Vishwanathapura <niranjana.vishwanathapura@intel.com>
+Signed-off-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Acked-by: Simona Vetter <simona.vetter@ffwll.ch>
+Reviewed-by: Maarten Lankhorst <maarten.lankhorst@linux.intel.com>
+Link: https://lore.kernel.org/r/20250918092207.54472-4-thomas.hellstrom@linux.intel.com
+(cherry-picked from commit df636bf2836644667c632864e25878bd928154f7 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/tests/xe_dma_buf.c | 17 +++++++++--
+ drivers/gpu/drm/xe/xe_dma_buf.c       | 41 +++++++++++++++++----------
+ 2 files changed, 41 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/tests/xe_dma_buf.c b/drivers/gpu/drm/xe/tests/xe_dma_buf.c
+index d9b917c6f..8de189eee 100644
+--- a/drivers/gpu/drm/xe/tests/xe_dma_buf.c
++++ b/drivers/gpu/drm/xe/tests/xe_dma_buf.c
+@@ -31,6 +31,7 @@ static void check_residency(struct kunit *test, struct xe_bo *exported,
+ 			    struct drm_exec *exec)
+ {
+ 	struct dma_buf_test_params *params = to_dma_buf_test_params(test->priv);
++	struct dma_buf_attachment *attach;
+ 	u32 mem_type;
+ 	int ret;
+ 
+@@ -46,7 +47,7 @@ static void check_residency(struct kunit *test, struct xe_bo *exported,
+ 		mem_type = XE_PL_TT;
+ 	else if (params->force_different_devices && !is_dynamic(params) &&
+ 		 (params->mem_mask & XE_BO_FLAG_SYSTEM))
+-		/* Pin migrated to TT */
++		/* Pin migrated to TT on non-dynamic attachments. */
+ 		mem_type = XE_PL_TT;
+ 
+ 	if (!xe_bo_is_mem_type(exported, mem_type)) {
+@@ -92,6 +93,18 @@ static void check_residency(struct kunit *test, struct xe_bo *exported,
+ 
+ 	KUNIT_EXPECT_TRUE(test, xe_bo_is_mem_type(exported, mem_type));
+ 
++	/* Check that we can pin without migrating. */
++	attach = list_first_entry_or_null(&dmabuf->attachments, typeof(*attach), node);
++	if (attach) {
++		int err = dma_buf_pin(attach);
++
++		if (!err) {
++			KUNIT_EXPECT_TRUE(test, xe_bo_is_mem_type(exported, mem_type));
++			dma_buf_unpin(attach);
++		}
++		KUNIT_EXPECT_EQ(test, err, 0);
++	}
++
+ 	if (params->force_different_devices)
+ 		KUNIT_EXPECT_TRUE(test, xe_bo_is_mem_type(imported, XE_PL_TT));
+ 	else
+@@ -153,7 +166,7 @@ static void xe_test_dmabuf_import_same_driver(struct xe_device *xe)
+ 			xe_bo_lock(import_bo, false);
+ 			err = xe_bo_validate(import_bo, NULL, false, exec);
+ 
+-			/* Pinning in VRAM is not allowed. */
++			/* Pinning in VRAM is not allowed for non-dynamic attachments */
+ 			if (!is_dynamic(params) &&
+ 			    params->force_different_devices &&
+ 			    !(params->mem_mask & XE_BO_FLAG_SYSTEM))
+diff --git a/drivers/gpu/drm/xe/xe_dma_buf.c b/drivers/gpu/drm/xe/xe_dma_buf.c
+index 607c3f4ef..a5d3cbf3f 100644
+--- a/drivers/gpu/drm/xe/xe_dma_buf.c
++++ b/drivers/gpu/drm/xe/xe_dma_buf.c
+@@ -48,32 +48,43 @@ static void xe_dma_buf_detach(struct dma_buf *dmabuf,
+ 
+ static int xe_dma_buf_pin(struct dma_buf_attachment *attach)
+ {
+-	struct drm_gem_object *obj = attach->dmabuf->priv;
++	struct dma_buf *dmabuf = attach->dmabuf;
++	struct drm_gem_object *obj = dmabuf->priv;
+ 	struct xe_bo *bo = gem_to_xe_bo(obj);
+ 	struct xe_device *xe = xe_bo_device(bo);
+ 	struct drm_exec *exec = XE_VALIDATION_UNSUPPORTED;
++	bool allow_vram = true;
+ 	int ret;
+ 
+-	/*
+-	 * For now only support pinning in TT memory, for two reasons:
+-	 * 1) Avoid pinning in a placement not accessible to some importers.
+-	 * 2) Pinning in VRAM requires PIN accounting which is a to-do.
+-	 */
+-	if (xe_bo_is_pinned(bo) && !xe_bo_is_mem_type(bo, XE_PL_TT)) {
++	if (!IS_ENABLED(CONFIG_DMABUF_MOVE_NOTIFY)) {
++		allow_vram = false;
++	} else {
++		list_for_each_entry(attach, &dmabuf->attachments, node) {
++			if (!attach->peer2peer) {
++				allow_vram = false;
++				break;
++			}
++		}
++	}
++
++	if (xe_bo_is_pinned(bo) && !xe_bo_is_mem_type(bo, XE_PL_TT) &&
++	    !(xe_bo_is_vram(bo) && allow_vram)) {
+ 		drm_dbg(&xe->drm, "Can't migrate pinned bo for dma-buf pin.\n");
+ 		return -EINVAL;
+ 	}
+ 
+-	ret = xe_bo_migrate(bo, XE_PL_TT, NULL, exec);
+-	if (ret) {
+-		if (ret != -EINTR && ret != -ERESTARTSYS)
+-			drm_dbg(&xe->drm,
+-				"Failed migrating dma-buf to TT memory: %pe\n",
+-				ERR_PTR(ret));
+-		return ret;
++	if (!allow_vram) {
++		ret = xe_bo_migrate(bo, XE_PL_TT, NULL, exec);
++		if (ret) {
++			if (ret != -EINTR && ret != -ERESTARTSYS)
++				drm_dbg(&xe->drm,
++					"Failed migrating dma-buf to TT memory: %pe\n",
++					ERR_PTR(ret));
++			return ret;
++		}
+ 	}
+ 
+-	ret = xe_bo_pin_external(bo, true, exec);
++	ret = xe_bo_pin_external(bo, !allow_vram, exec);
+ 	xe_assert(xe, !ret);
+ 
+ 	return 0;
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -102,6 +102,7 @@ backport/patches/base/0001-drm-xe-Restore-engine-registers-before-restarting-sc.
 backport/patches/base/0001-drm-xe-guc-Fix-stack_depot-usage.patch
 backport/patches/base/0001-drm-xe-Increase-TDF-timeout.patch
 backport/patches/base/0001-drm-ttm-test-private-resv-obj-on-release-destroy.patch
+backport/patches/base/0001-drm-xe-Drop-preempt-fences-when-destroying-imported-.patch
 # features/xe-late-bind-fw
 backport/patches/features/xe-late-bind-fw/0001-mei-bus-add-mei_cldev_mtu-interface.patch
 backport/patches/features/xe-late-bind-fw/0001-mei-late_bind-add-late-binding-component-driver.patch

--- a/series
+++ b/series
@@ -101,6 +101,7 @@ backport/patches/base/0001-drm-xe-Apply-Wa_14020316580-in-xe_gt_idle_enable_pg.p
 backport/patches/base/0001-drm-xe-Restore-engine-registers-before-restarting-sc.patch
 backport/patches/base/0001-drm-xe-guc-Fix-stack_depot-usage.patch
 backport/patches/base/0001-drm-xe-Increase-TDF-timeout.patch
+backport/patches/base/0001-drm-ttm-test-private-resv-obj-on-release-destroy.patch
 # features/xe-late-bind-fw
 backport/patches/features/xe-late-bind-fw/0001-mei-bus-add-mei_cldev_mtu-interface.patch
 backport/patches/features/xe-late-bind-fw/0001-mei-late_bind-add-late-binding-component-driver.patch

--- a/series
+++ b/series
@@ -577,6 +577,10 @@ backport/patches/features/sriov/0001-drm-xe-vf-Start-re-emission-from-first-unsi
 backport/patches/features/sriov/0001-drm-xe-vf-Stop-waiting-for-ring-space-on-VF-post-mig.patch
 backport/patches/features/sriov/0001-drm-xe-Do-not-reference-loop-variable-directly.patch
 backport/patches/features/sriov/0001-drm-xe-migrate-Switch-from-drm-to-dev-managed-action.patch
+# features/multigpu
+backport/patches/features/multigpu/0001-drm-xe-Don-t-copy-pinned-kernel-bos-twice-on-suspend.patch
+backport/patches/features/multigpu/0001-drm-xe-Pre-allocate-system-memory-for-pinned-externa.patch
+backport/patches/features/multigpu/0001-drm-xe-dma-buf-Allow-pinning-of-p2p-dma-buf.patch
 # features/vf-double-migration
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Enable-VF-migration-only-on-supported-GuC-.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch


### PR DESCRIPTION
Fix double copying of pinned kernel BOs on suspend and copy pinned
external BOs in the correct pass.
Pre-allocate system memory for pinned external BOs in the PM notifier.
Allow pinning of P2P dma-bufs in VRAM with proper TTM cgroup accounting.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>