### PR TITLE
drm/xe/pf: Handle VF BAR resize without PCI VF REBAR helpers

### DIFF
--- a/src/drivers/gpu/drm/xe/xe_pci_sriov.c
+++ b/src/drivers/gpu/drm/xe/xe_pci_sriov.c
@@ -21,6 +21,44 @@
 #include "xe_sriov_pf_helpers.h"
 #include "xe_sriov_printk.h"
 
+/*
+ * NOTE: Backport-only.
+ *
+ * We need to update the SR-IOV VF BAR size cache (pdev->sriov->barsz[])
+ * when programming VF Resizable BAR (VF REBAR) on kernels that do not
+ * provide PCI VF REBAR helper APIs.
+ *
+ * The real 'struct pci_sriov' is PCI-core internal (drivers/pci/pci.h).
+ * For OOT/backport builds, we provide a local copy of the v6.6 layout
+ * to access barsz[] only. Keep this in sync with the target baseline.
+ */
+#ifndef HAVE_STRUCT_PCI_SRIOV
+struct pci_sriov {
+	int		pos;			/* Capability position */
+	int		nres;			/* Number of resources */
+	u32		cap;			/* SR-IOV Capabilities */
+	u16		ctrl;			/* SR-IOV Control */
+	u16		total_VFs;		/* Total VFs associated with the PF */
+	u16		initial_VFs;		/* Initial VFs associated with the PF */
+	u16		num_VFs;		/* Number of VFs available */
+	u16		offset;			/* First VF Routing ID offset */
+	u16		stride;			/* Following VF stride */
+	u16		vf_device;		/* VF device ID */
+	u32		pgsz;			/* Page size for BAR alignment */
+	u8		link;			/* Function Dependency Link */
+	u8		max_VF_buses;		/* Max buses consumed by VFs */
+	u16		driver_max_VFs;		/* Max num VFs driver supports */
+	struct pci_dev	*dev;			/* Lowest numbered PF */
+	struct pci_dev	*self;			/* This PF */
+	u32		class;			/* VF device */
+	u8		hdr_type;		/* VF header type */
+	u16		subsystem_vendor;	/* VF subsystem vendor */
+	u16		subsystem_device;	/* VF subsystem device */
+	resource_size_t	barsz[PCI_SRIOV_NUM_BARS]; /* VF BAR size */
+	bool		drivers_autoprobe;	/* Auto probing of VFs by driver */
+};
+#endif /* HAVE_STRUCT_PCI_SRIOV */
+
 static int pf_needs_provisioning(struct xe_gt *gt, unsigned int num_vfs)
 {
 	unsigned int n;
@@ -133,16 +171,73 @@ static void pf_engine_activity_stats(struct xe_device *xe, unsigned int num_vfs,
 	}
 }
 
+#ifndef PCI_EXT_CAP_ID_VF_REBAR
+#define PCI_EXT_CAP_ID_VF_REBAR 0x24 /* VF Resizable BAR */
+#endif
+
+#ifndef HAVE_PCI_REBAR_SIZE_TO_BYTES
+static inline resource_size_t pci_rebar_size_to_bytes(int size)
+{
+	return 1ULL << (size + ilog2((resource_size_t)SZ_1M));
+}
+#endif
+
 static int resize_vf_vram_bar(struct xe_device *xe, int num_vfs)
 {
 	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
-	u32 sizes;
+	resource_size_t size, total;
+	int pos, i, vf_bar_idx = VF_LMEM_BAR - PCI_IOV_RESOURCES;
+	u32 rebar, ctrl;
+	int err;
 
-	sizes = pci_iov_vf_bar_get_sizes(pdev, VF_LMEM_BAR, num_vfs);
-	if (!sizes)
+	pos = pci_find_ext_capability(pdev, PCI_EXT_CAP_ID_VF_REBAR);
+	if (!pos)
 		return 0;
 
-	return pci_iov_vf_bar_set_size(pdev, VF_LMEM_BAR, __fls(sizes));
+	/*
+	 * For all current platforms we're expecting a single VF resizable BAR,
+	 * and we expect it to always be BAR2.
+	 */
+	err = pci_read_config_dword(pdev, pos + PCI_REBAR_CTRL, &ctrl);
+	if (err)
+		return err;
+
+	if (FIELD_GET(PCI_REBAR_CTRL_NBAR_MASK, ctrl) != 1 ||
+	    FIELD_GET(PCI_REBAR_CTRL_BAR_IDX, ctrl) != vf_bar_idx) {
+		xe_sriov_warn(xe, "Unexpected resource in VF resizable BAR, skipping resize\n");
+		return 0;
+	}
+
+	err = pci_read_config_dword(pdev, pos + PCI_REBAR_CAP, &rebar);
+	if (err)
+		return err;
+
+	rebar = FIELD_GET(PCI_REBAR_CAP_SIZES, rebar);
+	total = pci_resource_len(pdev, VF_LMEM_BAR);
+
+	while (rebar) {
+		i = __fls(rebar);
+		size = pci_rebar_size_to_bytes(i);
+
+		if (num_vfs && size <= div_u64(total, num_vfs)) {
+			ctrl &= ~PCI_REBAR_CTRL_BAR_SIZE;
+			ctrl |= pci_rebar_bytes_to_size(size) << PCI_REBAR_CTRL_BAR_SHIFT;
+
+			err = pci_write_config_dword(pdev, pos + PCI_REBAR_CTRL, ctrl);
+			if (err)
+				return err;
+
+			((struct pci_sriov *)pdev->sriov)->barsz[vf_bar_idx] = size;
+
+			xe_sriov_info(xe, "VF BAR%d resized to %llu MiB\n",
+				      vf_bar_idx, (unsigned long long)(size >> 20));
+			break;
+		}
+
+		rebar &= ~BIT(i);
+	}
+
+	return 0;
 }
 
 static int pf_enable_vfs(struct xe_device *xe, int num_vfs)
@@ -182,7 +277,7 @@ static int pf_enable_vfs(struct xe_device *xe, int num_vfs)
 	if (IS_DGFX(xe)) {
 		err = resize_vf_vram_bar(xe, num_vfs);
 		if (err)
-			xe_sriov_info(xe, "Failed to set VF LMEM BAR size: %d\n", err);
+			xe_sriov_info(xe, "Failed to set VF LMEM BAR size: %pe\n", ERR_PTR(err));
 	}
 
 	err = pci_enable_sriov(pdev, num_vfs);

--- a/src/drivers/gpu/drm/xe/xe_pci_sriov.c
+++ b/src/drivers/gpu/drm/xe/xe_pci_sriov.c
@@ -240,6 +240,19 @@ static int resize_vf_vram_bar(struct xe_device *xe, int num_vfs)
 	return 0;
 }
 
+static void restore_vf_vram_bar_size(struct xe_device *xe)
+{
+	int err;
+
+	if (!IS_DGFX(xe))
+		return;
+
+	err = resize_vf_vram_bar(xe, xe->sriov.pf.device_total_vfs);
+	if (err)
+		xe_sriov_info(xe, "Failed to restore VF LMEM BAR size: %pe\n",
+			      ERR_PTR(err));
+}
+
 static int pf_enable_vfs(struct xe_device *xe, int num_vfs)
 {
 	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
@@ -294,6 +307,7 @@ static int pf_enable_vfs(struct xe_device *xe, int num_vfs)
 	return num_vfs;
 
 failed:
+	restore_vf_vram_bar_size(xe);
 	pf_unprovision_vfs(xe, num_vfs);
 	xe_pm_runtime_put(xe);
 	prelim_xe_eudebug_support_enable(xe);
@@ -318,6 +332,8 @@ static int pf_disable_vfs(struct xe_device *xe)
 	pf_engine_activity_stats(xe, num_vfs, false);
 
 	pci_disable_sriov(pdev);
+
+	restore_vf_vram_bar_size(xe);
 
 	pf_reset_vfs(xe, num_vfs);
 


### PR DESCRIPTION
Implement VF BAR resizing via the VF Resizable BAR capability directly
in PCI config space for kernels that lack PCI VF REBAR helper APIs.