### PR TITLE
drm/xe: Backport fix for crash in xe_migrate_fini during driver unload

### DIFF
--- a/backport/patches/features/sriov/0001-drm-xe-migrate-Switch-from-drm-to-dev-managed-action.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-migrate-Switch-from-drm-to-dev-managed-action.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aradhya Bhatia <aradhya.bhatia@intel.com>
+Date: Wed, 26 Mar 2025 20:49:29 +0530
+Subject: drm/xe/migrate: Switch from drm to dev managed actions
+
+Change the scope of the migrate subsystem to be dev managed instead of
+drm managed.
+
+The parent pci struct &device, that the xe struct &drm_device is a part
+of, gets removed when a hot unplug is triggered, which causes the
+underlying iommu group to get destroyed as well.
+
+The migrate subsystem, which handles the lifetime of the page-table tree
+(pt) BO, doesn't get a chance to keep the BO back during the hot unplug,
+as all the references to DRM haven't been put back.
+When all the references to DRM are indeed put back later, the migrate
+subsystem tries to put back the pt BO. Since the underlying iommu group
+has been already destroyed, a kernel NULL ptr dereference takes place
+while attempting to keep back the pt BO.
+
+Closes: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues/3914
+Suggested-by: Thomas Hellstrom <thomas.hellstrom@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Signed-off-by: Aradhya Bhatia <aradhya.bhatia@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20250326151929.1495972-1-aradhya.bhatia@intel.com
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from commit c045e03634ab677ef9351e9b350da78b5c9d7961 linux-next )
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_migrate.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
+index 2e331b383..1f4d811c7 100644
+--- a/drivers/gpu/drm/xe/xe_migrate.c
++++ b/drivers/gpu/drm/xe/xe_migrate.c
+@@ -88,7 +88,7 @@ struct xe_migrate {
+  */
+ #define MAX_PTE_PER_SDI 0x1FE
+ 
+-static void xe_migrate_fini(struct drm_device *dev, void *arg)
++static void xe_migrate_fini(void *arg)
+ {
+ 	struct xe_migrate *m = arg;
+ 
+@@ -478,7 +478,7 @@ int xe_migrate_init(struct xe_migrate *m)
+ 	might_lock(&m->job_mutex);
+ 	fs_reclaim_release(GFP_KERNEL);
+ 
+-	err = drmm_add_action_or_reset(&xe->drm, xe_migrate_fini, m);
++	err = devm_add_action_or_reset(xe->drm.dev, xe_migrate_fini, m);
+ 	if (err)
+ 		return err;
+ 
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -576,6 +576,7 @@ backport/patches/features/sriov/0001-drm-xe-Protect-against-unset-LRC-when-pausi
 backport/patches/features/sriov/0001-drm-xe-vf-Start-re-emission-from-first-unsignaled-jo.patch
 backport/patches/features/sriov/0001-drm-xe-vf-Stop-waiting-for-ring-space-on-VF-post-mig.patch
 backport/patches/features/sriov/0001-drm-xe-Do-not-reference-loop-variable-directly.patch
+backport/patches/features/sriov/0001-drm-xe-migrate-Switch-from-drm-to-dev-managed-action.patch
 # features/vf-double-migration
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Enable-VF-migration-only-on-supported-GuC-.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch


### PR DESCRIPTION
[ Backport to fix use-after-free crash during driver unload ]

Backport upstream changes to fix a use-after-free crash in
xe_migrate_fini during driver unload. The issue occurs when
xe_migrate_fini is called during drm_managed_release and attempts
to access GGTT resources that have already been freed.i

Fix: Switch from drmm_add_action_or_reset to devm_add_action_or_reset
to ensure xe_migrate_fini runs before underlying device resources are
torn down. Also remove unused drm_device parameter.

This backport is needed to prevent system crashes during driver
unload/device removal scenarios.

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>