### PR TITLE
drm/xe: Avoid serialization during unbind bursts

### DIFF
--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-UFENCE-events-with-acks.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-UFENCE-events-with-acks.patch
@@ -31,14 +31,14 @@ Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
  drivers/gpu/drm/xe/xe_exec.c          |   2 +-
  drivers/gpu/drm/xe/xe_oa.c            |   3 +-
  drivers/gpu/drm/xe/xe_sync.c          |  46 +++--
- drivers/gpu/drm/xe/xe_sync.h          |   8 +-
+ drivers/gpu/drm/xe/xe_sync.h          |   3 +
  drivers/gpu/drm/xe/xe_sync_types.h    |  28 ++-
  drivers/gpu/drm/xe/xe_vm.c            |   4 +-
  include/uapi/drm/xe_drm_eudebug.h     |  13 ++
- 10 files changed, 386 insertions(+), 30 deletions(-)
+ 10 files changed, 382 insertions(+), 29 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
-index 2ae819a21a68..42343cd00861 100644
+index b9fe9ae85..2a7d4433c 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.c
 +++ b/drivers/gpu/drm/xe/xe_eudebug.c
 @@ -32,6 +32,7 @@
@@ -410,7 +410,7 @@ index 2ae819a21a68..42343cd00861 100644
 +	ufence->eudebug.debugger = NULL;
 +}
 diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
-index 9e5d012474df..a26d01451e95 100644
+index 9e5d01247..a26d01451 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.h
 +++ b/drivers/gpu/drm/xe/xe_eudebug.h
 @@ -16,6 +16,7 @@ struct xe_vm;
@@ -451,7 +451,7 @@ index 9e5d012474df..a26d01451e95 100644
  
  #endif /* _XE_EUDEBUG_H_ */
 diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
-index d9c9ec73df42..d3098311dfd8 100644
+index d9c9ec73d..d3098311d 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug_types.h
 +++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
 @@ -151,6 +151,14 @@ struct xe_eudebug {
@@ -480,40 +480,40 @@ index d9c9ec73df42..d3098311dfd8 100644
 +
  #endif /* _XE_EUDEBUG_TYPES_H_ */
 diff --git a/drivers/gpu/drm/xe/xe_exec.c b/drivers/gpu/drm/xe/xe_exec.c
-index 44364c042ad7..d638bd13d17c 100644
+index de83e8b18..efad60f07 100644
 --- a/drivers/gpu/drm/xe/xe_exec.c
 +++ b/drivers/gpu/drm/xe/xe_exec.c
-@@ -159,7 +159,7 @@ int xe_exec_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -163,7 +163,7 @@ int xe_exec_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  	vm = q->vm;
  
  	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
 -		err = xe_sync_entry_parse(xe, xef, &syncs[num_syncs],
 +		err = xe_sync_entry_parse(xe, xef, vm, &syncs[num_syncs],
- 					  &syncs_user[num_syncs], SYNC_PARSE_FLAG_EXEC |
+ 					  &syncs_user[num_syncs], NULL, 0,
+ 					  SYNC_PARSE_FLAG_EXEC |
  					  (xe_vm_in_lr_mode(vm) ?
- 					   SYNC_PARSE_FLAG_LR_MODE : 0));
 diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
-index 5729e7d3e335..4474518eab3e 100644
+index 80fbde8ac..1af98f4de 100644
 --- a/drivers/gpu/drm/xe/xe_oa.c
 +++ b/drivers/gpu/drm/xe/xe_oa.c
-@@ -1408,7 +1408,8 @@ static int xe_oa_parse_syncs(struct xe_oa *oa, struct xe_oa_open_param *param)
+@@ -1411,7 +1411,8 @@ static int xe_oa_parse_syncs(struct xe_oa *oa,
  	}
  
  	for (num_syncs = 0; num_syncs < param->num_syncs; num_syncs++) {
 -		ret = xe_sync_entry_parse(oa->xe, param->xef, &param->syncs[num_syncs],
-+		ret = xe_sync_entry_parse(oa->xe, param->xef, NULL,
++		ret = xe_sync_entry_parse(oa->xe, param->xef, stream->exec_q->vm,
 +					  &param->syncs[num_syncs],
- 					  &param->syncs_user[num_syncs], 0);
- 		if (ret)
- 			goto err_syncs;
+ 					  &param->syncs_user[num_syncs],
+ 					  stream->ufence_syncobj,
+ 					  ++stream->ufence_timeline_value, 0);
 diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
-index 82872a51f098..f11ad6367d85 100644
+index ff74528ca..400eaf3fe 100644
 --- a/drivers/gpu/drm/xe/xe_sync.c
 +++ b/drivers/gpu/drm/xe/xe_sync.c
 @@ -15,27 +15,20 @@
  #include <uapi/drm/xe_drm.h>
  
- #include "xe_device_types.h"
+ #include "xe_device.h"
 +#include "xe_eudebug.h"
  #include "xe_exec_queue.h"
  #include "xe_macros.h"
@@ -605,11 +605,11 @@ index 82872a51f098..f11ad6367d85 100644
 +			struct xe_vm *vm,
  			struct xe_sync_entry *sync,
  			struct drm_xe_sync __user *sync_user,
- 			unsigned int flags)
-@@ -192,7 +205,8 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
- 		if (exec) {
+ 			struct drm_syncobj *ufence_syncobj,
+@@ -195,7 +208,8 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
  			sync->addr = sync_in.addr;
  		} else {
+ 			sync->ufence_timeline_value = ufence_timeline_value;
 -			sync->ufence = user_fence_create(xe, sync_in.addr,
 +			sync->ufence = user_fence_create(xe, xef, vm,
 +							 sync_in.addr,
@@ -617,32 +617,26 @@ index 82872a51f098..f11ad6367d85 100644
  			if (XE_IOCTL_DBG(xe, IS_ERR(sync->ufence)))
  				return PTR_ERR(sync->ufence);
 diff --git a/drivers/gpu/drm/xe/xe_sync.h b/drivers/gpu/drm/xe/xe_sync.h
-index 256ffc1e54dc..f5bec2b1b4f6 100644
+index 51f2d803e..e17273483 100644
 --- a/drivers/gpu/drm/xe/xe_sync.h
 +++ b/drivers/gpu/drm/xe/xe_sync.h
-@@ -9,8 +9,12 @@
+@@ -9,6 +9,7 @@
  #include "xe_sync_types.h"
  
- struct xe_device;
--struct xe_exec_queue;
- struct xe_file;
-+struct xe_exec_queue;
-+struct drm_syncobj;
-+struct dma_fence;
-+struct dma_fence_chain;
+ struct drm_syncobj;
 +struct drm_xe_sync;
- struct xe_sched_job;
- struct xe_vm;
- 
-@@ -19,6 +23,7 @@ struct xe_vm;
+ struct xe_device;
+ struct xe_exec_queue;
+ struct xe_file;
+@@ -20,6 +21,7 @@ struct xe_vm;
  #define SYNC_PARSE_FLAG_DISALLOW_USER_FENCE	BIT(2)
  
  int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
 +			struct xe_vm *vm,
  			struct xe_sync_entry *sync,
  			struct drm_xe_sync __user *sync_user,
- 			unsigned int flags);
-@@ -40,5 +45,6 @@ struct xe_user_fence *__xe_sync_ufence_get(struct xe_user_fence *ufence);
+ 			struct drm_syncobj *ufence_syncobj,
+@@ -43,5 +45,6 @@ struct xe_user_fence *__xe_sync_ufence_get(struct xe_user_fence *ufence);
  struct xe_user_fence *xe_sync_ufence_get(struct xe_sync_entry *sync);
  void xe_sync_ufence_put(struct xe_user_fence *ufence);
  int xe_sync_ufence_get_status(struct xe_user_fence *ufence);
@@ -650,7 +644,7 @@ index 256ffc1e54dc..f5bec2b1b4f6 100644
  
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_sync_types.h b/drivers/gpu/drm/xe/xe_sync_types.h
-index 30ac3f51993b..dcd3165e66a7 100644
+index b88f1833e..33a93a0fa 100644
 --- a/drivers/gpu/drm/xe/xe_sync_types.h
 +++ b/drivers/gpu/drm/xe/xe_sync_types.h
 @@ -6,13 +6,31 @@
@@ -691,10 +685,10 @@ index 30ac3f51993b..dcd3165e66a7 100644
  struct xe_sync_entry {
  	struct drm_syncobj *syncobj;
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index 1f6f9a78c554..f5d2a9f32cbd 100644
+index 5ca131f11..e51b6bc08 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
-@@ -3644,9 +3644,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3792,11 +3792,13 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		}
  	}
  
@@ -702,13 +696,15 @@ index 1f6f9a78c554..f5d2a9f32cbd 100644
 +
  	syncs_user = u64_to_user_ptr(args->syncs);
  	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
+ 		struct xe_exec_queue *__q = q ?: vm->q[0];
+ 
 -		err = xe_sync_entry_parse(xe, xef, &syncs[num_syncs],
 +		err = xe_sync_entry_parse(xe, xef, vm, &syncs[num_syncs],
  					  &syncs_user[num_syncs],
- 					  (xe_vm_in_lr_mode(vm) ?
- 					   SYNC_PARSE_FLAG_LR_MODE : 0) |
+ 					  __q->ufence_syncobj,
+ 					  ++__q->ufence_timeline_value,
 diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
-index cacad4ccfca5..821d9dac4f16 100644
+index cacad4ccf..821d9dac4 100644
 --- a/include/uapi/drm/xe_drm_eudebug.h
 +++ b/include/uapi/drm/xe_drm_eudebug.h
 @@ -17,6 +17,7 @@ extern "C" {

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-vm-bind-and-vm-bind-ops.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Add-vm-bind-and-vm-bind-ops.patch
@@ -27,7 +27,7 @@ Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
  6 files changed, 448 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/xe_eudebug.c
-index 5656b1585c8f..2ae819a21a68 100644
+index 25ab6d8ec..b9fe9ae85 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.c
 +++ b/drivers/gpu/drm/xe/xe_eudebug.c
 @@ -804,7 +804,7 @@ static struct xe_eudebug_event *
@@ -369,7 +369,7 @@ index 5656b1585c8f..2ae819a21a68 100644
  {
  	struct xe_exec_queue *q;
 diff --git a/drivers/gpu/drm/xe/xe_eudebug.h b/drivers/gpu/drm/xe/xe_eudebug.h
-index 98352a56f630..9e5d012474df 100644
+index 98352a56f..9e5d01247 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.h
 +++ b/drivers/gpu/drm/xe/xe_eudebug.h
 @@ -6,11 +6,14 @@
@@ -412,7 +412,7 @@ index 98352a56f630..9e5d012474df 100644
  
  #endif /* _XE_EUDEBUG_H_ */
 diff --git a/drivers/gpu/drm/xe/xe_eudebug_types.h b/drivers/gpu/drm/xe/xe_eudebug_types.h
-index 08a751b337e6..d9c9ec73df42 100644
+index 08a751b33..d9c9ec73d 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug_types.h
 +++ b/drivers/gpu/drm/xe/xe_eudebug_types.h
 @@ -178,6 +178,11 @@ struct xe_eudebug_event {
@@ -457,10 +457,10 @@ index 08a751b337e6..d9c9ec73df42 100644
 +
  #endif /* _XE_EUDEBUG_TYPES_H_ */
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index e1f15d8421cf..1f6f9a78c554 100644
+index 8cfaadc14..5ca131f11 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
-@@ -1704,6 +1704,8 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
+@@ -1792,6 +1792,8 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
  	for_each_tile(tile, xe, id)
  		xe_range_fence_tree_init(&vm->rftree[id]);
  
@@ -469,7 +469,7 @@ index e1f15d8421cf..1f6f9a78c554 100644
  	vm->pt_ops = &xelp_pt_ops;
  
  	/*
-@@ -1999,6 +2001,8 @@ static void vm_destroy_work_func(struct work_struct *w)
+@@ -2105,6 +2107,8 @@ static void vm_destroy_work_func(struct work_struct *w)
  	struct xe_tile *tile;
  	u8 id;
  
@@ -478,16 +478,16 @@ index e1f15d8421cf..1f6f9a78c554 100644
  	/* xe_vm_close_and_put was not called? */
  	xe_assert(xe, !vm->size);
  
-@@ -3229,7 +3233,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -3371,7 +3375,7 @@ static void op_add_ufence(struct xe_vm *vm, struct xe_vma_op *op,
+ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
  				   struct dma_fence *fence)
  {
- 	struct xe_exec_queue *wait_exec_queue = to_wait_exec_queue(vm, vops->q);
 -	struct xe_user_fence *ufence;
 +	struct xe_user_fence *ufence = NULL;
  	struct xe_vma_op *op;
  	int i;
  
-@@ -3244,6 +3248,9 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -3386,6 +3390,9 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
  			xe_vma_destroy(gpuva_to_vma(op->base.remap.unmap->va),
  				       fence);
  	}
@@ -497,7 +497,7 @@ index e1f15d8421cf..1f6f9a78c554 100644
  	if (ufence)
  		xe_sync_ufence_put(ufence);
  	if (fence) {
-@@ -3685,6 +3692,8 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3839,6 +3846,8 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		if (err)
  			goto unwind_ops;
  
@@ -506,7 +506,7 @@ index e1f15d8421cf..1f6f9a78c554 100644
  #ifdef TEST_VM_OPS_ERROR
  		if (flags & FORCE_OP_ERROR) {
  			vops.inject_error = true;
-@@ -3716,8 +3725,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3870,8 +3879,11 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		dma_fence_put(fence);
  
  unwind_ops:
@@ -520,10 +520,10 @@ index e1f15d8421cf..1f6f9a78c554 100644
  	for (i = args->num_binds - 1; i >= 0; --i)
  		if (ops[i])
 diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
-index 8a07feef503b..cc53ea5de669 100644
+index 3a4a15bce..49466bbdc 100644
 --- a/drivers/gpu/drm/xe/xe_vm_types.h
 +++ b/drivers/gpu/drm/xe/xe_vm_types.h
-@@ -329,6 +329,19 @@ struct xe_vm {
+@@ -345,6 +345,19 @@ struct xe_vm {
  	bool batch_invalidate_tlb;
  	/** @xef: XE file handle for tracking this VM's drm client */
  	struct xe_file *xef;
@@ -544,7 +544,7 @@ index 8a07feef503b..cc53ea5de669 100644
  
  /** struct xe_vma_op_map - VMA map operation */
 diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
-index 4165318f3722..cacad4ccfca5 100644
+index 4165318f3..cacad4ccf 100644
 --- a/include/uapi/drm/xe_drm_eudebug.h
 +++ b/include/uapi/drm/xe_drm_eudebug.h
 @@ -29,6 +29,8 @@ struct drm_xe_eudebug_event {

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
@@ -2100,10 +2100,10 @@ index 02c9c7fbc..78f607b3d 100644
  		/** @client_link: list entry in xe_device.clients.list */
  		struct list_head client_link;
 diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
-index c31e04f45..27d0bade8 100644
+index d22fbb196..8b472ff65 100644
 --- a/drivers/gpu/drm/xe/xe_exec_queue.c
 +++ b/drivers/gpu/drm/xe/xe_exec_queue.c
-@@ -28,7 +28,7 @@
+@@ -29,7 +29,7 @@
  #include "xe_trace.h"
  #include "xe_vm.h"
  #include "xe_pxp.h"
@@ -2112,7 +2112,7 @@ index c31e04f45..27d0bade8 100644
  
  enum xe_exec_queue_sched_prop {
  	XE_EXEC_QUEUE_JOB_TIMEOUT = 0,
-@@ -531,7 +531,7 @@ exec_queue_set_pxp_type(struct xe_device *xe, struct xe_exec_queue *q, u64 value
+@@ -559,7 +559,7 @@ exec_queue_set_pxp_type(struct xe_device *xe, struct xe_exec_queue *q, u64 value
  static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
  				  u64 value)
  {
@@ -2121,7 +2121,7 @@ index c31e04f45..27d0bade8 100644
  
  	if (XE_IOCTL_DBG(xe, (q->class != XE_ENGINE_CLASS_RENDER &&
  			      q->class != XE_ENGINE_CLASS_COMPUTE)))
-@@ -540,7 +540,7 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
+@@ -568,7 +568,7 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
  	if (XE_IOCTL_DBG(xe, (value & ~known_flags)))
  		return -EINVAL;
  
@@ -2130,7 +2130,7 @@ index c31e04f45..27d0bade8 100644
  		return -EOPNOTSUPP;
  
  	if (XE_IOCTL_DBG(xe, !xe_exec_queue_is_lr(q)))
-@@ -550,10 +550,10 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
+@@ -578,10 +578,10 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
  	 * property is set.
  	 */
  	if (XE_IOCTL_DBG(xe,
@@ -2143,7 +2143,7 @@ index c31e04f45..27d0bade8 100644
  		return -EPERM;
  
  	q->eudebug_flags = EXEC_QUEUE_EUDEBUG_FLAG_ENABLE;
-@@ -575,7 +575,7 @@ static const xe_exec_queue_set_property_fn exec_queue_set_property_funcs[] = {
+@@ -603,7 +603,7 @@ static const xe_exec_queue_set_property_fn exec_queue_set_property_funcs[] = {
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY] = exec_queue_set_priority,
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE] = exec_queue_set_timeslice,
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_PXP_TYPE] = exec_queue_set_pxp_type,
@@ -2152,7 +2152,7 @@ index c31e04f45..27d0bade8 100644
  };
  
  static int exec_queue_user_ext_set_property(struct xe_device *xe,
-@@ -597,7 +597,7 @@ static int exec_queue_user_ext_set_property(struct xe_device *xe,
+@@ -625,7 +625,7 @@ static int exec_queue_user_ext_set_property(struct xe_device *xe,
  	    XE_IOCTL_DBG(xe, ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY &&
  			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE &&
  			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_PXP_TYPE &&
@@ -2161,7 +2161,7 @@ index c31e04f45..27d0bade8 100644
  		return -EINVAL;
  
  	idx = array_index_nospec(ext.property, ARRAY_SIZE(exec_queue_set_property_funcs));
-@@ -824,7 +824,7 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
+@@ -872,7 +872,7 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
  
  	args->exec_queue_id = id;
  
@@ -2170,7 +2170,7 @@ index c31e04f45..27d0bade8 100644
  
  	return 0;
  
-@@ -1011,7 +1011,7 @@ int xe_exec_queue_destroy_ioctl(struct drm_device *dev, void *data,
+@@ -1059,7 +1059,7 @@ int xe_exec_queue_destroy_ioctl(struct drm_device *dev, void *data,
  	if (q->vm && q->hwe->hw_engine_group)
  		xe_hw_engine_group_del_exec_queue(q->hwe->hw_engine_group, q);
  
@@ -2180,7 +2180,7 @@ index c31e04f45..27d0bade8 100644
  	xe_exec_queue_kill(q);
  
 diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
-index 91942a69c..3b18e7398 100644
+index bb4266593..694cce984 100644
 --- a/drivers/gpu/drm/xe/xe_gt.c
 +++ b/drivers/gpu/drm/xe/xe_gt.c
 @@ -22,7 +22,7 @@
@@ -2192,7 +2192,7 @@ index 91942a69c..3b18e7398 100644
  #include "xe_eu_stall.h"
  #include "xe_exec_queue.h"
  #include "xe_execlist.h"
-@@ -769,7 +769,7 @@ static int do_gt_reset(struct xe_gt *gt)
+@@ -762,7 +762,7 @@ static int do_gt_reset(struct xe_gt *gt)
  
  	xe_gsc_wa_14015076503(gt, true);
  
@@ -2262,13 +2262,13 @@ index cb400c051..123a7000e 100644
  #include "xe_force_wake.h"
  #include "xe_gsc.h"
 diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
-index f11ad6367..a66742586 100644
+index 04bd13be9..b58657cc7 100644
 --- a/drivers/gpu/drm/xe/xe_sync.c
 +++ b/drivers/gpu/drm/xe/xe_sync.c
 @@ -15,7 +15,7 @@
  #include <uapi/drm/xe_drm.h>
  
- #include "xe_device_types.h"
+ #include "xe_device.h"
 -#include "xe_eudebug.h"
 +#include "prelim/xe_eudebug.h"
  #include "xe_exec_queue.h"
@@ -2302,7 +2302,7 @@ index f11ad6367..a66742586 100644
  		xe_sync_ufence_signal(ufence);
  
 diff --git a/drivers/gpu/drm/xe/xe_sync_types.h b/drivers/gpu/drm/xe/xe_sync_types.h
-index dcd3165e6..63807cfe5 100644
+index 33a93a0fa..be9fc77ad 100644
 --- a/drivers/gpu/drm/xe/xe_sync_types.h
 +++ b/drivers/gpu/drm/xe/xe_sync_types.h
 @@ -21,7 +21,7 @@ struct xe_user_fence {
@@ -2315,7 +2315,7 @@ index dcd3165e6..63807cfe5 100644
  		spinlock_t lock;
  		struct xe_eudebug *debugger;
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index 692708a6f..36fa9f5bc 100644
+index 66c35c1ea..ea6916a67 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
 @@ -24,10 +24,10 @@
@@ -2331,7 +2331,7 @@ index 692708a6f..36fa9f5bc 100644
  #include "xe_exec_queue.h"
  #include "xe_gt_pagefault.h"
  #include "xe_migrate.h"
-@@ -1253,7 +1253,7 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+@@ -1255,7 +1255,7 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
  			vma->gpuva.gem.obj = &bo->ttm.base;
  	}
  
@@ -2340,7 +2340,7 @@ index 692708a6f..36fa9f5bc 100644
  	INIT_LIST_HEAD(&vma->eudebug.metadata.list);
  #endif
  	INIT_LIST_HEAD(&vma->combined_links.rebind);
-@@ -1795,7 +1795,7 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
+@@ -1797,7 +1797,7 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
  	for_each_tile(tile, xe, id)
  		xe_range_fence_tree_init(&vm->rftree[id]);
  
@@ -2349,7 +2349,7 @@ index 692708a6f..36fa9f5bc 100644
  
  	vm->pt_ops = &xelp_pt_ops;
  
-@@ -2108,7 +2108,7 @@ static void vm_destroy_work_func(struct work_struct *w)
+@@ -2112,7 +2112,7 @@ static void vm_destroy_work_func(struct work_struct *w)
  	struct xe_tile *tile;
  	u8 id;
  
@@ -2358,7 +2358,7 @@ index 692708a6f..36fa9f5bc 100644
  
  	/* xe_vm_close_and_put was not called? */
  	xe_assert(xe, !vm->size);
-@@ -2244,7 +2244,7 @@ int xe_vm_create_ioctl(struct drm_device *dev, void *data,
+@@ -2248,7 +2248,7 @@ int xe_vm_create_ioctl(struct drm_device *dev, void *data,
  
  	args->vm_id = id;
  
@@ -2367,7 +2367,7 @@ index 692708a6f..36fa9f5bc 100644
  
  	return 0;
  
-@@ -2278,7 +2278,7 @@ int xe_vm_destroy_ioctl(struct drm_device *dev, void *data,
+@@ -2282,7 +2282,7 @@ int xe_vm_destroy_ioctl(struct drm_device *dev, void *data,
  	mutex_unlock(&xef->vm.lock);
  
  	if (!err) {
@@ -2376,7 +2376,7 @@ index 692708a6f..36fa9f5bc 100644
  		xe_vm_close_and_put(vm);
  	}
  
-@@ -2482,7 +2482,7 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -2486,7 +2486,7 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_vma_ops *vops,
  			op->map.invalidate_on_bind =
  				__xe_vm_needs_clear_scratch_pages(vm, flags);
  
@@ -2385,7 +2385,7 @@ index 692708a6f..36fa9f5bc 100644
  			INIT_LIST_HEAD(&op->map.eudebug.metadata.list);
  #endif
  		} else if (__op->op == DRM_GPUVA_OP_PREFETCH) {
-@@ -3268,7 +3268,7 @@ typedef int (*xe_vm_bind_op_user_extension_fn)(struct xe_device *xe,
+@@ -3272,7 +3272,7 @@ typedef int (*xe_vm_bind_op_user_extension_fn)(struct xe_device *xe,
  					       u32 operation, u64 extension);
  
  static const xe_vm_bind_op_user_extension_fn vm_bind_op_extension_funcs[] = {
@@ -2394,7 +2394,7 @@ index 692708a6f..36fa9f5bc 100644
  };
  
  #define MAX_USER_EXTENSIONS	16
-@@ -3451,7 +3451,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -3469,7 +3469,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
  				       fence);
  	}
  
@@ -2403,7 +2403,7 @@ index 692708a6f..36fa9f5bc 100644
  
  	if (ufence)
  		xe_sync_ufence_put(ufence);
-@@ -3858,7 +3858,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3880,7 +3880,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		}
  	}
  
@@ -2412,7 +2412,7 @@ index 692708a6f..36fa9f5bc 100644
  
  	syncs_user = u64_to_user_ptr(args->syncs);
  	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
-@@ -3916,7 +3916,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3942,7 +3942,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		if (err)
  			goto unwind_ops;
  
@@ -2421,7 +2421,7 @@ index 692708a6f..36fa9f5bc 100644
  
  #ifdef TEST_VM_OPS_ERROR
  		if (flags & FORCE_OP_ERROR) {
-@@ -3950,7 +3950,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3976,7 +3976,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  
  unwind_ops:
  	if (err && err != -ENODATA) {
@@ -2431,7 +2431,7 @@ index 692708a6f..36fa9f5bc 100644
  	}
  
 diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
-index bdcb677c0..d85dbf277 100644
+index abceff3ff..6cb4ef66d 100644
 --- a/drivers/gpu/drm/xe/xe_vm_types.h
 +++ b/drivers/gpu/drm/xe/xe_vm_types.h
 @@ -78,7 +78,7 @@ struct xe_userptr {
@@ -2443,7 +2443,7 @@ index bdcb677c0..d85dbf277 100644
  struct xe_eudebug_vma_metadata {
  	struct list_head list;
  };
-@@ -365,7 +365,7 @@ struct xe_vm {
+@@ -360,7 +360,7 @@ struct xe_vm {
  	/** @xef: XE file handle for tracking this VM's drm client */
  	struct xe_file *xef;
  

--- a/backport/patches/features/sriov/0001-drm-xe-Attach-last-fence-to-TLB-invalidation-job-que.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Attach-last-fence-to-TLB-invalidation-job-que.patch
@@ -1,0 +1,302 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Fri, 31 Oct 2025 16:40:46 -0700
+Subject: drm/xe: Attach last fence to TLB invalidation job queues
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add support for attaching the last fence to TLB invalidation job queues
+to address serialization issues during bursts of unbind jobs. Ensure
+that user fence signaling for a bind job reflects both the bind job
+itself and the last fences of all related TLB invalidations. Maintain
+submission order based solely on the state of the bind and TLB
+invalidation queues.
+
+Introduce support functions for last fence attachment to TLB
+invalidation queues.
+
+v3:
+ - Fix assert in xe_exec_queue_tlb_inval_last_fence_set (CI)
+ - Ensure migrate lock held for migrate queues (Testing)
+v5:
+ - Style nits (Thomas)
+ - Rewrite commit message (Thomas)
+
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patch.msgid.link/20251031234050.3043507-3-matthew.brost@intel.com
+(backported from commit b2d7ec41f2a3ab99cf0bf0fafc20d4d10bb6b0de linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_exec_queue.c       | 103 ++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_exec_queue.h       |  21 +++++
+ drivers/gpu/drm/xe/xe_exec_queue_types.h |   5 ++
+ drivers/gpu/drm/xe/xe_migrate.c          |  14 +++
+ drivers/gpu/drm/xe/xe_migrate.h          |   8 ++
+ drivers/gpu/drm/xe/xe_vm.c               |   7 +-
+ 6 files changed, 156 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index 28380d1f7..e8ffe8a6a 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -368,6 +368,7 @@ void xe_exec_queue_destroy(struct kref *ref)
+ {
+ 	struct xe_exec_queue *q = container_of(ref, struct xe_exec_queue, refcount);
+ 	struct xe_exec_queue *eq, *next;
++	int i;
+ 
+ 	if (q->ufence_syncobj)
+ 		drm_syncobj_put(q->ufence_syncobj);
+@@ -376,6 +377,9 @@ void xe_exec_queue_destroy(struct kref *ref)
+ 		xe_pxp_exec_queue_remove(gt_to_xe(q->gt)->pxp, q);
+ 
+ 	xe_exec_queue_last_fence_put_unlocked(q);
++	for_each_tlb_inval(i)
++		xe_exec_queue_tlb_inval_last_fence_put_unlocked(q, i);
++
+ 	if (!(q->flags & EXEC_QUEUE_FLAG_BIND_ENGINE_CHILD)) {
+ 		list_for_each_entry_safe(eq, next, &q->multi_gt_list,
+ 					 multi_gt_link)
+@@ -1019,7 +1023,9 @@ int xe_exec_queue_destroy_ioctl(struct drm_device *dev, void *data,
+ static void xe_exec_queue_last_fence_lockdep_assert(struct xe_exec_queue *q,
+ 						    struct xe_vm *vm)
+ {
+-	if (q->flags & EXEC_QUEUE_FLAG_VM) {
++	if (q->flags & EXEC_QUEUE_FLAG_MIGRATE) {
++		xe_migrate_job_lock_assert(q);
++	} else if (q->flags & EXEC_QUEUE_FLAG_VM) {
+ 		lockdep_assert_held(&vm->lock);
+ 	} else {
+ 		xe_vm_assert_held(vm);
+@@ -1118,6 +1124,7 @@ void xe_exec_queue_last_fence_set(struct xe_exec_queue *q, struct xe_vm *vm,
+ 				  struct dma_fence *fence)
+ {
+ 	xe_exec_queue_last_fence_lockdep_assert(q, vm);
++	xe_assert(vm->xe, !dma_fence_is_container(fence));
+ 
+ 	xe_exec_queue_last_fence_put(q, vm);
+ 	q->last_fence = dma_fence_get(fence);
+@@ -1146,6 +1153,100 @@ int xe_exec_queue_last_fence_test_dep(struct xe_exec_queue *q, struct xe_vm *vm)
+ 	return err;
+ }
+ 
++/**
++ * xe_exec_queue_tlb_inval_last_fence_put() - Drop ref to last TLB invalidation fence
++ * @q: The exec queue
++ * @vm: The VM the engine does a bind for
++ * @type: Either primary or media GT
++ */
++void xe_exec_queue_tlb_inval_last_fence_put(struct xe_exec_queue *q,
++					    struct xe_vm *vm,
++					    unsigned int type)
++{
++	xe_exec_queue_last_fence_lockdep_assert(q, vm);
++	xe_assert(vm->xe, type == XE_EXEC_QUEUE_TLB_INVAL_MEDIA_GT ||
++		  type == XE_EXEC_QUEUE_TLB_INVAL_PRIMARY_GT);
++
++	xe_exec_queue_tlb_inval_last_fence_put_unlocked(q, type);
++}
++
++/**
++ * xe_exec_queue_tlb_inval_last_fence_put_unlocked() - Drop ref to last TLB
++ * invalidation fence unlocked
++ * @q: The exec queue
++ * @type: Either primary or media GT
++ *
++ * Only safe to be called from xe_exec_queue_destroy().
++ */
++void xe_exec_queue_tlb_inval_last_fence_put_unlocked(struct xe_exec_queue *q,
++						     unsigned int type)
++{
++	xe_assert(q->vm->xe, type == XE_EXEC_QUEUE_TLB_INVAL_MEDIA_GT ||
++		  type == XE_EXEC_QUEUE_TLB_INVAL_PRIMARY_GT);
++
++	dma_fence_put(q->tlb_inval[type].last_fence);
++	q->tlb_inval[type].last_fence = NULL;
++}
++
++/**
++ * xe_exec_queue_tlb_inval_last_fence_get() - Get last fence for TLB invalidation
++ * @q: The exec queue
++ * @vm: The VM the engine does a bind for
++ * @type: Either primary or media GT
++ *
++ * Get last fence, takes a ref
++ *
++ * Returns: last fence if not signaled, dma fence stub if signaled
++ */
++struct dma_fence *xe_exec_queue_tlb_inval_last_fence_get(struct xe_exec_queue *q,
++							 struct xe_vm *vm,
++							 unsigned int type)
++{
++	struct dma_fence *fence;
++
++	xe_exec_queue_last_fence_lockdep_assert(q, vm);
++	xe_assert(vm->xe, type == XE_EXEC_QUEUE_TLB_INVAL_MEDIA_GT ||
++		  type == XE_EXEC_QUEUE_TLB_INVAL_PRIMARY_GT);
++	xe_assert(vm->xe, q->flags & (EXEC_QUEUE_FLAG_VM |
++				      EXEC_QUEUE_FLAG_MIGRATE));
++
++	if (q->tlb_inval[type].last_fence &&
++	    test_bit(DMA_FENCE_FLAG_SIGNALED_BIT,
++		     &q->tlb_inval[type].last_fence->flags))
++		xe_exec_queue_tlb_inval_last_fence_put(q, vm, type);
++
++	fence = q->tlb_inval[type].last_fence ?: dma_fence_get_stub();
++	dma_fence_get(fence);
++	return fence;
++}
++
++/**
++ * xe_exec_queue_tlb_inval_last_fence_set() - Set last fence for TLB invalidation
++ * @q: The exec queue
++ * @vm: The VM the engine does a bind for
++ * @fence: The fence
++ * @type: Either primary or media GT
++ *
++ * Set the last fence for the tlb invalidation type on the queue. Increases
++ * reference count for fence, when closing queue
++ * xe_exec_queue_tlb_inval_last_fence_put should be called.
++ */
++void xe_exec_queue_tlb_inval_last_fence_set(struct xe_exec_queue *q,
++					    struct xe_vm *vm,
++					    struct dma_fence *fence,
++					    unsigned int type)
++{
++	xe_exec_queue_last_fence_lockdep_assert(q, vm);
++	xe_assert(vm->xe, type == XE_EXEC_QUEUE_TLB_INVAL_MEDIA_GT ||
++		  type == XE_EXEC_QUEUE_TLB_INVAL_PRIMARY_GT);
++	xe_assert(vm->xe, q->flags & (EXEC_QUEUE_FLAG_VM |
++				      EXEC_QUEUE_FLAG_MIGRATE));
++	xe_assert(vm->xe, !dma_fence_is_container(fence));
++
++	xe_exec_queue_tlb_inval_last_fence_put(q, vm, type);
++	q->tlb_inval[type].last_fence = dma_fence_get(fence);
++}
++
+ /**
+  * xe_exec_queue_contexts_hwsp_rebase - Re-compute GGTT references
+  * within all LRCs of a queue.
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.h b/drivers/gpu/drm/xe/xe_exec_queue.h
+index 9e73b7eff..6f60545a7 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue.h
+@@ -14,6 +14,10 @@ struct drm_file;
+ struct xe_device;
+ struct xe_file;
+ 
++#define for_each_tlb_inval(__i)	\
++	for (__i = XE_EXEC_QUEUE_TLB_INVAL_PRIMARY_GT; \
++	     __i <= XE_EXEC_QUEUE_TLB_INVAL_MEDIA_GT; ++__i)
++
+ struct xe_exec_queue *xe_exec_queue_create(struct xe_device *xe, struct xe_vm *vm,
+ 					   u32 logical_mask, u16 width,
+ 					   struct xe_hw_engine *hw_engine, u32 flags,
+@@ -87,6 +91,23 @@ void xe_exec_queue_last_fence_set(struct xe_exec_queue *e, struct xe_vm *vm,
+ 				  struct dma_fence *fence);
+ int xe_exec_queue_last_fence_test_dep(struct xe_exec_queue *q,
+ 				      struct xe_vm *vm);
++
++void xe_exec_queue_tlb_inval_last_fence_put(struct xe_exec_queue *q,
++					    struct xe_vm *vm,
++					    unsigned int type);
++
++void xe_exec_queue_tlb_inval_last_fence_put_unlocked(struct xe_exec_queue *q,
++						     unsigned int type);
++
++struct dma_fence *xe_exec_queue_tlb_inval_last_fence_get(struct xe_exec_queue *q,
++							 struct xe_vm *vm,
++							 unsigned int type);
++
++void xe_exec_queue_tlb_inval_last_fence_set(struct xe_exec_queue *q,
++					    struct xe_vm *vm,
++					    struct dma_fence *fence,
++					    unsigned int type);
++
+ void xe_exec_queue_update_run_ticks(struct xe_exec_queue *q);
+ 
+ int xe_exec_queue_contexts_hwsp_rebase(struct xe_exec_queue *q, void *scratch);
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue_types.h b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+index b29ce5688..5278ba30d 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue_types.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+@@ -152,6 +152,11 @@ struct xe_exec_queue {
+ 		 * dependency scheduler
+ 		 */
+ 		struct xe_dep_scheduler *dep_scheduler;
++		/**
++		 * @last_fence: last fence for tlb invalidation, protected by
++		 * vm->lock in write mode
++		 */
++		struct dma_fence *last_fence;
+ 	} tlb_inval[XE_EXEC_QUEUE_TLB_INVAL_COUNT];
+ 
+ 	/** @pxp: PXP info tracking */
+diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
+index 0781ab28f..478dd07d9 100644
+--- a/drivers/gpu/drm/xe/xe_migrate.c
++++ b/drivers/gpu/drm/xe/xe_migrate.c
+@@ -2280,6 +2280,20 @@ void xe_migrate_job_unlock(struct xe_migrate *m, struct xe_exec_queue *q)
+ 		xe_vm_assert_held(q->user_vm);	/* User queues VM's should be locked */
+ }
+ 
++#if IS_ENABLED(CONFIG_PROVE_LOCKING)
++/**
++ * xe_migrate_job_lock_assert() - Assert migrate job lock held of queue
++ * @q: Migrate queue
++ */
++void xe_migrate_job_lock_assert(struct xe_exec_queue *q)
++{
++	struct xe_migrate *m = gt_to_tile(q->gt)->migrate;
++
++	xe_gt_assert(q->gt, q == m->q);
++	lockdep_assert_held(&m->job_mutex);
++}
++#endif
++
+ #if IS_ENABLED(CONFIG_DRM_XE_KUNIT_TEST)
+ #include "tests/xe_migrate.c"
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_migrate.h b/drivers/gpu/drm/xe/xe_migrate.h
+index 6f635a398..ca9383ebb 100644
+--- a/drivers/gpu/drm/xe/xe_migrate.h
++++ b/drivers/gpu/drm/xe/xe_migrate.h
+@@ -159,6 +159,14 @@ xe_migrate_update_pgtables(struct xe_migrate *m,
+ 
+ void xe_migrate_wait(struct xe_migrate *m);
+ 
++#if IS_ENABLED(CONFIG_PROVE_LOCKING)
++void xe_migrate_job_lock_assert(struct xe_exec_queue *q);
++#else
++static inline void xe_migrate_job_lock_assert(struct xe_exec_queue *q)
++{
++}
++#endif
++
+ void xe_migrate_job_lock(struct xe_migrate *m, struct xe_exec_queue *q);
+ void xe_migrate_job_unlock(struct xe_migrate *m, struct xe_exec_queue *q);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 110af7395..e5ca720fe 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -2010,8 +2010,13 @@ void xe_vm_close_and_put(struct xe_vm *vm)
+ 
+ 	down_write(&vm->lock);
+ 	for_each_tile(tile, xe, id) {
+-		if (vm->q[id])
++		if (vm->q[id]) {
++			int i;
++
+ 			xe_exec_queue_last_fence_put(vm->q[id], vm);
++			for_each_tlb_inval(i)
++				xe_exec_queue_tlb_inval_last_fence_put(vm->q[id], vm, i);
++		}
+ 	}
+ 	up_write(&vm->lock);
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-Decouple-bind-queue-last-fence-from-TLB-inval.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Decouple-bind-queue-last-fence-from-TLB-inval.patch
@@ -1,0 +1,596 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Fri, 31 Oct 2025 16:40:47 -0700
+Subject: drm/xe: Decouple bind queue last fence from TLB invalidations
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Separate the bind queue’s last fence to apply exclusively to the bind
+job, avoiding unnecessary serialization on prior TLB invalidations.
+Preserve correct user fence signaling by merging bind and TLB
+invalidation fences later in the pipeline.
+
+v3:
+ - Fix lockdep assert for migrate queues (CI)
+ - Use individual dma fence contexts for array out fences (Testing)
+ - Don't set last fence with arrays (Testing)
+ - Move TLB invalid last fence under migrate lock (Testing)
+ - Don't set queue last for migrate queues (Testing)
+
+Link: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues/6047
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patch.msgid.link/20251031234050.3043507-4-matthew.brost@intel.com
+(backported from commit cb99e12ba8cb8a16c44e6de7927e9a1d84260f24 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pt.c            | 73 ++++++++++---------------
+ drivers/gpu/drm/xe/xe_sync.c          | 63 +++++++++++++++++-----
+ drivers/gpu/drm/xe/xe_tlb_inval_job.c | 31 ++++++++---
+ drivers/gpu/drm/xe/xe_tlb_inval_job.h |  5 +-
+ drivers/gpu/drm/xe/xe_vm.c            | 76 ++++++++++++++-------------
+ drivers/gpu/drm/xe/xe_vm_types.h      |  5 --
+ 6 files changed, 143 insertions(+), 110 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pt.c b/drivers/gpu/drm/xe/xe_pt.c
+index 7d51ac490..63c4373f4 100644
+--- a/drivers/gpu/drm/xe/xe_pt.c
++++ b/drivers/gpu/drm/xe/xe_pt.c
+@@ -3,8 +3,6 @@
+  * Copyright © 2022 Intel Corporation
+  */
+ 
+-#include <linux/dma-fence-array.h>
+-
+ #include "xe_pt.h"
+ 
+ #include "regs/xe_gtt_defs.h"
+@@ -2369,10 +2367,9 @@ xe_pt_update_ops_run(struct xe_tile *tile, struct xe_vma_ops *vops)
+ 	struct xe_vm *vm = vops->vm;
+ 	struct xe_vm_pgtable_update_ops *pt_update_ops =
+ 		&vops->pt_update_ops[tile->id];
+-	struct dma_fence *fence, *ifence, *mfence;
++	struct xe_exec_queue *q = pt_update_ops->q;
++	struct dma_fence *fence, *ifence = NULL, *mfence = NULL;
+ 	struct xe_tlb_inval_job *ijob = NULL, *mjob = NULL;
+-	struct dma_fence **fences = NULL;
+-	struct dma_fence_array *cf = NULL;
+ 	struct xe_range_fence *rfence;
+ 	struct xe_vma_op *op;
+ 	int err = 0, i;
+@@ -2402,15 +2399,14 @@ xe_pt_update_ops_run(struct xe_tile *tile, struct xe_vma_ops *vops)
+ #endif
+ 
+ 	if (pt_update_ops->needs_invalidation) {
+-		struct xe_exec_queue *q = pt_update_ops->q;
+ 		struct xe_dep_scheduler *dep_scheduler =
+ 			to_dep_scheduler(q, tile->primary_gt);
+ 
+ 		ijob = xe_tlb_inval_job_create(q, &tile->primary_gt->tlb_inval,
+-					       dep_scheduler,
++					       dep_scheduler, vm,
+ 					       pt_update_ops->start,
+ 					       pt_update_ops->last,
+-					       vm->usm.asid);
++					       XE_EXEC_QUEUE_TLB_INVAL_PRIMARY_GT);
+ 		if (IS_ERR(ijob)) {
+ 			err = PTR_ERR(ijob);
+ 			goto kill_vm_tile1;
+@@ -2422,26 +2418,15 @@ xe_pt_update_ops_run(struct xe_tile *tile, struct xe_vma_ops *vops)
+ 
+ 			mjob = xe_tlb_inval_job_create(q,
+ 						       &tile->media_gt->tlb_inval,
+-						       dep_scheduler,
++						       dep_scheduler, vm,
+ 						       pt_update_ops->start,
+ 						       pt_update_ops->last,
+-						       vm->usm.asid);
++						       XE_EXEC_QUEUE_TLB_INVAL_MEDIA_GT);
+ 			if (IS_ERR(mjob)) {
+ 				err = PTR_ERR(mjob);
+ 				goto free_ijob;
+ 			}
+ 			update.mjob = mjob;
+-
+-			fences = kmalloc_array(2, sizeof(*fences), GFP_KERNEL);
+-			if (!fences) {
+-				err = -ENOMEM;
+-				goto free_ijob;
+-			}
+-			cf = dma_fence_array_alloc(2);
+-			if (!cf) {
+-				err = -ENOMEM;
+-				goto free_ijob;
+-			}
+ 		}
+ 	}
+ 
+@@ -2472,31 +2457,12 @@ xe_pt_update_ops_run(struct xe_tile *tile, struct xe_vma_ops *vops)
+ 				  pt_update_ops->last, fence))
+ 		dma_fence_wait(fence, false);
+ 
+-	/* tlb invalidation must be done before signaling unbind/rebind */
+-	if (ijob) {
+-		struct dma_fence *__fence;
+-
++	if (ijob)
+ 		ifence = xe_tlb_inval_job_push(ijob, tile->migrate, fence);
+-		__fence = ifence;
+-
+-		if (mjob) {
+-			fences[0] = ifence;
+-			mfence = xe_tlb_inval_job_push(mjob, tile->migrate,
+-						       fence);
+-			fences[1] = mfence;
+-
+-			dma_fence_array_init(cf, 2, fences,
+-					     vm->composite_fence_ctx,
+-					     vm->composite_fence_seqno++,
+-					     false);
+-			__fence = &cf->base;
+-		}
++	if (mjob)
++		mfence = xe_tlb_inval_job_push(mjob, tile->migrate, fence);
+ 
+-		dma_fence_put(fence);
+-		fence = __fence;
+-	}
+-
+-	if (!mjob) {
++	if (!mjob && !ijob) {
+ 		dma_resv_add_fence(xe_vm_resv(vm), fence,
+ 				   pt_update_ops->wait_vm_bookkeep ?
+ 				   DMA_RESV_USAGE_KERNEL :
+@@ -2504,6 +2470,14 @@ xe_pt_update_ops_run(struct xe_tile *tile, struct xe_vma_ops *vops)
+ 
+ 		list_for_each_entry(op, &vops->list, link)
+ 			op_commit(vops->vm, tile, pt_update_ops, op, fence, NULL);
++	} else if (ijob && !mjob) {
++		dma_resv_add_fence(xe_vm_resv(vm), ifence,
++				   pt_update_ops->wait_vm_bookkeep ?
++				   DMA_RESV_USAGE_KERNEL :
++				   DMA_RESV_USAGE_BOOKKEEP);
++
++		list_for_each_entry(op, &vops->list, link)
++			op_commit(vops->vm, tile, pt_update_ops, op, ifence, NULL);
+ 	} else {
+ 		dma_resv_add_fence(xe_vm_resv(vm), ifence,
+ 				   pt_update_ops->wait_vm_bookkeep ?
+@@ -2525,16 +2499,23 @@ xe_pt_update_ops_run(struct xe_tile *tile, struct xe_vma_ops *vops)
+ 	if (pt_update_ops->needs_userptr_lock)
+ 		up_read(&vm->userptr.notifier_lock);
+ 
++	/*
++	* The last fence is only used for zero bind queue idling; migrate
++	* queues are not exposed to user space.
++	*/
++	if (!(q->flags & EXEC_QUEUE_FLAG_MIGRATE))
++		xe_exec_queue_last_fence_set(q, vm, fence);
++
+ 	xe_tlb_inval_job_put(mjob);
+ 	xe_tlb_inval_job_put(ijob);
++	dma_fence_put(ifence);
++	dma_fence_put(mfence);
+ 
+ 	return fence;
+ 
+ free_rfence:
+ 	kfree(rfence);
+ free_ijob:
+-	kfree(cf);
+-	kfree(fences);
+ 	xe_tlb_inval_job_put(mjob);
+ 	xe_tlb_inval_job_put(ijob);
+ kill_vm_tile1:
+diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
+index d48ab7b32..df7ca3493 100644
+--- a/drivers/gpu/drm/xe/xe_sync.c
++++ b/drivers/gpu/drm/xe/xe_sync.c
+@@ -14,7 +14,7 @@
+ #include <drm/drm_syncobj.h>
+ #include <uapi/drm/xe_drm.h>
+ 
+-#include "xe_device_types.h"
++#include "xe_device.h"
+ #include "xe_exec_queue.h"
+ #include "xe_macros.h"
+ #include "xe_sched_job_types.h"
+@@ -297,26 +297,67 @@ xe_sync_in_fence_get(struct xe_sync_entry *sync, int num_sync,
+ 	struct dma_fence **fences = NULL;
+ 	struct dma_fence_array *cf = NULL;
+ 	struct dma_fence *fence;
+-	int i, num_in_fence = 0, current_fence = 0;
++	int i, num_fence = 0, current_fence = 0;
+ 
+ 	lockdep_assert_held(&vm->lock);
+ 
+ 	/* Count in-fences */
+ 	for (i = 0; i < num_sync; ++i) {
+ 		if (sync[i].fence) {
+-			++num_in_fence;
++			++num_fence;
+ 			fence = sync[i].fence;
+ 		}
+ 	}
+ 
+ 	/* Easy case... */
+-	if (!num_in_fence) {
++	if (!num_fence) {
++		if (q->flags & EXEC_QUEUE_FLAG_VM) {
++			struct xe_exec_queue *__q;
++			struct xe_tile *tile;
++			u8 id;
++
++			for_each_tile(tile, vm->xe, id)
++				num_fence += (1 + XE_MAX_GT_PER_TILE);
++
++			fences = kmalloc_array(num_fence, sizeof(*fences),
++					       GFP_KERNEL);
++			if (!fences)
++				return ERR_PTR(-ENOMEM);
++
++			fences[current_fence++] =
++				xe_exec_queue_last_fence_get(q, vm);
++			for_each_tlb_inval(i)
++				fences[current_fence++] =
++					xe_exec_queue_tlb_inval_last_fence_get(q, vm, i);
++			list_for_each_entry(__q, &q->multi_gt_list,
++					    multi_gt_link) {
++				fences[current_fence++] =
++					xe_exec_queue_last_fence_get(__q, vm);
++				for_each_tlb_inval(i)
++					fences[current_fence++] =
++						xe_exec_queue_tlb_inval_last_fence_get(__q, vm, i);
++			}
++
++			xe_assert(vm->xe, current_fence == num_fence);
++			cf = dma_fence_array_create(num_fence, fences,
++						    dma_fence_context_alloc(1),
++						    1, false);
++			if (!cf)
++				goto err_out;
++
++			return &cf->base;
++		}
++
+ 		fence = xe_exec_queue_last_fence_get(q, vm);
+ 		return fence;
+ 	}
+ 
+-	/* Create composite fence */
+-	fences = kmalloc_array(num_in_fence + 1, sizeof(*fences), GFP_KERNEL);
++	/*
++	 * Create composite fence - FIXME - the below code doesn't work. This is
++	 * unused in Mesa so we are ok for the moment. Perhaps we just disable
++	 * this entire code path if number of in fences != 0.
++	 */
++	fences = kmalloc_array(num_fence + 1, sizeof(*fences), GFP_KERNEL);
+ 	if (!fences)
+ 		return ERR_PTR(-ENOMEM);
+ 	for (i = 0; i < num_sync; ++i) {
+@@ -326,14 +367,10 @@ xe_sync_in_fence_get(struct xe_sync_entry *sync, int num_sync,
+ 		}
+ 	}
+ 	fences[current_fence++] = xe_exec_queue_last_fence_get(q, vm);
+-	cf = dma_fence_array_create(num_in_fence, fences,
+-				    vm->composite_fence_ctx,
+-				    vm->composite_fence_seqno++,
+-				    false);
+-	if (!cf) {
+-		--vm->composite_fence_seqno;
++	cf = dma_fence_array_create(num_fence, fences,
++				    dma_fence_context_alloc(1), 1, false);
++	if (!cf)
+ 		goto err_out;
+-	}
+ 
+ 	return &cf->base;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_tlb_inval_job.c b/drivers/gpu/drm/xe/xe_tlb_inval_job.c
+index 492def04a..1ae0dec2c 100644
+--- a/drivers/gpu/drm/xe/xe_tlb_inval_job.c
++++ b/drivers/gpu/drm/xe/xe_tlb_inval_job.c
+@@ -12,6 +12,7 @@
+ #include "xe_tlb_inval_job.h"
+ #include "xe_migrate.h"
+ #include "xe_pm.h"
++#include "xe_vm.h"
+ 
+ /** struct xe_tlb_inval_job - TLB invalidation job */
+ struct xe_tlb_inval_job {
+@@ -21,6 +22,8 @@ struct xe_tlb_inval_job {
+ 	struct xe_tlb_inval *tlb_inval;
+ 	/** @q: exec queue issuing the invalidate */
+ 	struct xe_exec_queue *q;
++	/** @vm: VM which TLB invalidation is being issued for */
++	struct xe_vm *vm;
+ 	/** @refcount: ref count of this job */
+ 	struct kref refcount;
+ 	/**
+@@ -32,8 +35,8 @@ struct xe_tlb_inval_job {
+ 	u64 start;
+ 	/** @end: End address to invalidate */
+ 	u64 end;
+-	/** @asid: Address space ID to invalidate */
+-	u32 asid;
++	/** @type: GT type */
++	int type;
+ 	/** @fence_armed: Fence has been armed */
+ 	bool fence_armed;
+ };
+@@ -46,7 +49,7 @@ static struct dma_fence *xe_tlb_inval_job_run(struct xe_dep_job *dep_job)
+ 		container_of(job->fence, typeof(*ifence), base);
+ 
+ 	xe_tlb_inval_range(job->tlb_inval, ifence, job->start,
+-			   job->end, job->asid);
++			   job->end, job->vm->usm.asid);
+ 
+ 	return job->fence;
+ }
+@@ -70,9 +73,10 @@ static const struct xe_dep_job_ops dep_job_ops = {
+  * @q: exec queue issuing the invalidate
+  * @tlb_inval: TLB invalidation client
+  * @dep_scheduler: Dependency scheduler for job
++ * @vm: VM which TLB invalidation is being issued for
+  * @start: Start address to invalidate
+  * @end: End address to invalidate
+- * @asid: Address space ID to invalidate
++ * @type: GT type
+  *
+  * Create a TLB invalidation job and initialize internal fields. The caller is
+  * responsible for releasing the creation reference.
+@@ -81,8 +85,8 @@ static const struct xe_dep_job_ops dep_job_ops = {
+  */
+ struct xe_tlb_inval_job *
+ xe_tlb_inval_job_create(struct xe_exec_queue *q, struct xe_tlb_inval *tlb_inval,
+-			struct xe_dep_scheduler *dep_scheduler, u64 start,
+-			u64 end, u32 asid)
++			struct xe_dep_scheduler *dep_scheduler,
++			struct xe_vm *vm, u64 start, u64 end, int type)
+ {
+ 	struct xe_tlb_inval_job *job;
+ 	struct drm_sched_entity *entity =
+@@ -90,19 +94,24 @@ xe_tlb_inval_job_create(struct xe_exec_queue *q, struct xe_tlb_inval *tlb_inval,
+ 	struct xe_tlb_inval_fence *ifence;
+ 	int err;
+ 
++	xe_assert(vm->xe, type == XE_EXEC_QUEUE_TLB_INVAL_MEDIA_GT ||
++		  type == XE_EXEC_QUEUE_TLB_INVAL_PRIMARY_GT);
++
+ 	job = kmalloc(sizeof(*job), GFP_KERNEL);
+ 	if (!job)
+ 		return ERR_PTR(-ENOMEM);
+ 
+ 	job->q = q;
++	job->vm = vm;
+ 	job->tlb_inval = tlb_inval;
+ 	job->start = start;
+ 	job->end = end;
+-	job->asid = asid;
+ 	job->fence_armed = false;
+ 	job->dep.ops = &dep_job_ops;
++	job->type = type;
+ 	kref_init(&job->refcount);
+ 	xe_exec_queue_get(q);	/* Pairs with put in xe_tlb_inval_job_destroy */
++	xe_vm_get(vm);		/* Pairs with put in xe_tlb_inval_job_destroy */
+ 
+ 	ifence = kmalloc(sizeof(*ifence), GFP_KERNEL);
+ 	if (!ifence) {
+@@ -124,6 +133,7 @@ xe_tlb_inval_job_create(struct xe_exec_queue *q, struct xe_tlb_inval *tlb_inval,
+ err_fence:
+ 	kfree(ifence);
+ err_job:
++	xe_vm_put(vm);
+ 	xe_exec_queue_put(q);
+ 	kfree(job);
+ 
+@@ -138,6 +148,7 @@ static void xe_tlb_inval_job_destroy(struct kref *ref)
+ 		container_of(job->fence, typeof(*ifence), base);
+ 	struct xe_exec_queue *q = job->q;
+ 	struct xe_device *xe = gt_to_xe(q->gt);
++	struct xe_vm *vm = job->vm;
+ 
+ 	if (!job->fence_armed)
+ 		kfree(ifence);
+@@ -147,6 +158,7 @@ static void xe_tlb_inval_job_destroy(struct kref *ref)
+ 
+ 	drm_sched_job_cleanup(&job->dep.drm);
+ 	kfree(job);
++	xe_vm_put(vm);		/* Pairs with get from xe_tlb_inval_job_create */
+ 	xe_exec_queue_put(q);	/* Pairs with get from xe_tlb_inval_job_create */
+ 	xe_pm_runtime_put(xe);	/* Pairs with get from xe_tlb_inval_job_create */
+ }
+@@ -231,6 +243,11 @@ struct dma_fence *xe_tlb_inval_job_push(struct xe_tlb_inval_job *job,
+ 	dma_fence_get(&job->dep.drm.s_fence->finished);
+ 	drm_sched_entity_push_job(&job->dep.drm);
+ 
++	/* Let the upper layers fish this out */
++	xe_exec_queue_tlb_inval_last_fence_set(job->q, job->vm,
++					       &job->dep.drm.s_fence->finished,
++					       job->type);
++
+ 	xe_migrate_job_unlock(m, job->q);
+ 
+ 	/*
+diff --git a/drivers/gpu/drm/xe/xe_tlb_inval_job.h b/drivers/gpu/drm/xe/xe_tlb_inval_job.h
+index e63edcb26..4d6df1a6c 100644
+--- a/drivers/gpu/drm/xe/xe_tlb_inval_job.h
++++ b/drivers/gpu/drm/xe/xe_tlb_inval_job.h
+@@ -11,14 +11,15 @@
+ struct dma_fence;
+ struct xe_dep_scheduler;
+ struct xe_exec_queue;
++struct xe_migrate;
+ struct xe_tlb_inval;
+ struct xe_tlb_inval_job;
+-struct xe_migrate;
++struct xe_vm;
+ 
+ struct xe_tlb_inval_job *
+ xe_tlb_inval_job_create(struct xe_exec_queue *q, struct xe_tlb_inval *tlb_inval,
+ 			struct xe_dep_scheduler *dep_scheduler,
+-			u64 start, u64 end, u32 asid);
++			struct xe_vm *vm, u64 start, u64 end, int type);
+ 
+ int xe_tlb_inval_job_alloc_dep(struct xe_tlb_inval_job *job);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index e5ca720fe..c4f2e4535 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -1902,9 +1902,6 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
+ 		}
+ 	}
+ 
+-	if (number_tiles > 1)
+-		vm->composite_fence_ctx = dma_fence_context_alloc(1);
+-
+ 	if (xef && xe->info.has_asid) {
+ 		u32 asid;
+ 
+@@ -3239,20 +3236,26 @@ static struct dma_fence *ops_execute(struct xe_vm *vm,
+ 	struct dma_fence *fence = NULL;
+ 	struct dma_fence **fences = NULL;
+ 	struct dma_fence_array *cf = NULL;
+-	int number_tiles = 0, current_fence = 0, err;
++	int number_tiles = 0, current_fence = 0, n_fence = 0, err;
+ 	u8 id;
+ 
+ 	number_tiles = vm_ops_setup_tile_args(vm, vops);
+ 	if (number_tiles == 0)
+ 		return ERR_PTR(-ENODATA);
+ 
+-	if (number_tiles > 1) {
+-		fences = kmalloc_array(number_tiles, sizeof(*fences),
+-				       GFP_KERNEL);
+-		if (!fences) {
+-			fence = ERR_PTR(-ENOMEM);
+-			goto err_trace;
+-		}
++	for_each_tile(tile, vm->xe, id)
++		n_fence += (1 + XE_MAX_GT_PER_TILE);
++
++	fences = kmalloc_array(n_fence, sizeof(*fences), GFP_KERNEL);
++	if (!fences) {
++		fence = ERR_PTR(-ENOMEM);
++		goto err_trace;
++	}
++
++	cf = dma_fence_array_alloc(n_fence);
++	if (!cf) {
++		fence = ERR_PTR(-ENOMEM);
++		goto err_out;
+ 	}
+ 
+ 	for_each_tile(tile, vm->xe, id) {
+@@ -3269,29 +3272,30 @@ static struct dma_fence *ops_execute(struct xe_vm *vm,
+ 	trace_xe_vm_ops_execute(vops);
+ 
+ 	for_each_tile(tile, vm->xe, id) {
++		struct xe_exec_queue *q = vops->pt_update_ops[tile->id].q;
++		int i;
++
++		fence = NULL;
+ 		if (!vops->pt_update_ops[id].num_ops)
+-			continue;
++			goto collect_fences;
+ 
+ 		fence = xe_pt_update_ops_run(tile, vops);
+ 		if (IS_ERR(fence))
+ 			goto err_out;
+ 
+-		if (fences)
+-			fences[current_fence++] = fence;
++collect_fences:
++		fences[current_fence++] = fence ?: dma_fence_get_stub();
++		xe_migrate_job_lock(tile->migrate, q);
++		for_each_tlb_inval(i)
++			fences[current_fence++] =
++				xe_exec_queue_tlb_inval_last_fence_get(q, vm, i);
++		xe_migrate_job_unlock(tile->migrate, q);
+ 	}
+ 
+-	if (fences) {
+-		cf = dma_fence_array_create(number_tiles, fences,
+-					    vm->composite_fence_ctx,
+-					    vm->composite_fence_seqno++,
+-					    false);
+-		if (!cf) {
+-			--vm->composite_fence_seqno;
+-			fence = ERR_PTR(-ENOMEM);
+-			goto err_out;
+-		}
+-		fence = &cf->base;
+-	}
++	xe_assert(vm->xe, current_fence == n_fence);
++	dma_fence_array_init(cf, n_fence, fences, dma_fence_context_alloc(1),
++			     1, false);
++	fence = &cf->base;
+ 
+ 	for_each_tile(tile, vm->xe, id) {
+ 		if (!vops->pt_update_ops[id].num_ops)
+@@ -3352,7 +3356,6 @@ static void op_add_ufence(struct xe_vm *vm, struct xe_vma_op *op,
+ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+ 				   struct dma_fence *fence)
+ {
+-	struct xe_exec_queue *wait_exec_queue = to_wait_exec_queue(vm, vops->q);
+ 	struct xe_user_fence *ufence;
+ 	struct xe_vma_op *op;
+ 	int i;
+@@ -3373,7 +3376,6 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+ 	if (fence) {
+ 		for (i = 0; i < vops->num_syncs; i++)
+ 			xe_sync_entry_signal(vops->syncs + i, fence);
+-		xe_exec_queue_last_fence_set(wait_exec_queue, vm, fence);
+ 	}
+ }
+ 
+@@ -3562,19 +3564,19 @@ static int vm_bind_ioctl_signal_fences(struct xe_vm *vm,
+ 				       struct xe_sync_entry *syncs,
+ 				       int num_syncs)
+ {
+-	struct dma_fence *fence;
++	struct dma_fence *fence = NULL;
+ 	int i, err = 0;
+ 
+-	fence = xe_sync_in_fence_get(syncs, num_syncs,
+-				     to_wait_exec_queue(vm, q), vm);
+-	if (IS_ERR(fence))
+-		return PTR_ERR(fence);
++	if (num_syncs) {
++		fence = xe_sync_in_fence_get(syncs, num_syncs,
++					     to_wait_exec_queue(vm, q), vm);
++		if (IS_ERR(fence))
++			return PTR_ERR(fence);
+ 
+-	for (i = 0; i < num_syncs; i++)
+-		xe_sync_entry_signal(&syncs[i], fence);
++		for (i = 0; i < num_syncs; i++)
++			xe_sync_entry_signal(&syncs[i], fence);
++	}
+ 
+-	xe_exec_queue_last_fence_set(to_wait_exec_queue(vm, q), vm,
+-				     fence);
+ 	dma_fence_put(fence);
+ 
+ 	return err;
+diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
+index 1a0f210b7..e4b184700 100644
+--- a/drivers/gpu/drm/xe/xe_vm_types.h
++++ b/drivers/gpu/drm/xe/xe_vm_types.h
+@@ -205,11 +205,6 @@ struct xe_vm {
+ #define XE_VM_FLAG_GSC			BIT(8)
+ 	unsigned long flags;
+ 
+-	/** @composite_fence_ctx: context composite fence */
+-	u64 composite_fence_ctx;
+-	/** @composite_fence_seqno: seqno for composite fence */
+-	u32 composite_fence_seqno;
+-
+ 	/**
+ 	 * @lock: outer most lock, protects objects of anything attached to this
+ 	 * VM
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-Disallow-input-fences-on-zero-batch-execs-and.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Disallow-input-fences-on-zero-batch-execs-and.patch
@@ -1,0 +1,155 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Fri, 31 Oct 2025 16:40:49 -0700
+Subject: drm/xe: Disallow input fences on zero batch execs and zero
+ binds
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Prevent input fences from being installed on zero batch execs or zero
+binds, which were originally added to support queue idling in Mesa via
+output fences. Although input fence support was introduced for interface
+consistency, it leads to incorrect behavior due to chained composite
+fences, which are disallowed.
+
+Avoid the complexity of fixing this by removing support, as input fences
+for these cases are not used in practice.
+
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patch.msgid.link/20251031234050.3043507-6-matthew.brost@intel.com
+(cherry-picked from commit aa87b681bc728ae2fb2b725733bcb129079985f4 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_sync.c | 101 +++++++++++++----------------------
+ 1 file changed, 36 insertions(+), 65 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
+index df7ca3493..ff74528ca 100644
+--- a/drivers/gpu/drm/xe/xe_sync.c
++++ b/drivers/gpu/drm/xe/xe_sync.c
+@@ -301,84 +301,55 @@ xe_sync_in_fence_get(struct xe_sync_entry *sync, int num_sync,
+ 
+ 	lockdep_assert_held(&vm->lock);
+ 
+-	/* Count in-fences */
+-	for (i = 0; i < num_sync; ++i) {
+-		if (sync[i].fence) {
+-			++num_fence;
+-			fence = sync[i].fence;
+-		}
+-	}
+-
+-	/* Easy case... */
+-	if (!num_fence) {
+-		if (q->flags & EXEC_QUEUE_FLAG_VM) {
+-			struct xe_exec_queue *__q;
+-			struct xe_tile *tile;
+-			u8 id;
+-
+-			for_each_tile(tile, vm->xe, id)
+-				num_fence += (1 + XE_MAX_GT_PER_TILE);
+-
+-			fences = kmalloc_array(num_fence, sizeof(*fences),
+-					       GFP_KERNEL);
+-			if (!fences)
+-				return ERR_PTR(-ENOMEM);
+-
++	/* Reject in fences */
++	for (i = 0; i < num_sync; ++i)
++		if (sync[i].fence)
++			return ERR_PTR(-EOPNOTSUPP);
++
++	if (q->flags & EXEC_QUEUE_FLAG_VM) {
++		struct xe_exec_queue *__q;
++		struct xe_tile *tile;
++		u8 id;
++
++		for_each_tile(tile, vm->xe, id)
++			num_fence += (1 + XE_MAX_GT_PER_TILE);
++
++		fences = kmalloc_array(num_fence, sizeof(*fences),
++				       GFP_KERNEL);
++		if (!fences)
++			return ERR_PTR(-ENOMEM);
++
++		fences[current_fence++] =
++			xe_exec_queue_last_fence_get(q, vm);
++		for_each_tlb_inval(i)
++			fences[current_fence++] =
++				xe_exec_queue_tlb_inval_last_fence_get(q, vm, i);
++		list_for_each_entry(__q, &q->multi_gt_list,
++				    multi_gt_link) {
+ 			fences[current_fence++] =
+-				xe_exec_queue_last_fence_get(q, vm);
++				xe_exec_queue_last_fence_get(__q, vm);
+ 			for_each_tlb_inval(i)
+ 				fences[current_fence++] =
+-					xe_exec_queue_tlb_inval_last_fence_get(q, vm, i);
+-			list_for_each_entry(__q, &q->multi_gt_list,
+-					    multi_gt_link) {
+-				fences[current_fence++] =
+-					xe_exec_queue_last_fence_get(__q, vm);
+-				for_each_tlb_inval(i)
+-					fences[current_fence++] =
+-						xe_exec_queue_tlb_inval_last_fence_get(__q, vm, i);
+-			}
+-
+-			xe_assert(vm->xe, current_fence == num_fence);
+-			cf = dma_fence_array_create(num_fence, fences,
+-						    dma_fence_context_alloc(1),
+-						    1, false);
+-			if (!cf)
+-				goto err_out;
+-
+-			return &cf->base;
++					xe_exec_queue_tlb_inval_last_fence_get(__q, vm, i);
+ 		}
+ 
+-		fence = xe_exec_queue_last_fence_get(q, vm);
+-		return fence;
+-	}
++		xe_assert(vm->xe, current_fence == num_fence);
++		cf = dma_fence_array_create(num_fence, fences,
++					    dma_fence_context_alloc(1),
++					    1, false);
++		if (!cf)
++			goto err_out;
+ 
+-	/*
+-	 * Create composite fence - FIXME - the below code doesn't work. This is
+-	 * unused in Mesa so we are ok for the moment. Perhaps we just disable
+-	 * this entire code path if number of in fences != 0.
+-	 */
+-	fences = kmalloc_array(num_fence + 1, sizeof(*fences), GFP_KERNEL);
+-	if (!fences)
+-		return ERR_PTR(-ENOMEM);
+-	for (i = 0; i < num_sync; ++i) {
+-		if (sync[i].fence) {
+-			dma_fence_get(sync[i].fence);
+-			fences[current_fence++] = sync[i].fence;
+-		}
++		return &cf->base;
+ 	}
+-	fences[current_fence++] = xe_exec_queue_last_fence_get(q, vm);
+-	cf = dma_fence_array_create(num_fence, fences,
+-				    dma_fence_context_alloc(1), 1, false);
+-	if (!cf)
+-		goto err_out;
+ 
+-	return &cf->base;
++	fence = xe_exec_queue_last_fence_get(q, vm);
++	return fence;
+ 
+ err_out:
+ 	while (current_fence)
+ 		dma_fence_put(fences[--current_fence]);
+ 	kfree(fences);
+-	kfree(cf);
+ 
+ 	return ERR_PTR(-ENOMEM);
+ }
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-Enforce-correct-user-fence-signaling-order-us.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Enforce-correct-user-fence-signaling-order-us.patch
@@ -1,0 +1,374 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Fri, 31 Oct 2025 16:40:45 -0700
+Subject: drm/xe: Enforce correct user fence signaling order using
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Prevent application hangs caused by out-of-order fence signaling when
+user fences are attached. Use drm_syncobj (via dma-fence-chain) to
+guarantee that each user fence signals in order, regardless of the
+signaling order of the attached fences. Ensure user fence writebacks to
+user space occur in the correct sequence.
+
+v7:
+ - Skip drm_syncbj create of error (CI)
+
+Fixes: dd08ebf6c352 ("drm/xe: Introduce a new DRM driver for Intel GPUs")
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patch.msgid.link/20251031234050.3043507-2-matthew.brost@intel.com
+(backported from commit adda4e855ab6409a3edaa585293f1f2069ab7299 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_exec.c             |  3 +-
+ drivers/gpu/drm/xe/xe_exec_queue.c       | 11 ++++++
+ drivers/gpu/drm/xe/xe_exec_queue_types.h |  7 ++++
+ drivers/gpu/drm/xe/xe_oa.c               | 45 ++++++++++++++++--------
+ drivers/gpu/drm/xe/xe_oa_types.h         |  8 +++++
+ drivers/gpu/drm/xe/xe_sync.c             | 17 +++++++--
+ drivers/gpu/drm/xe/xe_sync.h             |  3 ++
+ drivers/gpu/drm/xe/xe_sync_types.h       |  3 ++
+ drivers/gpu/drm/xe/xe_vm.c               |  4 +++
+ 9 files changed, 83 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec.c b/drivers/gpu/drm/xe/xe_exec.c
+index f87bc1d53..f67bf5790 100644
+--- a/drivers/gpu/drm/xe/xe_exec.c
++++ b/drivers/gpu/drm/xe/xe_exec.c
+@@ -164,7 +164,8 @@ int xe_exec_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 
+ 	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
+ 		err = xe_sync_entry_parse(xe, xef, &syncs[num_syncs],
+-					  &syncs_user[num_syncs], SYNC_PARSE_FLAG_EXEC |
++					  &syncs_user[num_syncs], NULL, 0,
++					  SYNC_PARSE_FLAG_EXEC |
+ 					  (xe_vm_in_lr_mode(vm) ?
+ 					   SYNC_PARSE_FLAG_LR_MODE : 0));
+ 		if (err)
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index c3f49579b..28380d1f7 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -10,6 +10,7 @@
+ #include <drm/drm_device.h>
+ #include <drm/drm_drv.h>
+ #include <drm/drm_file.h>
++#include <drm/drm_syncobj.h>
+ #include <uapi/drm/xe_drm.h>
+ 
+ #include "xe_dep_scheduler.h"
+@@ -348,6 +349,13 @@ struct xe_exec_queue *xe_exec_queue_create_bind(struct xe_device *xe,
+ 	xe_vm_put(migrate_vm);
+ 
+ 	if (!IS_ERR(q)) {
++		int err = drm_syncobj_create(&q->ufence_syncobj,
++				DRM_SYNCOBJ_CREATE_SIGNALED, NULL);
++		if (err) {
++			xe_exec_queue_put(q);
++			return ERR_PTR(err);
++		}
++
+ 		if (user_vm)
+ 			q->user_vm = xe_vm_get(user_vm);
+ 	}
+@@ -361,6 +369,9 @@ void xe_exec_queue_destroy(struct kref *ref)
+ 	struct xe_exec_queue *q = container_of(ref, struct xe_exec_queue, refcount);
+ 	struct xe_exec_queue *eq, *next;
+ 
++	if (q->ufence_syncobj)
++		drm_syncobj_put(q->ufence_syncobj);
++
+ 	if (xe_exec_queue_uses_pxp(q))
+ 		xe_pxp_exec_queue_remove(gt_to_xe(q->gt)->pxp, q);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue_types.h b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+index 47c18a895..b29ce5688 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue_types.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+@@ -15,6 +15,7 @@
+ #include "xe_hw_fence_types.h"
+ #include "xe_lrc_types.h"
+ 
++struct drm_syncobj;
+ struct xe_execlist_exec_queue;
+ struct xe_gt;
+ struct xe_guc_exec_queue;
+@@ -161,6 +162,12 @@ struct xe_exec_queue {
+ 		struct list_head link;
+ 	} pxp;
+ 
++	/** @ufence_syncobj: User fence syncobj */
++	struct drm_syncobj *ufence_syncobj;
++
++	/** @ufence_timeline_value: User fence timeline value */
++	u64 ufence_timeline_value;
++
+ 	/** @ops: submission backend exec queue operations */
+ 	const struct xe_exec_queue_ops *ops;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index c1966c5e5..80fbde8ac 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -10,6 +10,7 @@
+ 
+ #include <drm/drm_drv.h>
+ #include <drm/drm_managed.h>
++#include <drm/drm_syncobj.h>
+ #include <uapi/drm/xe_drm.h>
+ 
+ #include <generated/xe_wa_oob.h>
+@@ -1389,7 +1390,9 @@ static int xe_oa_user_extensions(struct xe_oa *oa, enum xe_oa_user_extn_from fro
+ 	return 0;
+ }
+ 
+-static int xe_oa_parse_syncs(struct xe_oa *oa, struct xe_oa_open_param *param)
++static int xe_oa_parse_syncs(struct xe_oa *oa,
++			     struct xe_oa_stream *stream,
++			     struct xe_oa_open_param *param)
+ {
+ 	int ret, num_syncs, num_ufence = 0;
+ 
+@@ -1409,7 +1412,9 @@ static int xe_oa_parse_syncs(struct xe_oa *oa, struct xe_oa_open_param *param)
+ 
+ 	for (num_syncs = 0; num_syncs < param->num_syncs; num_syncs++) {
+ 		ret = xe_sync_entry_parse(oa->xe, param->xef, &param->syncs[num_syncs],
+-					  &param->syncs_user[num_syncs], 0);
++					  &param->syncs_user[num_syncs],
++					  stream->ufence_syncobj,
++					  ++stream->ufence_timeline_value, 0);
+ 		if (ret)
+ 			goto err_syncs;
+ 
+@@ -1539,7 +1544,7 @@ static long xe_oa_config_locked(struct xe_oa_stream *stream, u64 arg)
+ 		return -ENODEV;
+ 
+ 	param.xef = stream->xef;
+-	err = xe_oa_parse_syncs(stream->oa, &param);
++	err = xe_oa_parse_syncs(stream->oa, stream, &param);
+ 	if (err)
+ 		goto err_config_put;
+ 
+@@ -1635,6 +1640,7 @@ static void xe_oa_destroy_locked(struct xe_oa_stream *stream)
+ 	if (stream->exec_q)
+ 		xe_exec_queue_put(stream->exec_q);
+ 
++	drm_syncobj_put(stream->ufence_syncobj);
+ 	kfree(stream);
+ }
+ 
+@@ -1826,6 +1832,7 @@ static int xe_oa_stream_open_ioctl_locked(struct xe_oa *oa,
+ 					  struct xe_oa_open_param *param)
+ {
+ 	struct xe_oa_stream *stream;
++	struct drm_syncobj *ufence_syncobj;
+ 	int stream_fd;
+ 	int ret;
+ 
+@@ -1836,17 +1843,31 @@ static int xe_oa_stream_open_ioctl_locked(struct xe_oa *oa,
+ 		goto exit;
+ 	}
+ 
++	ret = drm_syncobj_create(&ufence_syncobj, DRM_SYNCOBJ_CREATE_SIGNALED,
++				 NULL);
++	if (ret)
++		goto exit;
++
+ 	stream = kzalloc(sizeof(*stream), GFP_KERNEL);
+ 	if (!stream) {
+ 		ret = -ENOMEM;
+-		goto exit;
++		goto err_syncobj;
+ 	}
+-
++	stream->ufence_syncobj = ufence_syncobj;
+ 	stream->oa = oa;
+-	ret = xe_oa_stream_init(stream, param);
++
++	ret = xe_oa_parse_syncs(oa, stream, param);
+ 	if (ret)
+ 		goto err_free;
+ 
++	ret = xe_oa_stream_init(stream, param);
++	if (ret) {
++		while (param->num_syncs--)
++			xe_sync_entry_cleanup(&param->syncs[param->num_syncs]);
++		kfree(param->syncs);
++		goto err_free;
++	}
++
+ 	if (!param->disabled) {
+ 		ret = xe_oa_enable_locked(stream);
+ 		if (ret)
+@@ -1870,6 +1891,8 @@ static int xe_oa_stream_open_ioctl_locked(struct xe_oa *oa,
+ 	xe_oa_stream_destroy(stream);
+ err_free:
+ 	kfree(stream);
++err_syncobj:
++	drm_syncobj_put(ufence_syncobj);
+ exit:
+ 	return ret;
+ }
+@@ -2083,22 +2106,14 @@ int xe_oa_stream_open_ioctl(struct drm_device *dev, u64 data, struct drm_file *f
+ 		goto err_exec_q;
+ 	}
+ 
+-	ret = xe_oa_parse_syncs(oa, &param);
+-	if (ret)
+-		goto err_exec_q;
+-
+ 	mutex_lock(&param.hwe->gt->oa.gt_lock);
+ 	ret = xe_oa_stream_open_ioctl_locked(oa, &param);
+ 	mutex_unlock(&param.hwe->gt->oa.gt_lock);
+ 	if (ret < 0)
+-		goto err_sync_cleanup;
++		goto err_exec_q;
+ 
+ 	return ret;
+ 
+-err_sync_cleanup:
+-	while (param.num_syncs--)
+-		xe_sync_entry_cleanup(&param.syncs[param.num_syncs]);
+-	kfree(param.syncs);
+ err_exec_q:
+ 	if (param.exec_q)
+ 		xe_exec_queue_put(param.exec_q);
+diff --git a/drivers/gpu/drm/xe/xe_oa_types.h b/drivers/gpu/drm/xe/xe_oa_types.h
+index 2628f78c4..daf701b5d 100644
+--- a/drivers/gpu/drm/xe/xe_oa_types.h
++++ b/drivers/gpu/drm/xe/xe_oa_types.h
+@@ -15,6 +15,8 @@
+ #include "regs/xe_reg_defs.h"
+ #include "xe_hw_engine_types.h"
+ 
++struct drm_syncobj;
++
+ #define DEFAULT_XE_OA_BUFFER_SIZE SZ_16M
+ 
+ enum xe_oa_report_header {
+@@ -248,6 +250,12 @@ struct xe_oa_stream {
+ 	/** @xef: xe_file with which the stream was opened */
+ 	struct xe_file *xef;
+ 
++	/** @ufence_syncobj: User fence syncobj */
++	struct drm_syncobj *ufence_syncobj;
++
++	/** @ufence_timeline_value: User fence timeline value */
++	u64 ufence_timeline_value;
++
+ 	/** @last_fence: fence to use in stream destroy when needed */
+ 	struct dma_fence *last_fence;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
+index 82872a51f..d48ab7b32 100644
+--- a/drivers/gpu/drm/xe/xe_sync.c
++++ b/drivers/gpu/drm/xe/xe_sync.c
+@@ -113,6 +113,8 @@ static void user_fence_cb(struct dma_fence *fence, struct dma_fence_cb *cb)
+ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 			struct xe_sync_entry *sync,
+ 			struct drm_xe_sync __user *sync_user,
++			struct drm_syncobj *ufence_syncobj,
++			u64 ufence_timeline_value,
+ 			unsigned int flags)
+ {
+ 	struct drm_xe_sync sync_in;
+@@ -192,10 +194,15 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 		if (exec) {
+ 			sync->addr = sync_in.addr;
+ 		} else {
++			sync->ufence_timeline_value = ufence_timeline_value;
+ 			sync->ufence = user_fence_create(xe, sync_in.addr,
+ 							 sync_in.timeline_value);
+ 			if (XE_IOCTL_DBG(xe, IS_ERR(sync->ufence)))
+ 				return PTR_ERR(sync->ufence);
++			sync->ufence_chain_fence = dma_fence_chain_alloc();
++			if (!sync->ufence_chain_fence)
++				return -ENOMEM;
++			sync->ufence_syncobj = ufence_syncobj;
+ 		}
+ 
+ 		break;
+@@ -239,7 +246,12 @@ void xe_sync_entry_signal(struct xe_sync_entry *sync, struct dma_fence *fence)
+ 	} else if (sync->ufence) {
+ 		int err;
+ 
+-		dma_fence_get(fence);
++		drm_syncobj_add_point(sync->ufence_syncobj,
++				      sync->ufence_chain_fence,
++				      fence, sync->ufence_timeline_value);
++		sync->ufence_chain_fence = NULL;
++
++		fence = drm_syncobj_fence_get(sync->ufence_syncobj);
+ 		user_fence_get(sync->ufence);
+ 		err = dma_fence_add_callback(fence, &sync->ufence->cb,
+ 					     user_fence_cb);
+@@ -259,7 +271,8 @@ void xe_sync_entry_cleanup(struct xe_sync_entry *sync)
+ 		drm_syncobj_put(sync->syncobj);
+ 	dma_fence_put(sync->fence);
+ 	dma_fence_chain_free(sync->chain_fence);
+-	if (sync->ufence)
++	dma_fence_chain_free(sync->ufence_chain_fence);
++	if (!IS_ERR_OR_NULL(sync->ufence))
+ 		user_fence_put(sync->ufence);
+ }
+ 
+diff --git a/drivers/gpu/drm/xe/xe_sync.h b/drivers/gpu/drm/xe/xe_sync.h
+index 256ffc1e5..51f2d803e 100644
+--- a/drivers/gpu/drm/xe/xe_sync.h
++++ b/drivers/gpu/drm/xe/xe_sync.h
+@@ -8,6 +8,7 @@
+ 
+ #include "xe_sync_types.h"
+ 
++struct drm_syncobj;
+ struct xe_device;
+ struct xe_exec_queue;
+ struct xe_file;
+@@ -21,6 +22,8 @@ struct xe_vm;
+ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 			struct xe_sync_entry *sync,
+ 			struct drm_xe_sync __user *sync_user,
++			struct drm_syncobj *ufence_syncobj,
++			u64 ufence_timeline_value,
+ 			unsigned int flags);
+ int xe_sync_entry_add_deps(struct xe_sync_entry *sync,
+ 			   struct xe_sched_job *job);
+diff --git a/drivers/gpu/drm/xe/xe_sync_types.h b/drivers/gpu/drm/xe/xe_sync_types.h
+index 30ac3f519..b88f1833e 100644
+--- a/drivers/gpu/drm/xe/xe_sync_types.h
++++ b/drivers/gpu/drm/xe/xe_sync_types.h
+@@ -18,9 +18,12 @@ struct xe_sync_entry {
+ 	struct drm_syncobj *syncobj;
+ 	struct dma_fence *fence;
+ 	struct dma_fence_chain *chain_fence;
++	struct dma_fence_chain *ufence_chain_fence;
++	struct drm_syncobj *ufence_syncobj;
+ 	struct xe_user_fence *ufence;
+ 	u64 addr;
+ 	u64 timeline_value;
++	u64 ufence_timeline_value;
+ 	u32 type;
+ 	u32 flags;
+ };
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index e907b3ffe..110af7395 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -3765,8 +3765,12 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 
+ 	syncs_user = u64_to_user_ptr(args->syncs);
+ 	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
++		struct xe_exec_queue *__q = q ?: vm->q[0];
++
+ 		err = xe_sync_entry_parse(xe, xef, &syncs[num_syncs],
+ 					  &syncs_user[num_syncs],
++					  __q->ufence_syncobj,
++					  ++__q->ufence_timeline_value,
+ 					  (xe_vm_in_lr_mode(vm) ?
+ 					   SYNC_PARSE_FLAG_LR_MODE : 0) |
+ 					  (!args->num_binds ?
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-Remove-last-fence-dependency-check-from-binds.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Remove-last-fence-dependency-check-from-binds.patch
@@ -1,0 +1,150 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Fri, 31 Oct 2025 16:40:50 -0700
+Subject: drm/xe: Remove last fence dependency check from binds and
+ execs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Eliminate redundant last fence dependency checks in exec and bind jobs,
+as they are now equivalent to xe_exec_queue_is_idle. Simplify the code
+by removing this dead logic.
+
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patch.msgid.link/20251031234050.3043507-7-matthew.brost@intel.com
+(backported from commit 1a2cf01e1c92f29fd22ae394c06860da1c339339 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_exec.c       |  4 ----
+ drivers/gpu/drm/xe/xe_exec_queue.c | 23 -----------------------
+ drivers/gpu/drm/xe/xe_exec_queue.h |  2 --
+ drivers/gpu/drm/xe/xe_pt.c         |  7 -------
+ drivers/gpu/drm/xe/xe_sched_job.c  | 17 -----------------
+ drivers/gpu/drm/xe/xe_sched_job.h  |  1 -
+ 6 files changed, 54 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec.c b/drivers/gpu/drm/xe/xe_exec.c
+index f67bf5790..de83e8b18 100644
+--- a/drivers/gpu/drm/xe/xe_exec.c
++++ b/drivers/gpu/drm/xe/xe_exec.c
+@@ -293,10 +293,6 @@ int xe_exec_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+ 		goto err_put_job;
+ 
+ 	if (!xe_vm_in_lr_mode(vm)) {
+-		err = xe_sched_job_last_fence_add_dep(job, vm);
+-		if (err)
+-			goto err_put_job;
+-
+ 		err = down_read_interruptible(&vm->userptr.notifier_lock);
+ 		if (err)
+ 			goto err_put_job;
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index e8ffe8a6a..137d6db5c 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -1130,29 +1130,6 @@ void xe_exec_queue_last_fence_set(struct xe_exec_queue *q, struct xe_vm *vm,
+ 	q->last_fence = dma_fence_get(fence);
+ }
+ 
+-/**
+- * xe_exec_queue_last_fence_test_dep - Test last fence dependency of queue
+- * @q: The exec queue
+- * @vm: The VM the engine does a bind or exec for
+- *
+- * Returns:
+- * -ETIME if there exists an unsignalled last fence dependency, zero otherwise.
+- */
+-int xe_exec_queue_last_fence_test_dep(struct xe_exec_queue *q, struct xe_vm *vm)
+-{
+-	struct dma_fence *fence;
+-	int err = 0;
+-
+-	fence = xe_exec_queue_last_fence_get(q, vm);
+-	if (fence) {
+-		err = test_bit(DMA_FENCE_FLAG_SIGNALED_BIT, &fence->flags) ?
+-			0 : -ETIME;
+-		dma_fence_put(fence);
+-	}
+-
+-	return err;
+-}
+-
+ /**
+  * xe_exec_queue_tlb_inval_last_fence_put() - Drop ref to last TLB invalidation fence
+  * @q: The exec queue
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.h b/drivers/gpu/drm/xe/xe_exec_queue.h
+index 6f60545a7..37a9da22f 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue.h
+@@ -89,8 +89,6 @@ struct dma_fence *xe_exec_queue_last_fence_get_for_resume(struct xe_exec_queue *
+ 							  struct xe_vm *vm);
+ void xe_exec_queue_last_fence_set(struct xe_exec_queue *e, struct xe_vm *vm,
+ 				  struct dma_fence *fence);
+-int xe_exec_queue_last_fence_test_dep(struct xe_exec_queue *q,
+-				      struct xe_vm *vm);
+ 
+ void xe_exec_queue_tlb_inval_last_fence_put(struct xe_exec_queue *q,
+ 					    struct xe_vm *vm,
+diff --git a/drivers/gpu/drm/xe/xe_pt.c b/drivers/gpu/drm/xe/xe_pt.c
+index 63c4373f4..8376b4b7d 100644
+--- a/drivers/gpu/drm/xe/xe_pt.c
++++ b/drivers/gpu/drm/xe/xe_pt.c
+@@ -1323,13 +1323,6 @@ static int xe_pt_vm_dependencies(struct xe_sched_job *job,
+ 			return err;
+ 	}
+ 
+-	if (!(pt_update_ops->q->flags & EXEC_QUEUE_FLAG_KERNEL)) {
+-		if (job)
+-			err = xe_sched_job_last_fence_add_dep(job, vm);
+-		else
+-			err = xe_exec_queue_last_fence_test_dep(pt_update_ops->q, vm);
+-	}
+-
+ 	for (i = 0; job && !err && i < vops->num_syncs; i++)
+ 		err = xe_sync_entry_add_deps(&vops->syncs[i], job);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_sched_job.c b/drivers/gpu/drm/xe/xe_sched_job.c
+index d21bf8f26..6b63b4daa 100644
+--- a/drivers/gpu/drm/xe/xe_sched_job.c
++++ b/drivers/gpu/drm/xe/xe_sched_job.c
+@@ -295,23 +295,6 @@ void xe_sched_job_push(struct xe_sched_job *job)
+ 	xe_sched_job_put(job);
+ }
+ 
+-/**
+- * xe_sched_job_last_fence_add_dep - Add last fence dependency to job
+- * @job:job to add the last fence dependency to
+- * @vm: virtual memory job belongs to
+- *
+- * Returns:
+- * 0 on success, or an error on failing to expand the array.
+- */
+-int xe_sched_job_last_fence_add_dep(struct xe_sched_job *job, struct xe_vm *vm)
+-{
+-	struct dma_fence *fence;
+-
+-	fence = xe_exec_queue_last_fence_get(job->q, vm);
+-
+-	return drm_sched_job_add_dependency(&job->drm, fence);
+-}
+-
+ /**
+  * xe_sched_job_init_user_fence - Initialize user_fence for the job
+  * @job: job whose user_fence needs an init
+diff --git a/drivers/gpu/drm/xe/xe_sched_job.h b/drivers/gpu/drm/xe/xe_sched_job.h
+index 3dc72c5c1..ff5621bd3 100644
+--- a/drivers/gpu/drm/xe/xe_sched_job.h
++++ b/drivers/gpu/drm/xe/xe_sched_job.h
+@@ -58,7 +58,6 @@ bool xe_sched_job_completed(struct xe_sched_job *job);
+ void xe_sched_job_arm(struct xe_sched_job *job);
+ void xe_sched_job_push(struct xe_sched_job *job);
+ 
+-int xe_sched_job_last_fence_add_dep(struct xe_sched_job *job, struct xe_vm *vm);
+ void xe_sched_job_init_user_fence(struct xe_sched_job *job,
+ 				  struct xe_sync_entry *sync);
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-Skip-TLB-invalidation-waits-in-page-fault-bin.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Skip-TLB-invalidation-waits-in-page-fault-bin.patch
@@ -1,0 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Fri, 31 Oct 2025 16:40:48 -0700
+Subject: drm/xe: Skip TLB invalidation waits in page fault binds
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Avoid waiting on unrelated TLB invalidations when servicing page fault
+binds. Since the migrate queue is shared across processes, TLB
+invalidations triggered by other processes may occur concurrently but
+are not relevant to the current bind. Teach the bind pipeline to skip
+waits on such invalidations to prevent unnecessary serialization.
+
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patch.msgid.link/20251031234050.3043507-5-matthew.brost@intel.com
+(cherry-picked from commit ebb0880d497356befb0ff4d36fb0e1d072701805 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_vm.c       | 14 ++++++++++++--
+ drivers/gpu/drm/xe/xe_vm_types.h |  1 +
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index c4f2e4535..f3c59afd1 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -995,6 +995,7 @@ struct dma_fence *xe_vma_rebind(struct xe_vm *vm, struct xe_vma *vma, u8 tile_ma
+ 	xe_assert(vm->xe, xe_vm_in_fault_mode(vm));
+ 
+ 	xe_vma_ops_init(&vops, vm, NULL, NULL, 0);
++	vops.flags |= XE_VMA_OPS_FLAG_SKIP_TLB_WAIT;
+ 	for_each_tile(tile, vm->xe, id) {
+ 		vops.pt_update_ops[id].wait_vm_bookkeep = true;
+ 		vops.pt_update_ops[tile->id].q =
+@@ -1085,6 +1086,7 @@ struct dma_fence *xe_vm_range_rebind(struct xe_vm *vm,
+ 	xe_assert(vm->xe, xe_vma_is_cpu_addr_mirror(vma));
+ 
+ 	xe_vma_ops_init(&vops, vm, NULL, NULL, 0);
++	vops.flags |= XE_VMA_OPS_FLAG_SKIP_TLB_WAIT;
+ 	for_each_tile(tile, vm->xe, id) {
+ 		vops.pt_update_ops[id].wait_vm_bookkeep = true;
+ 		vops.pt_update_ops[tile->id].q =
+@@ -3243,8 +3245,13 @@ static struct dma_fence *ops_execute(struct xe_vm *vm,
+ 	if (number_tiles == 0)
+ 		return ERR_PTR(-ENODATA);
+ 
+-	for_each_tile(tile, vm->xe, id)
+-		n_fence += (1 + XE_MAX_GT_PER_TILE);
++	if (vops->flags & XE_VMA_OPS_FLAG_SKIP_TLB_WAIT) {
++		for_each_tile(tile, vm->xe, id)
++			++n_fence;
++	} else {
++		for_each_tile(tile, vm->xe, id)
++			n_fence += (1 + XE_MAX_GT_PER_TILE);
++	}
+ 
+ 	fences = kmalloc_array(n_fence, sizeof(*fences), GFP_KERNEL);
+ 	if (!fences) {
+@@ -3285,6 +3292,9 @@ static struct dma_fence *ops_execute(struct xe_vm *vm,
+ 
+ collect_fences:
+ 		fences[current_fence++] = fence ?: dma_fence_get_stub();
++		if (vops->flags & XE_VMA_OPS_FLAG_SKIP_TLB_WAIT)
++			continue;
++
+ 		xe_migrate_job_lock(tile->migrate, q);
+ 		for_each_tlb_inval(i)
+ 			fences[current_fence++] =
+diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
+index e4b184700..3a4a15bce 100644
+--- a/drivers/gpu/drm/xe/xe_vm_types.h
++++ b/drivers/gpu/drm/xe/xe_vm_types.h
+@@ -480,6 +480,7 @@ struct xe_vma_ops {
+ #define XE_VMA_OPS_FLAG_HAS_SVM_PREFETCH BIT(0)
+ #define XE_VMA_OPS_FLAG_MADVISE          BIT(1)
+ #define XE_VMA_OPS_ARRAY_OF_BINDS	 BIT(2)
++#define XE_VMA_OPS_FLAG_SKIP_TLB_WAIT	 BIT(3)
+ 	u32 flags;
+ #ifdef TEST_VM_OPS_ERROR
+ 	/** @inject_error: inject error to test error handling */
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -253,6 +253,12 @@ backport/patches/features/sriov/0001-drm-xe-pf-Allow-to-lockdown-the-PF-using-cu
 backport/patches/features/sriov/0001-drm-xe-Move-VRAM-MM-debugfs-creation-to-tile-level.patch
 backport/patches/features/sriov/0001-drm-xe-migrate-fix-job-lock-assert.patch
 backport/patches/features/sriov/0001-drm-xe-uapi-disallow-bind-queue-sharing.patch
+backport/patches/features/sriov/0001-drm-xe-Enforce-correct-user-fence-signaling-order-us.patch
+backport/patches/features/sriov/0001-drm-xe-Attach-last-fence-to-TLB-invalidation-job-que.patch
+backport/patches/features/sriov/0001-drm-xe-Decouple-bind-queue-last-fence-from-TLB-inval.patch
+backport/patches/features/sriov/0001-drm-xe-Skip-TLB-invalidation-waits-in-page-fault-bin.patch
+backport/patches/features/sriov/0001-drm-xe-Disallow-input-fences-on-zero-batch-execs-and.patch
+backport/patches/features/sriov/0001-drm-xe-Remove-last-fence-dependency-check-from-binds.patch
 # features/vf-double-migration
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Enable-VF-migration-only-on-supported-GuC-.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch


### PR DESCRIPTION
A burst of unbind jobs can create unnecessary dependencies between TLB
invalidations, causing unbinds to serialize and slow down execution.

Update the last-fence handling to avoid these dependencies and improve
performance during unbind bursts.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>