### PR TITLE
backport: fix migrate job lock assert for bind queue

### DIFF
--- a/backport/patches/features/sriov/0001-drm-xe-migrate-fix-job-lock-assert.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-migrate-fix-job-lock-assert.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Auld <matthew.auld@intel.com>
+Date: Tue, 20 Jan 2026 11:06:11 +0000
+Subject: drm/xe/migrate: fix job lock assert
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We are meant to be checking the user vm for the bind queue, but actually
+we are checking the migrate vm. For various reasons this is not
+currently firing but this will likely change in the future.
+
+Now that we have the user_vm attached to the bind queue, we can fix this
+by directly checking that here.
+
+Fixes: dba89840a920 ("drm/xe: Add GT TLB invalidation jobs")
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Cc: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Arvind Yadav <arvind.yadav@intel.com>
+Link: https://patch.msgid.link/20260120110609.77958-4-matthew.auld@intel.com
+(cherry-picked from commit 9dd1048bca4fe2aa67c7a286bafb3947537adedb linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_migrate.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
+index 82a0d8a71..0781ab28f 100644
+--- a/drivers/gpu/drm/xe/xe_migrate.c
++++ b/drivers/gpu/drm/xe/xe_migrate.c
+@@ -2259,7 +2259,7 @@ void xe_migrate_job_lock(struct xe_migrate *m, struct xe_exec_queue *q)
+ 	if (is_migrate)
+ 		mutex_lock(&m->job_mutex);
+ 	else
+-		xe_vm_assert_held(q->vm);	/* User queues VM's should be locked */
++		xe_vm_assert_held(q->user_vm);	/* User queues VM's should be locked */
+ }
+ 
+ /**
+@@ -2277,7 +2277,7 @@ void xe_migrate_job_unlock(struct xe_migrate *m, struct xe_exec_queue *q)
+ 	if (is_migrate)
+ 		mutex_unlock(&m->job_mutex);
+ 	else
+-		xe_vm_assert_held(q->vm);	/* User queues VM's should be locked */
++		xe_vm_assert_held(q->user_vm);	/* User queues VM's should be locked */
+ }
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_KUNIT_TEST)
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-uapi-disallow-bind-queue-sharing.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-uapi-disallow-bind-queue-sharing.patch
@@ -1,0 +1,219 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Auld <matthew.auld@intel.com>
+Date: Tue, 20 Jan 2026 11:06:10 +0000
+Subject: drm/xe/uapi: disallow bind queue sharing
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently this is very broken if someone attempts to create a bind
+queue and share it across multiple VMs. For example currently we assume
+it is safe to acquire the user VM lock to protect some of the bind queue
+state, but if allow sharing the bind queue with multiple VMs then this
+quickly breaks down.
+
+To fix this reject using a bind queue with any VM that is not the same
+VM that was originally passed when creating the bind queue. This a uAPI
+change, however this was more of an oversight on kernel side that we
+didn't reject this, and expectation is that userspace shouldn't be using
+bind queues in this way, so in theory this change should go unnoticed.
+
+Based on a patch from Matt Brost.
+
+v2 (Matt B):
+  - Hold the vm lock over queue create, to ensure it can't be closed as
+    we attach the user_vm to the queue.
+  - Make sure we actually check for NULL user_vm in destruction path.
+v3:
+  - Fix error path handling.
+
+Fixes: dd08ebf6c352 ("drm/xe: Introduce a new DRM driver for Intel GPUs")
+Reported-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Cc: José Roberto de Souza <jose.souza@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Michal Mrozek <michal.mrozek@intel.com>
+Cc: Carl Zhang <carl.zhang@intel.com>
+Cc: <stable@vger.kernel.org> # v6.8+
+Acked-by: José Roberto de Souza <jose.souza@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Arvind Yadav <arvind.yadav@intel.com>
+Acked-by: Michal Mrozek <michal.mrozek@intel.com>
+Link: https://patch.msgid.link/20260120110609.77958-3-matthew.auld@intel.com
+(cherry-picked from commit 9dd08fdecc0c98d6516c2d2d1fa189c1332f8dab linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_exec_queue.c       | 35 +++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_exec_queue.h       |  1 +
+ drivers/gpu/drm/xe/xe_exec_queue_types.h |  6 ++++
+ drivers/gpu/drm/xe/xe_sriov_vf_ccs.c     |  2 +-
+ drivers/gpu/drm/xe/xe_vm.c               |  7 ++++-
+ 5 files changed, 48 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index 27d0bade8..17ccab961 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -308,6 +308,7 @@ struct xe_exec_queue *xe_exec_queue_create_class(struct xe_device *xe, struct xe
+  * @xe: Xe device.
+  * @tile: tile which bind exec queue belongs to.
+  * @flags: exec queue creation flags
++ * @user_vm: The user VM which this exec queue belongs to
+  * @extensions: exec queue creation extensions
+  *
+  * Normalize bind exec queue creation. Bind exec queue is tied to migration VM
+@@ -321,6 +322,7 @@ struct xe_exec_queue *xe_exec_queue_create_class(struct xe_device *xe, struct xe
+  */
+ struct xe_exec_queue *xe_exec_queue_create_bind(struct xe_device *xe,
+ 						struct xe_tile *tile,
++						struct xe_vm *user_vm,
+ 						u32 flags, u64 extensions)
+ {
+ 	struct xe_gt *gt = tile->primary_gt;
+@@ -349,6 +351,11 @@ struct xe_exec_queue *xe_exec_queue_create_bind(struct xe_device *xe,
+ 	}
+ 	xe_vm_put(migrate_vm);
+ 
++	if (!IS_ERR(q)) {
++		if (user_vm)
++			q->user_vm = xe_vm_get(user_vm);
++	}
++
+ 	return q;
+ }
+ ALLOW_ERROR_INJECTION(xe_exec_queue_create_bind, ERRNO);
+@@ -368,6 +375,11 @@ void xe_exec_queue_destroy(struct kref *ref)
+ 			xe_exec_queue_put(eq);
+ 	}
+ 
++	if (q->user_vm) {
++                xe_vm_put(q->user_vm);
++                q->user_vm = NULL;
++        }
++
+ 	q->ops->destroy(q);
+ }
+ 
+@@ -492,6 +504,7 @@ xe_exec_queue_get_prop_minmax(struct xe_hw_engine_class_intf *eclass,
+ 		default:
+ 			break;
+ 		}
++
+ 	}
+ #endif
+ }
+@@ -744,6 +757,22 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
+ 		    XE_IOCTL_DBG(xe, eci[0].engine_instance != 0))
+ 			return -EINVAL;
+ 
++		vm = xe_vm_lookup(xef, args->vm_id);
++		if (XE_IOCTL_DBG(xe, !vm))
++			return -ENOENT;
++
++		err = down_read_interruptible(&vm->lock);
++		if (err) {
++			xe_vm_put(vm);
++			return err;
++		}
++
++		if (XE_IOCTL_DBG(xe, xe_vm_is_closed_or_banned(vm))) {
++			up_read(&vm->lock);
++			xe_vm_put(vm);
++			return -ENOENT;
++		}
++
+ 		for_each_tile(tile, xe, id) {
+ 			struct xe_exec_queue *new;
+ 
+@@ -751,9 +780,11 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
+ 			if (id)
+ 				flags |= EXEC_QUEUE_FLAG_BIND_ENGINE_CHILD;
+ 
+-			new = xe_exec_queue_create_bind(xe, tile, flags,
++			new = xe_exec_queue_create_bind(xe, tile, vm, flags,
+ 							args->extensions);
+ 			if (IS_ERR(new)) {
++				up_read(&vm->lock);
++				xe_vm_put(vm);
+ 				err = PTR_ERR(new);
+ 				if (q)
+ 					goto put_exec_queue;
+@@ -765,6 +796,8 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
+ 				list_add_tail(&new->multi_gt_list,
+ 					      &q->multi_gt_link);
+ 		}
++		up_read(&vm->lock);
++		xe_vm_put(vm);
+ 	} else {
+ 		logical_mask = calc_validate_logical_mask(xe, eci,
+ 							  args->width,
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.h b/drivers/gpu/drm/xe/xe_exec_queue.h
+index 9aa6a9e80..8d49a5f30 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue.h
+@@ -24,6 +24,7 @@ struct xe_exec_queue *xe_exec_queue_create_class(struct xe_device *xe, struct xe
+ 						 u32 flags, u64 extensions);
+ struct xe_exec_queue *xe_exec_queue_create_bind(struct xe_device *xe,
+ 						struct xe_tile *tile,
++						struct xe_vm *user_vm,
+ 						u32 flags, u64 extensions);
+ 
+ void xe_exec_queue_fini(struct xe_exec_queue *q);
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue_types.h b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+index a509520c6..c016dd610 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue_types.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+@@ -53,6 +53,12 @@ struct xe_exec_queue {
+ 	struct kref refcount;
+ 	/** @vm: VM (address space) for this exec queue */
+ 	struct xe_vm *vm;
++	/**
++	 * @user_vm: User VM (address space) for this exec queue (bind queues
++	 * only)
++	 */
++	struct xe_vm *user_vm;
++
+ 	/** @class: class of this exec queue */
+ 	enum xe_engine_class class;
+ 	/**
+diff --git a/drivers/gpu/drm/xe/xe_sriov_vf_ccs.c b/drivers/gpu/drm/xe/xe_sriov_vf_ccs.c
+index 797a4b866..d963231b5 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_vf_ccs.c
++++ b/drivers/gpu/drm/xe/xe_sriov_vf_ccs.c
+@@ -346,7 +346,7 @@ int xe_sriov_vf_ccs_init(struct xe_device *xe)
+ 		flags = EXEC_QUEUE_FLAG_KERNEL |
+ 			EXEC_QUEUE_FLAG_PERMANENT |
+ 			EXEC_QUEUE_FLAG_MIGRATE;
+-		q = xe_exec_queue_create_bind(xe, tile, flags, 0);
++		q = xe_exec_queue_create_bind(xe, tile, NULL, flags, 0);
+ 		if (IS_ERR(q)) {
+ 			err = PTR_ERR(q);
+ 			goto err_ret;
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 36fa9f5bc..48fcb4fe9 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -1900,7 +1900,7 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
+ 			if (!vm->pt_root[id])
+ 				continue;
+ 
+-			q = xe_exec_queue_create_bind(xe, tile, create_flags, 0);
++			q = xe_exec_queue_create_bind(xe, tile, vm, create_flags, 0);
+ 			if (IS_ERR(q)) {
+ 				err = PTR_ERR(q);
+ 				goto err_close;
+@@ -3782,6 +3782,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		}
+ 	}
+ 
++	if (XE_IOCTL_DBG(xe, q && vm != q->user_vm)) {
++		err = -EINVAL;
++		goto put_exec_queue;
++	}
++
+ 	/* Ensure all UNMAPs visible */
+ 	xe_svm_flush(vm);
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -251,6 +251,8 @@ backport/patches/features/sriov/0001-drm-xe-vf-Stop-waiting-for-ring-space-on-VF
 backport/patches/features/sriov/0001-drm-xe-Do-not-reference-loop-variable-directly.patch
 backport/patches/features/sriov/0001-drm-xe-pf-Allow-to-lockdown-the-PF-using-custom-guar.patch
 backport/patches/features/sriov/0001-drm-xe-Move-VRAM-MM-debugfs-creation-to-tile-level.patch
+backport/patches/features/sriov/0001-drm-xe-migrate-fix-job-lock-assert.patch
+backport/patches/features/sriov/0001-drm-xe-uapi-disallow-bind-queue-sharing.patch
 # features/vf-double-migration
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Enable-VF-migration-only-on-supported-GuC-.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch


### PR DESCRIPTION
The xe_migrate_job_lock() function incorrectly asserts that the
migration vm's reservation lock is held during bind queue operations.
However, only the user vm is locked via drm_exec_lock_obj() during
vm_bind, the migration vm lock is never acquired.

This mismatch causes assertion warnings when TLB invalidation jobs
are pushed, even though the actual locking is correct.

Fix by checking the user vm lock instead of the migrate vm lock,
since the bind queue now has user_vm attached and that's the vm
whose lock is actually held during these operations.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>