### PR TITLE
features/eu-debug: check attention bits only once in attention_scan_fn()

### DIFF
--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Check-attention-bits-only-once-in-att.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Check-attention-bits-only-once-in-att.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Maslak <jan.maslak@intel.com>
+Date: Fri, 2 Jan 2026 16:18:03 +0100
+Subject: drm/xe/eudebug: Check attention bits only once in
+ attention_scan_fn()
+
+Previously, handle_gt_queued_pagefault() and xe_eudebug_handle_gt_attention()
+each performed separate attention bit checks. This created a race window where
+attention bits could change between the two checks, leading to inconsistent
+event delivery.
+
+The fix consolidates attention checking to a single point in
+attention_scan_fn(), ensuring atomic decision making for both event types.
+
+Signed-off-by: Jan Maslak <jan.maslak@intel.com>
+(cherry-picked from commit ccb563c0d41a76bfce554aefd776475d4c282581 xe-internal)
+---
+ drivers/gpu/drm/xe/prelim/xe_eudebug.c | 37 +++++++++++++++-----------
+ 1 file changed, 22 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/prelim/xe_eudebug.c b/drivers/gpu/drm/xe/prelim/xe_eudebug.c
+index e143bf2f6..fea11389b 100644
+--- a/drivers/gpu/drm/xe/prelim/xe_eudebug.c
++++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.c
+@@ -1753,10 +1753,6 @@ static int xe_eudebug_handle_gt_attention(struct xe_gt *gt)
+ {
+ 	int ret;
+ 
+-	ret = prelim_xe_gt_eu_threads_needing_attention(gt);
+-	if (ret <= 0)
+-		return ret;
+-
+ 	ret = xe_send_gt_attention(gt);
+ 
+ 	/* Discovery in progress, fake it */
+@@ -1904,10 +1900,6 @@ static int handle_gt_queued_pagefault(struct xe_gt *gt)
+ 	struct xe_eudebug *d;
+ 	int ret, lrc_idx;
+ 
+-	ret = prelim_xe_gt_eu_threads_needing_attention(gt);
+-	if (ret <= 0)
+-		return ret;
+-
+ 	if (list_empty_careful(&gt_to_xe(gt)->eudebug.list))
+ 		return -ENOTCONN;
+ 
+@@ -1942,6 +1934,16 @@ static int handle_gt_queued_pagefault(struct xe_gt *gt)
+ 	return ret;
+ }
+ 
++static void _handle_attention_fail(struct xe_gt *gt, u8 gt_id, int ret)
++{
++	/* TODO: error capture */
++	drm_info(&gt_to_xe(gt)->drm,
++		 "gt:%d unable to handle eu attention ret=%d\n",
++		 gt_id, ret);
++
++	xe_gt_reset_async(gt);
++}
++
+ #define XE_EUDEBUG_ATTENTION_INTERVAL 100
+ static void attention_scan_fn(struct work_struct *work)
+ {
+@@ -1958,21 +1960,26 @@ static void attention_scan_fn(struct work_struct *work)
+ 
+ 	if (xe_pm_runtime_get_if_active(xe)) {
+ 		for_each_gt(gt, xe, gt_id) {
+-			int ret;
++			int ret, attns_count;
+ 
+ 			if (gt->info.type != XE_GT_TYPE_MAIN)
+ 				continue;
+ 
+-			handle_gt_queued_pagefault(gt);
++			attns_count = prelim_xe_gt_eu_threads_needing_attention(gt);
++			if (!attns_count)
++				continue;
+ 
+ 			ret = xe_eudebug_handle_gt_attention(gt);
++			ret = handle_gt_queued_pagefault(gt);
+ 			if (ret) {
+-				/* TODO: error capture */
+-				drm_info(&gt_to_xe(gt)->drm,
+-					 "gt:%d unable to handle eu attention ret=%d\n",
+-					 gt_id, ret);
++				_handle_attention_fail(gt, gt_id, ret);
++				continue;
++			}
+ 
+-				xe_gt_reset_async(gt);
++			ret = xe_eudebug_handle_gt_attention(gt);
++			if (ret) {
++				_handle_attention_fail(gt, gt_id, ret);
++				continue;
+ 			}
+ 		}
+ 
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -306,3 +306,4 @@ backport/patches/features/eu-debug/0001-drm-xe-Add-PRELIM-infrastructure.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-update-eudebug-prelim-flags.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-add-eudebug-drm-managed-finalize.patch
+backport/patches/features/eu-debug/0001-drm-xe-eudebug-Check-attention-bits-only-once-in-att.patch


### PR DESCRIPTION
This PR adds a new eu-debug patch that makes the attention bits be checked only once during attention scan.

---

Previously, handle_gt_queued_pagefault() and xe_eudebug_handle_gt_attention() each performed separate attention bit checks. This created a race window where attention bits could change between the two checks, leading to inconsistent event delivery.

The fix consolidates attention checking to a single point in attention_scan_fn(), ensuring atomic decision making for both event types.
