### PR TITLE
backport/sriov: Move VRAM MM debugfs creation to tile level

### DIFF
--- a/backport/patches/features/sriov/0001-drm-xe-Move-VRAM-MM-debugfs-creation-to-tile-level.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Move-VRAM-MM-debugfs-creation-to-tile-level.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Piotr=20Pi=C3=B3rkowski?= <piotr.piorkowski@intel.com>
+Date: Thu, 27 Nov 2025 08:36:43 +0100
+Subject: drm/xe: Move VRAM MM debugfs creation to tile level
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Previously, VRAM TTM resource manager debugfs entries (vram0_mm / vram1_mm)
+were created globally in the XE debugfs root directory. But technically,
+each tile has an associated VRAM TTM manager, which it can own.
+Let's create VRAM memory manager debugfs entries directly under each tile's
+debugfs directory for better alignment with the per-tile memory layout.
+
+Signed-off-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Reviewed-by: Stuart Summers <stuart.summers@intel.com>
+Link: https://patch.msgid.link/20251127073643.144379-1-piotr.piorkowski@intel.com
+Signed-off-by: Michał Winiarski <michal.winiarski@intel.com>
+(cherry-picked from commit 8e2610d9a5edefb99b1a708796a8f733358e5898 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_debugfs.c      | 12 ------------
+ drivers/gpu/drm/xe/xe_tile_debugfs.c |  9 +++++++++
+ 2 files changed, 9 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_debugfs.c b/drivers/gpu/drm/xe/xe_debugfs.c
+index 333378204..ceadef0b3 100644
+--- a/drivers/gpu/drm/xe/xe_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_debugfs.c
+@@ -376,7 +376,6 @@ void xe_debugfs_register(struct xe_device *xe)
+ 	struct ttm_resource_manager *man;
+ 	struct xe_tile *tile;
+ 	struct xe_gt *gt;
+-	u32 mem_type;
+ 	u8 tile_id;
+ 	u8 id;
+ 
+@@ -404,17 +403,6 @@ void xe_debugfs_register(struct xe_device *xe)
+ 	debugfs_create_file("disable_late_binding", 0600, root, xe,
+ 			    &disable_late_binding_fops);
+ 
+-	for (mem_type = XE_PL_VRAM0; mem_type <= XE_PL_VRAM1; ++mem_type) {
+-		man = ttm_manager_type(bdev, mem_type);
+-
+-		if (man) {
+-			char name[16];
+-
+-			snprintf(name, sizeof(name), "vram%d_mm", mem_type - XE_PL_VRAM0);
+-			ttm_resource_manager_create_debugfs(man, root, name);
+-		}
+-	}
+-
+ 	man = ttm_manager_type(bdev, XE_PL_TT);
+ 	ttm_resource_manager_create_debugfs(man, root, "gtt_mm");
+ 
+diff --git a/drivers/gpu/drm/xe/xe_tile_debugfs.c b/drivers/gpu/drm/xe/xe_tile_debugfs.c
+index fff242a5a..b4a192953 100644
+--- a/drivers/gpu/drm/xe/xe_tile_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_tile_debugfs.c
+@@ -110,6 +110,13 @@ static const struct drm_info_list vf_safe_debugfs_list[] = {
+ 	{ "sa_info", .show = xe_tile_debugfs_show_with_rpm, .data = sa_info },
+ };
+ 
++static void tile_debugfs_create_vram_mm(struct xe_tile *tile)
++{
++	if (tile->mem.vram)
++		ttm_resource_manager_create_debugfs(&tile->mem.vram->ttm.manager, tile->debugfs,
++						    "vram_mm");
++}
++
+ /**
+  * xe_tile_debugfs_register - Register tile's debugfs attributes
+  * @tile: the &xe_tile to register
+@@ -139,4 +146,6 @@ void xe_tile_debugfs_register(struct xe_tile *tile)
+ 	drm_debugfs_create_files(vf_safe_debugfs_list,
+ 				 ARRAY_SIZE(vf_safe_debugfs_list),
+ 				 tile->debugfs, minor);
++
++	tile_debugfs_create_vram_mm(tile);
+ }
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -250,6 +250,7 @@ backport/patches/features/sriov/0001-drm-xe-vf-Start-re-emission-from-first-unsi
 backport/patches/features/sriov/0001-drm-xe-vf-Stop-waiting-for-ring-space-on-VF-post-mig.patch
 backport/patches/features/sriov/0001-drm-xe-Do-not-reference-loop-variable-directly.patch
 backport/patches/features/sriov/0001-drm-xe-pf-Allow-to-lockdown-the-PF-using-custom-guar.patch
+backport/patches/features/sriov/0001-drm-xe-Move-VRAM-MM-debugfs-creation-to-tile-level.patch
 # features/vf-double-migration
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Enable-VF-migration-only-on-supported-GuC-.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch


### PR DESCRIPTION
VRAM TTM debugfs entries (vram0_mm, vram1_mm) were created at the global
XE debugfs level. Since VRAM memory managers are per tile, create these
entries under each tile’s debugfs directory instead.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>