### PR TITLE
drm/xe: Remove unused variables

### DIFF
--- a/patches/0003-drm-xe-Add-debugfs-compatibility-symlinks-for-kernel.patch
+++ b/patches/0003-drm-xe-Add-debugfs-compatibility-symlinks-for-kernel.patch
@@ -11,18 +11,20 @@ numbers (e.g., "0"), allowing UMD to access debugfs entries through either
 path. The symlinks are created at module load and cleaned up at unload
 using debugfs_lookup() to avoid issues during module reload.
 
+V1: Remove unused variables [Raju]
+
 Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
 ---
- drivers/gpu/drm/xe/xe_debugfs.c | 50 +++++++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_debugfs.c | 49 +++++++++++++++++++++++++++++
  drivers/gpu/drm/xe/xe_debugfs.h |  6 ++++
  drivers/gpu/drm/xe/xe_device.c  |  3 ++
- 3 files changed, 59 insertions(+)
+ 3 files changed, 58 insertions(+)
 
 diff --git a/drivers/gpu/drm/xe/xe_debugfs.c b/drivers/gpu/drm/xe/xe_debugfs.c
-index 044f80a..5f6a51e 100644
+index ceadef0..9308593 100644
 --- a/drivers/gpu/drm/xe/xe_debugfs.c
 +++ b/drivers/gpu/drm/xe/xe_debugfs.c
-@@ -55,6 +55,52 @@ static void read_residency_counter(struct xe_device *xe, struct xe_mmio *mmio,
+@@ -55,6 +55,51 @@ static void read_residency_counter(struct xe_device *xe, struct xe_mmio *mmio,
  	drm_printf(p, "%s : %llu\n", name, residency);
  }
  
@@ -33,7 +35,6 @@ index 044f80a..5f6a51e 100644
 +       struct drm_minor *minor = drm->primary;
 +       struct dentry *drm_root, *symlink;
 +       char minor_name[16];
-+       char *buf, *path_ptr;
 +
 +       drm_root = minor->debugfs_root->d_parent;
 +       if (!drm_root)
@@ -75,7 +76,7 @@ index 044f80a..5f6a51e 100644
  static struct xe_device *node_to_xe(struct drm_info_node *node)
  {
  	return to_xe_device(node->minor->dev);
-@@ -436,4 +482,8 @@ void xe_debugfs_register(struct xe_device *xe)
+@@ -424,4 +469,8 @@ void xe_debugfs_register(struct xe_device *xe)
  		xe_sriov_pf_debugfs_register(xe, root);
  	else if (IS_SRIOV_VF(xe))
  		xe_sriov_vf_debugfs_register(xe, root);
@@ -104,7 +105,7 @@ index 17f4c2f..fee9beb 100644
  
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
-index 586d788..b52bdd8 100644
+index b7b00b0..6fbdb55 100644
 --- a/drivers/gpu/drm/xe/xe_device.c
 +++ b/drivers/gpu/drm/xe/xe_device.c
 @@ -427,6 +427,9 @@ static void xe_device_destroy(struct drm_device *dev, void *dummy)


### PR DESCRIPTION
Remove unused 'buf' and 'path_ptr' variables from
xe_debugfs_create_compat_structure() function. These variables
were declared but never used, causing compilation warnings
when building against kernel 6.6:

Warning:
----------------------------------------------------------------------
unused variable 'path_ptr' [-Wunused-variable]
unused variable 'buf' [-Wunused-variable]
----------------------------------------------------------------------

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>