### PR TITLE
autotools/m4: correct upstream commit reference

### DIFF
--- a/autotools/m4/pci.m4
+++ b/autotools/m4/pci.m4
@@ -1,6 +1,6 @@
 dnl #
-dnl # v6.17-c42d50aefd17
-dnl # mm: shrinker: add infrastructure for dynamically allocating shrinker
+dnl # v6.17-84f890414a12
+dnl # PCI/IOV: Allow drivers to control VF BAR size
 dnl #
 AC_DEFUN([AC_PCI_IOV_VF_BAR_FUNCTIONS_NOT_PRESENT], [
 	AC_KERNEL_DO_BACKGROUND([


### PR DESCRIPTION
Correct upstream commit reference in autotools/m4/pci.m4.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>