### PR TITLE
drm/xe/debugfs: Add back missing GT stats entry

### DIFF
--- a/backport/patches/features/sriov/0001-drm-xe-debugfs-Add-back-missing-GT-stats-entry.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-debugfs-Add-back-missing-GT-stats-entry.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+Date: Tue, 3 Mar 2026 07:59:25 +0530
+Subject: drm/xe/debugfs: Add back missing GT stats entry
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Restore the stats debugfs entry that was dropped during rebase.
+
+Fixes: 91580d87eb58 (“drm/xe/debugfs: Improve .show() helper for GT-based attributes”)
+
+Signed-off-by: Nirmoy Das <nirmoy.das@intel.com>i
+(backported from commit acc4e41ec41fa28ae9fbdb1a2750525a7a242743 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_debugfs.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_debugfs.c b/drivers/gpu/drm/xe/xe_gt_debugfs.c
+index b9ad85f8d9535..2e07384e0b385 100644
+--- a/drivers/gpu/drm/xe/xe_gt_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_gt_debugfs.c
+@@ -219,6 +219,7 @@ static const struct drm_info_list vf_safe_debugfs_list[] = {
+ 	{ "default_lrc_bcs", .show = xe_gt_debugfs_show_with_rpm, .data = bcs_default_lrc },
+ 	{ "default_lrc_vcs", .show = xe_gt_debugfs_show_with_rpm, .data = vcs_default_lrc },
+ 	{ "default_lrc_vecs", .show = xe_gt_debugfs_show_with_rpm, .data = vecs_default_lrc },
++	{ "stats", .show = xe_gt_debugfs_simple_show, .data = xe_gt_stats_print_info },
+ 	{ "hwconfig", .show = xe_gt_debugfs_show_with_rpm, .data = hwconfig },
+ };
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -259,6 +259,7 @@ backport/patches/features/sriov/0001-drm-xe-Decouple-bind-queue-last-fence-from-
 backport/patches/features/sriov/0001-drm-xe-Skip-TLB-invalidation-waits-in-page-fault-bin.patch
 backport/patches/features/sriov/0001-drm-xe-Disallow-input-fences-on-zero-batch-execs-and.patch
 backport/patches/features/sriov/0001-drm-xe-Remove-last-fence-dependency-check-from-binds.patch
+backport/patches/features/sriov/0001-drm-xe-debugfs-Add-back-missing-GT-stats-entry.patch
 # features/vf-double-migration
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Enable-VF-migration-only-on-supported-GuC-.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch


### PR DESCRIPTION
Restore the stats debugfs entry that was dropped during rebase.

Fixes: 91580d87eb58 ("drm/xe/debugfs: Improve .show() helper for GT-based attributes")

Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>