### PR TITLE
gitignore: Exclude autotools and build-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+Makefile.in
+aclocal.m4
+autom4te.cache/
+configure
+compile
+install-sh
+missing
+src/.config*
+src/.kernel_config_md5
+src/Kconfig.kernel
+src/Kconfig.versions
+src/backport-include/backport/autoconf.h
+src/backport-include/backport/automacro.h
+src/backport-include/backport/*.in


### PR DESCRIPTION
Ignore autotools artifacts and kernel configuration files that are
generated during the gentree and build process to prevent them from
being included in pull requests to releases/main.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>