### PR TITLE
backport/base: Backport RAS feature related patches

### DIFF
--- a/backport/patches/base/0001-PCI-AER-Allow-drivers-to-opt-in-to-Bus-Reset-on-Non-.patch
+++ b/backport/patches/base/0001-PCI-AER-Allow-drivers-to-opt-in-to-Bus-Reset-on-Non-.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lukas Wunner <lukas@wunner.de>
+Date: Wed, 13 Aug 2025 07:11:01 +0200
+Subject: PCI/AER: Allow drivers to opt in to Bus Reset on Non-Fatal Errors
+
+When Advanced Error Reporting was introduced in September 2006 by commit
+6c2b374d7485 ("PCI-Express AER implemetation: AER core and aerdriver"), it
+sought to adhere to the recovery flow and callbacks specified in
+Documentation/PCI/pci-error-recovery.rst.
+
+That document had been added in January 2006, when Enhanced Error Handling
+(EEH) was introduced for PowerPC with commit 065c6359071c ("[PATCH] PCI
+Error Recovery: documentation").
+
+However the AER driver deviates from the document in that it never
+performs a Secondary Bus Reset on Non-Fatal Errors, but always on Fatal
+Errors.  By contrast, EEH allows drivers to opt in or out of a Bus Reset
+regardless of error severity, by returning PCI_ERS_RESULT_NEED_RESET or
+PCI_ERS_RESULT_CAN_RECOVER from their ->error_detected() callback.  If all
+drivers agree that they can recover without a Bus Reset, EEH skips it.
+Should one of them request a Bus Reset, it overrides all other drivers.
+
+This inconsistency between EEH and AER seems problematic because drivers
+need to be aware of and cope with it.
+
+The file Documentation/PCI/pcieaer-howto.rst hints at a rationale for
+always performing a Bus Reset on Fatal Errors:  "Fatal errors [...] cause
+the link to be unreliable.  [...] This [reset_link] callback is used to
+reset the PCIe physical link when a fatal error happens.  If an error
+message indicates a fatal error, [...] performing link reset at upstream
+is necessary."
+
+There's no such rationale provided for never performing a Bus Reset on
+Non-Fatal Errors.
+
+The "xe" driver has a need to attempt a reset of local units on graphics
+cards upon a Non-Fatal Error.  If that is insufficient for recovery, the
+driver wants to opt in to a Bus Reset.
+
+Accommodate such use cases and align AER more closely with EEH by
+performing a Bus Reset in pcie_do_recovery() if drivers request it and the
+faulting device's channel_state is pci_channel_io_normal.  The AER driver
+sets this channel_state for Non-Fatal Errors.  For Fatal Errors, it uses
+pci_channel_io_frozen.
+
+This limits the deviation from Documentation/PCI/pci-error-recovery.rst
+and EEH to the unconditional Bus Reset on Fatal Errors.
+
+pcie_do_recovery() is also invoked by the Downstream Port Containment and
+Error Disconnect Recover drivers.  They both set the channel_state to
+pci_channel_io_frozen, hence pcie_do_recovery() continues to always invoke
+the ->reset_subordinates() callback in their case.  That is necessary
+because the callback brings the link back up at the containing Downstream
+Port.
+
+There are two behavioral changes resulting from this commit:
+
+First, if channel_state is pci_channel_io_normal and one of the affected
+drivers returns PCI_ERS_RESULT_NEED_RESET from its ->error_detected()
+callback, a Bus Reset will now be performed.  There are drivers doing this
+and although it would be possible to avoid a behavioral change by letting
+them return PCI_ERS_RESULT_CAN_RECOVER instead, the impression I got from
+examination of all drivers is that they actually expect or want a Bus
+Reset (cxl_error_detected() is a case in point).  In any case, if they can
+cope with a Bus Reset on Fatal Errors, they shouldn't have issues with a
+Bus Reset on Non-Fatal Errors.
+
+Second, if channel_state is pci_channel_io_frozen and all affected drivers
+return PCI_ERS_RESULT_CAN_RECOVER from ->error_detected(), their
+->mmio_enabled() callback is now invoked prior to performing a Bus Reset,
+instead of afterwards.  This actually makes sense:  For example,
+drivers/scsi/sym53c8xx_2/sym_glue.c dumps debug registers in its
+->mmio_enabled() callback.  Doing so after reset right now captures the
+post-reset state instead of the faulting state, which is useless.
+
+There is only one other driver which implements ->mmio_enabled() and
+returns PCI_ERS_RESULT_CAN_RECOVER from ->error_detected() for
+channel_state pci_channel_io_frozen, drivers/scsi/ipr.c (IBM Power RAID).
+It appears to only be used on EEH platforms.  So the second behavioral
+change is limited to these two drivers.
+
+Signed-off-by: Lukas Wunner <lukas@wunner.de>
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+(backported from commit d0a2dee7d4585a7ebab45bf63eebeb8b6944e88f)
+Signed-off-by: Rachapalli Bandi Jagadeesh <jagadeesh.rachapalli.bandi@intel.com>
+Link: https://patch.msgid.link/28fd805043bb57af390168d05abb30898cf4fc58.1755008151.git.lukas@wunner.de
+---
+ drivers/pci/pcie/err.c | 17 ++++++++++-------
+ 1 file changed, 10 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/pci/pcie/err.c b/drivers/pci/pcie/err.c
+index de6381c690f5..e795e5ae6b03 100644
+--- a/drivers/pci/pcie/err.c
++++ b/drivers/pci/pcie/err.c
+@@ -217,15 +217,10 @@ pci_ers_result_t pcie_do_recovery(struct pci_dev *dev,
+ 	pci_walk_bridge(bridge, pci_pm_runtime_get_sync, NULL);
+ 
+ 	pci_dbg(bridge, "broadcast error_detected message\n");
+-	if (state == pci_channel_io_frozen) {
++	if (state == pci_channel_io_frozen)
+ 		pci_walk_bridge(bridge, report_frozen_detected, &status);
+-		if (reset_subordinates(bridge) != PCI_ERS_RESULT_RECOVERED) {
+-			pci_warn(bridge, "subordinate device reset failed\n");
+-			goto failed;
+-		}
+-	} else {
++	else
+ 		pci_walk_bridge(bridge, report_normal_detected, &status);
+-	}
+ 
+ 	if (status == PCI_ERS_RESULT_CAN_RECOVER) {
+ 		status = PCI_ERS_RESULT_RECOVERED;
+@@ -233,6 +228,14 @@ pci_ers_result_t pcie_do_recovery(struct pci_dev *dev,
+ 		pci_walk_bridge(bridge, report_mmio_enabled, &status);
+ 	}
+ 
++	if (status == PCI_ERS_RESULT_NEED_RESET ||
++	    state == pci_channel_io_frozen) {
++		if (reset_subordinates(bridge) != PCI_ERS_RESULT_RECOVERED) {
++			pci_warn(bridge, "subordinate device reset failed\n");
++			goto failed;
++		}
++	}
++
+ 	if (status == PCI_ERS_RESULT_NEED_RESET) {
+ 		/*
+ 		 * TODO: Should call platform-specific
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-PCI-ERR-Ensure-error-recoverability-at-all-times.patch
+++ b/backport/patches/base/0001-PCI-ERR-Ensure-error-recoverability-at-all-times.patch
@@ -1,0 +1,95 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lukas Wunner <lukas@wunner.de>
+Date: Wed, 19 Nov 2025 09:50:03 +0100
+Subject: PCI/ERR: Ensure error recoverability at all times
+
+When the PCI core gained power management support in 2002, it introduced
+pci_save_state() and pci_restore_state() helpers to restore Config Space
+after a D3hot or D3cold transition, which implies a Soft or Fundamental
+Reset (PCIe r7.0 sec 5.8):
+
+  https://git.kernel.org/tglx/history/c/a5287abe398b
+
+In 2006, EEH and AER were introduced to recover from errors by performing
+a reset.  Because errors can occur at any time, drivers began calling
+pci_save_state() on probe to ensure recoverability.
+
+In 2009, recoverability was foiled by commit c82f63e411f1 ("PCI: check
+saved state before restore"):  It amended pci_restore_state() to bail out
+if the "state_saved" flag has been cleared.  The flag is cleared by
+pci_restore_state() itself, hence a saved state is now allowed to be
+restored only once and is then invalidated.  That doesn't seem to make
+sense because the saved state should be good enough to be reused.
+
+Soon after, drivers began to work around this behavior by calling
+pci_save_state() immediately after pci_restore_state(), see e.g. commit
+b94f2d775a71 ("igb: call pci_save_state after pci_restore_state").
+Hilariously, two drivers even set the "saved_state" flag to true before
+invoking pci_restore_state(), see ipr_reset_restore_cfg_space() and
+e1000_io_slot_reset().
+
+Despite these workarounds, recoverability at all times is not guaranteed:
+E.g. when a PCIe port goes through a runtime suspend and resume cycle,
+the "saved_state" flag is cleared by:
+
+  pci_pm_runtime_resume()
+    pci_pm_default_resume_early()
+      pci_restore_state()
+
+... and hence on a subsequent AER event, the port's Config Space cannot be
+restored.  Riana reports a recovery failure of a GPU-integrated PCIe
+switch and has root-caused it to the behavior of pci_restore_state().
+Another workaround would be necessary, namely calling pci_save_state() in
+pcie_port_device_runtime_resume().
+
+The motivation of commit c82f63e411f1 was to prevent restoring state if
+pci_save_state() hasn't been called before.  But that can be achieved by
+saving state already on device addition, after Config Space has been
+initialized.  A desirable side effect is that devices become recoverable
+even if no driver gets bound.  This renders the commit unnecessary, so
+revert it.
+
+Reported-by: Riana Tauro <riana.tauro@intel.com> # off-list
+Signed-off-by: Lukas Wunner <lukas@wunner.de>
+Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
+Tested-by: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Rafael J. Wysocki (Intel) <rafael@kernel.org>
+(backported from commit a2f1e22390ac2ca7ac8d77aa0f78c068b6dd2208)
+Signed-off-by: Rachapalli Bandi Jagadeesh <jagadeesh.rachapalli.bandi@intel.com>
+Link: https://patch.msgid.link/9e34ce61c5404e99ffdd29205122c6fb334b38aa.1763483367.git.lukas@wunner.de
+---
+ drivers/pci/bus.c | 3 +++
+ drivers/pci/pci.c | 3 ---
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/pci/bus.c b/drivers/pci/bus.c
+index 826b5016a..c6d752a5f 100644
+--- a/drivers/pci/bus.c
++++ b/drivers/pci/bus.c
+@@ -348,6 +348,9 @@ void pci_bus_add_device(struct pci_dev *dev)
+ 	pci_proc_attach_device(dev);
+ 	pci_bridge_d3_update(dev);
+ 
++	/* Save config space for error recoverability */
++	pci_save_state(dev);
++
+ 	dev->match_driver = !dn || of_device_is_available(dn);
+ 	retval = device_attach(&dev->dev);
+ 	if (retval < 0 && retval != -EPROBE_DEFER)
+diff --git a/drivers/pci/pci.c b/drivers/pci/pci.c
+index 9a3f6bb60..c30788dc5 100644
+--- a/drivers/pci/pci.c
++++ b/drivers/pci/pci.c
+@@ -1843,9 +1843,6 @@ static void pci_restore_rebar_state(struct pci_dev *pdev)
+  */
+ void pci_restore_state(struct pci_dev *dev)
+ {
+-	if (!dev->state_saved)
+-		return;
+-
+ 	/*
+ 	 * Restore max latencies (in the LTR capability) before enabling
+ 	 * LTR itself (in the PCIe capability).
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -1,3 +1,5 @@
 # base
 backport/patches/base/0001-vfio-Create-vfio_fs_type-with-inode-per-device.patch
 backport/patches/base/0001-vfio-pci-Use-unmap_mapping_range.patch
+backport/patches/base/0001-PCI-AER-Allow-drivers-to-opt-in-to-Bus-Reset-on-Non-.patch
+backport/patches/base/0001-PCI-ERR-Ensure-error-recoverability-at-all-times.patch


### PR DESCRIPTION
This backports two related fixes for RAS address translation.
First patch ensures correct handling of specific memory types.
Second patch addresses edge cases identified during further validation.

Signed-off-by: Rachapalli Bandi Jagadeesh <jagadeesh.rachapalli.bandi@intel.com>