### PR TITLE
backport/base: make xe_gt_idle_disable_c6() handle forcewake internally

### DIFF
--- a/backport/patches/base/0001-drm-xe-make-xe_gt_idle_disable_c6-handle-the-forcewa.patch
+++ b/backport/patches/base/0001-drm-xe-make-xe_gt_idle_disable_c6-handle-the-forcewa.patch
@@ -1,0 +1,117 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xin Wang <x.wang@intel.com>
+Date: Tue, 26 Aug 2025 17:06:32 -0700
+Subject: drm/xe: make xe_gt_idle_disable_c6() handle the forcewake
+ internally
+
+Move forcewake_get() into xe_gt_idle_enable_c6() to streamline the
+code and make it easier to use.
+
+Suggested-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Xin Wang <x.wang@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://lore.kernel.org/r/20250827000633.1369890-2-x.wang@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit 1313351e71181a4818afeb8dfe202e4162091ef6 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_idle.c | 21 +++++++++++++--------
+ drivers/gpu/drm/xe/xe_gt_idle.h |  2 +-
+ drivers/gpu/drm/xe/xe_guc_pc.c  | 13 +------------
+ 3 files changed, 15 insertions(+), 21 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_idle.c b/drivers/gpu/drm/xe/xe_gt_idle.c
+index aa4163267531..92247b9480c3 100644
+--- a/drivers/gpu/drm/xe/xe_gt_idle.c
++++ b/drivers/gpu/drm/xe/xe_gt_idle.c
+@@ -338,15 +338,11 @@ static void gt_idle_fini(void *arg)
+ {
+ 	struct kobject *kobj = arg;
+ 	struct xe_gt *gt = kobj_to_gt(kobj->parent);
+-	unsigned int fw_ref;
+ 
+ 	xe_gt_idle_disable_pg(gt);
+ 
+-	if (gt_to_xe(gt)->info.skip_guc_pc) {
+-		fw_ref = xe_force_wake_get(gt_to_fw(gt), XE_FW_GT);
++	if (gt_to_xe(gt)->info.skip_guc_pc)
+ 		xe_gt_idle_disable_c6(gt);
+-		xe_force_wake_put(gt_to_fw(gt), fw_ref);
+-	}
+ 
+ 	sysfs_remove_files(kobj, gt_idle_attrs);
+ 	kobject_put(kobj);
+@@ -406,14 +402,23 @@ void xe_gt_idle_enable_c6(struct xe_gt *gt)
+ 			RC_CTL_HW_ENABLE | RC_CTL_TO_MODE | RC_CTL_RC6_ENABLE);
+ }
+ 
+-void xe_gt_idle_disable_c6(struct xe_gt *gt)
++int xe_gt_idle_disable_c6(struct xe_gt *gt)
+ {
++	unsigned int fw_ref;
++
+ 	xe_device_assert_mem_access(gt_to_xe(gt));
+-	xe_force_wake_assert_held(gt_to_fw(gt), XE_FW_GT);
+ 
+ 	if (IS_SRIOV_VF(gt_to_xe(gt)))
+-		return;
++		return 0;
++
++	fw_ref = xe_force_wake_get(gt_to_fw(gt), XE_FW_GT);
++	if (!fw_ref)
++		return -ETIMEDOUT;
+ 
+ 	xe_mmio_write32(&gt->mmio, RC_CONTROL, 0);
+ 	xe_mmio_write32(&gt->mmio, RC_STATE, 0);
++
++	xe_force_wake_put(gt_to_fw(gt), fw_ref);
++
++	return 0;
+ }
+diff --git a/drivers/gpu/drm/xe/xe_gt_idle.h b/drivers/gpu/drm/xe/xe_gt_idle.h
+index 591a01e181bc..9c34a155e102 100644
+--- a/drivers/gpu/drm/xe/xe_gt_idle.h
++++ b/drivers/gpu/drm/xe/xe_gt_idle.h
+@@ -13,7 +13,7 @@ struct xe_gt;
+ 
+ int xe_gt_idle_init(struct xe_gt_idle *gtidle);
+ void xe_gt_idle_enable_c6(struct xe_gt *gt);
+-void xe_gt_idle_disable_c6(struct xe_gt *gt);
++int xe_gt_idle_disable_c6(struct xe_gt *gt);
+ void xe_gt_idle_enable_pg(struct xe_gt *gt);
+ void xe_gt_idle_disable_pg(struct xe_gt *gt);
+ int xe_gt_idle_pg_print(struct xe_gt *gt, struct drm_printer *p);
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
+index 68b192fe3b32..6b1c27d865b1 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc.c
++++ b/drivers/gpu/drm/xe/xe_guc_pc.c
+@@ -1076,7 +1076,6 @@ int xe_guc_pc_gucrc_disable(struct xe_guc_pc *pc)
+ {
+ 	struct xe_device *xe = pc_to_xe(pc);
+ 	struct xe_gt *gt = pc_to_gt(pc);
+-	unsigned int fw_ref;
+ 	int ret = 0;
+ 
+ 	if (xe->info.skip_guc_pc)
+@@ -1086,17 +1085,7 @@ int xe_guc_pc_gucrc_disable(struct xe_guc_pc *pc)
+ 	if (ret)
+ 		return ret;
+ 
+-	fw_ref = xe_force_wake_get(gt_to_fw(gt), XE_FORCEWAKE_ALL);
+-	if (!xe_force_wake_ref_has_domain(fw_ref, XE_FORCEWAKE_ALL)) {
+-		xe_force_wake_put(gt_to_fw(gt), fw_ref);
+-		return -ETIMEDOUT;
+-	}
+-
+-	xe_gt_idle_disable_c6(gt);
+-
+-	xe_force_wake_put(gt_to_fw(gt), fw_ref);
+-
+-	return 0;
++	return xe_gt_idle_disable_c6(gt);
+ }
+ 
+ /**
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -19,6 +19,7 @@ backport/patches/base/0001-drm-xe-Pre-allocate-system-memory-for-pinned-externa.
 backport/patches/base/0001-drm-xe-dma-buf-Allow-pinning-of-p2p-dma-buf.patch
 backport/patches/base/0001-drm-xe-Drop-preempt-fences-when-destroying-imported-.patch
 backport/patches/base/0001-drm-xe-migrate-fix-batch-buffer-sizing.patch
+backport/patches/base/0001-drm-xe-make-xe_gt_idle_disable_c6-handle-the-forcewa.patch
 # features/xe-late-bind-fw
 backport/patches/features/xe-late-bind-fw/0001-mei-bus-add-mei_cldev_mtu-interface.patch
 backport/patches/features/xe-late-bind-fw/0001-mei-late_bind-add-late-binding-component-driver.patch


### PR DESCRIPTION
Move forcewake_get() into xe_gt_idle_enable_c6() to streamline the code
and make the API easier to use by ensuring forcewake handling is done
internally.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>