### PR TITLE
drm/xe: Backport upstream fixes set 3

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-Do-not-preempt-fence-signaling-CS-instruction.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-Do-not-preempt-fence-signaling-CS-instruction.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Wed, 14 Jan 2026 16:45:46 -0800
+Subject: drm/xe: Do not preempt fence signaling CS instructions
+
+If a batch buffer is complete, it makes little sense to preempt the
+fence signaling instructions in the ring, as the largest portion of the
+work (the batch buffer) is already done and fence signaling consists of
+only a few instructions. If these instructions are preempted, the GuC
+would need to perform a context switch just to signal the fence, which
+is costly and delays fence signaling. Avoid this scenario by disabling
+preemption immediately after the BB start instruction and re-enabling it
+after executing the fence signaling instructions.
+
+Fixes: dd08ebf6c352 ("drm/xe: Introduce a new DRM driver for Intel GPUs")
+Cc: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Cc: Carlos Santa <carlos.santa@intel.com>
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Link: https://patch.msgid.link/20260115004546.58060-1-matthew.brost@intel.com
+(cherry-picked from commit 2bcbf2dcde0c839a73af664a3c77d4e77d58a3eb linux-next)
+Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>
+---
+ drivers/gpu/drm/xe/xe_ring_ops.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_ring_ops.c b/drivers/gpu/drm/xe/xe_ring_ops.c
+index 591e495c41f2..c58f26f02fcd 100644
+--- a/drivers/gpu/drm/xe/xe_ring_ops.c
++++ b/drivers/gpu/drm/xe/xe_ring_ops.c
+@@ -267,6 +267,9 @@ static void __emit_job_gen12_simple(struct xe_sched_job *job, struct xe_lrc *lrc
+ 
+ 	i = emit_bb_start(batch_addr, ppgtt_flag, dw, i);
+ 
++	/* Don't preempt fence signaling */
++	dw[i++] = MI_ARB_ON_OFF | MI_ARB_DISABLE;
++
+ 	if (job->user_fence.used) {
+ 		i = emit_flush_dw(dw, i);
+ 		i = emit_store_imm_ppgtt_posted(job->user_fence.addr,
+@@ -332,6 +335,9 @@ static void __emit_job_gen12_video(struct xe_sched_job *job, struct xe_lrc *lrc,
+ 
+ 	i = emit_bb_start(batch_addr, ppgtt_flag, dw, i);
+ 
++	/* Don't preempt fence signaling */
++	dw[i++] = MI_ARB_ON_OFF | MI_ARB_DISABLE;
++
+ 	if (job->user_fence.used) {
+ 		i = emit_flush_dw(dw, i);
+ 		i = emit_store_imm_ppgtt_posted(job->user_fence.addr,
+@@ -384,6 +390,9 @@ static void __emit_job_gen12_render_compute(struct xe_sched_job *job,
+ 
+ 	i = emit_bb_start(batch_addr, ppgtt_flag, dw, i);
+ 
++	/* Don't preempt fence signaling */
++	dw[i++] = MI_ARB_ON_OFF | MI_ARB_DISABLE;
++
+ 	i = emit_render_cache_flush(job, dw, i);
+ 
+ 	if (job->user_fence.used)
+-- 
+2.43.0
+

--- a/backport/patches/fixes/base/0001-drm-xe-gsc-Fix-GSC-proxy-cleanup-on-early-initializa.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-gsc-Fix-GSC-proxy-cleanup-on-early-initializa.patch
@@ -1,0 +1,128 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zhanjun Dong <zhanjun.dong@intel.com>
+Date: Fri, 20 Feb 2026 17:53:08 -0500
+Subject: drm/xe/gsc: Fix GSC proxy cleanup on early initialization
+ failure
+
+xe_gsc_proxy_remove undoes what is done in both xe_gsc_proxy_init and
+xe_gsc_proxy_start; however, if we fail between those 2 calls, it is
+possible that the HW forcewake access hasn't been initialized yet and so
+we hit errors when the cleanup code tries to write GSC register. To
+avoid that, split the cleanup in 2 functions so that the HW cleanup is
+only called if the HW setup was completed successfully.
+
+Since the HW cleanup (interrupt disabling) is now removed from
+xe_gsc_proxy_remove, the cleanup on error paths in xe_gsc_proxy_start
+must be updated to disable interrupts before returning.
+
+Fixes: ff6cd29b690b ("drm/xe: Cleanup unwind of gt initialization")
+Signed-off-by: Zhanjun Dong <zhanjun.dong@intel.com>
+Reviewed-by: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Signed-off-by: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Link: https://patch.msgid.link/20260220225308.101469-1-zhanjun.dong@intel.com
+(backported from commit 2b37c401b265c07b46408b5cb36a4b757c9b5060 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gsc_proxy.c | 43 +++++++++++++++++++++++++------
+ drivers/gpu/drm/xe/xe_gsc_types.h |  2 ++
+ 2 files changed, 37 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gsc_proxy.c b/drivers/gpu/drm/xe/xe_gsc_proxy.c
+index 464282a89..86db37ca2 100644
+--- a/drivers/gpu/drm/xe/xe_gsc_proxy.c
++++ b/drivers/gpu/drm/xe/xe_gsc_proxy.c
+@@ -435,16 +435,12 @@ static int proxy_channel_alloc(struct xe_gsc *gsc)
+ 	return 0;
+ }
+ 
+-static void xe_gsc_proxy_remove(void *arg)
++static void xe_gsc_proxy_stop(struct xe_gsc *gsc)
+ {
+-	struct xe_gsc *gsc = arg;
+ 	struct xe_gt *gt = gsc_to_gt(gsc);
+ 	struct xe_device *xe = gt_to_xe(gt);
+ 	unsigned int fw_ref = 0;
+ 
+-	if (!gsc->proxy.component_added)
+-		return;
+-
+ 	/* disable HECI2 IRQs */
+ 	xe_pm_runtime_get(xe);
+ 	fw_ref = xe_force_wake_get(gt_to_fw(gt), XE_FW_GSC);
+@@ -458,6 +454,30 @@ static void xe_gsc_proxy_remove(void *arg)
+ 	xe_pm_runtime_put(xe);
+ 
+ 	xe_gsc_wait_for_worker_completion(gsc);
++	gsc->proxy.started = false;
++}
++
++static void xe_gsc_proxy_remove(void *arg)
++{
++	struct xe_gsc *gsc = arg;
++	struct xe_gt *gt = gsc_to_gt(gsc);
++	struct xe_device *xe = gt_to_xe(gt);
++
++	if (!gsc->proxy.component_added)
++		return;
++
++	/*
++	* GSC proxy start is an async process that can be ongoing during
++	* Xe module load/unload. Using devm managed action to register
++	* xe_gsc_proxy_stop could cause issues if Xe module unload has
++	* already started when the action is registered, potentially leading
++	* to the cleanup being called at the wrong time. Therefore, instead
++	* of registering a separate devm action to undo what is done in
++	* proxy start, we call it from here, but only if the start has
++	* completed successfully (tracked with the 'started' flag).
++	*/
++	if (gsc->proxy.started)
++		xe_gsc_proxy_stop(gsc);
+ 
+ 	component_del(xe->drm.dev, &xe_gsc_proxy_component_ops);
+ 	gsc->proxy.component_added = false;
+@@ -513,6 +533,7 @@ int xe_gsc_proxy_init(struct xe_gsc *gsc)
+  */
+ int xe_gsc_proxy_start(struct xe_gsc *gsc)
+ {
++	struct xe_gt *gt = gsc_to_gt(gsc);
+ 	int err;
+ 
+ 	/* enable the proxy interrupt in the GSC shim layer */
+@@ -524,12 +545,18 @@ int xe_gsc_proxy_start(struct xe_gsc *gsc)
+ 	 */
+ 	err = xe_gsc_proxy_request_handler(gsc);
+ 	if (err)
+-		return err;
++		goto err_irq_disable;
+ 
+ 	if (!xe_gsc_proxy_init_done(gsc)) {
+-		xe_gt_err(gsc_to_gt(gsc), "GSC FW reports proxy init not completed\n");
+-		return -EIO;
++		xe_gt_err(gt, "GSC FW reports proxy init not completed\n");
++		err = -EIO;
++		goto err_irq_disable;
+ 	}
+ 
++	gsc->proxy.started = true;
+ 	return 0;
++
++err_irq_disable:
++	gsc_proxy_irq_toggle(gsc, false);
++	return err;
+ }
+diff --git a/drivers/gpu/drm/xe/xe_gsc_types.h b/drivers/gpu/drm/xe/xe_gsc_types.h
+index 97c056656..5aaa2a758 100644
+--- a/drivers/gpu/drm/xe/xe_gsc_types.h
++++ b/drivers/gpu/drm/xe/xe_gsc_types.h
+@@ -58,6 +58,8 @@ struct xe_gsc {
+ 		struct mutex mutex;
+ 		/** @proxy.component_added: whether the component has been added */
+ 		bool component_added;
++		/** @proxy.started: whether the proxy has been started */
++		bool started;
+ 		/** @proxy.bo: object to store message to and from the GSC */
+ 		struct xe_bo *bo;
+ 		/** @proxy.to_gsc: map of the memory used to send messages to the GSC */
+-- 
+2.43.0
+

--- a/backport/patches/fixes/base/0001-drm-xe-reg_sr-Fix-leak-on-xa_store-failure.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-reg_sr-Fix-leak-on-xa_store-failure.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shuicheng Lin <shuicheng.lin@intel.com>
+Date: Wed, 4 Feb 2026 17:28:11 +0000
+Subject: drm/xe/reg_sr: Fix leak on xa_store failure
+
+Free the newly allocated entry when xa_store() fails to avoid a memory
+leak on the error path.
+
+v2: use goto fail_free. (Bala)
+
+Fixes: e5283bd4dfec ("drm/xe/reg_sr: Remove register pool")
+Cc: Balasubramani Vivekanandan <balasubramani.vivekanandan@intel.com>
+Cc: Matt Roper <matthew.d.roper@intel.com>
+Signed-off-by: Shuicheng Lin <shuicheng.lin@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patch.msgid.link/20260204172810.1486719-2-shuicheng.lin@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(cherry-picked from commit 6bc6fec71ac45f52db609af4e62bdb96b9f5fadb linux-next)
+Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>
+---
+ drivers/gpu/drm/xe/xe_reg_sr.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_reg_sr.c b/drivers/gpu/drm/xe/xe_reg_sr.c
+index 8f525d6c6765..99b24c428d06 100644
+--- a/drivers/gpu/drm/xe/xe_reg_sr.c
++++ b/drivers/gpu/drm/xe/xe_reg_sr.c
+@@ -110,10 +110,12 @@ int xe_reg_sr_add(struct xe_reg_sr *sr,
+ 	*pentry = *e;
+ 	ret = xa_err(xa_store(&sr->xa, idx, pentry, GFP_KERNEL));
+ 	if (ret)
+-		goto fail;
++		goto fail_free;
+ 
+ 	return 0;
+ 
++fail_free:
++	kfree(pentry);
+ fail:
+ 	xe_gt_err(gt,
+ 		  "discarding save-restore reg %04lx (clear: %08x, set: %08x, masked: %s, mcr: %s): ret=%d\n",
+-- 
+2.43.0
+

--- a/backport/patches/fixes/base/0001-drm-xe-sync-Cleanup-partially-initialized-sync-on-pa.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-sync-Cleanup-partially-initialized-sync-on-pa.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shuicheng Lin <shuicheng.lin@intel.com>
+Date: Thu, 19 Feb 2026 23:35:18 +0000
+Subject: drm/xe/sync: Cleanup partially initialized sync on parse
+ failure
+
+xe_sync_entry_parse() can allocate references (syncobj, fence, chain fence,
+or user fence) before hitting a later failure path. Several of those paths
+returned directly, leaving partially initialized state and leaking refs.
+
+Route these error paths through a common free_sync label and call
+xe_sync_entry_cleanup(sync) before returning the error.
+
+Fixes: dd08ebf6c352 ("drm/xe: Introduce a new DRM driver for Intel GPUs")
+Cc: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Shuicheng Lin <shuicheng.lin@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Link: https://patch.msgid.link/20260219233516.2938172-5-shuicheng.lin@intel.com
+(cherry-picked from commit f939bdd9207a5d1fc55cced5459858480686ce22 linux-next)
+Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>
+---
+ drivers/gpu/drm/xe/xe_sync.c | 24 +++++++++++++++++-------
+ 1 file changed, 17 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
+index 3926b448dc09..c0ebf82088f8 100644
+--- a/drivers/gpu/drm/xe/xe_sync.c
++++ b/drivers/gpu/drm/xe/xe_sync.c
+@@ -159,8 +159,10 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 
+ 		if (!signal) {
+ 			sync->fence = drm_syncobj_fence_get(sync->syncobj);
+-			if (XE_IOCTL_DBG(xe, !sync->fence))
+-				return -EINVAL;
++			if (XE_IOCTL_DBG(xe, !sync->fence)) {
++				err = -EINVAL;
++				goto free_sync;
++			}
+ 		}
+ 		break;
+ 
+@@ -180,17 +182,21 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 
+ 		if (signal) {
+ 			sync->chain_fence = dma_fence_chain_alloc();
+-			if (!sync->chain_fence)
+-				return -ENOMEM;
++			if (!sync->chain_fence) {
++				err = -ENOMEM;
++				goto free_sync;
++			}
+ 		} else {
+ 			sync->fence = drm_syncobj_fence_get(sync->syncobj);
+-			if (XE_IOCTL_DBG(xe, !sync->fence))
+-				return -EINVAL;
++			if (XE_IOCTL_DBG(xe, !sync->fence)) {
++				err = -EINVAL;
++				goto free_sync;
++			}
+ 
+ 			err = dma_fence_chain_find_seqno(&sync->fence,
+ 							 sync_in.timeline_value);
+ 			if (err)
+-				return err;
++				goto free_sync;
+ 		}
+ 		break;
+ 
+@@ -232,6 +238,10 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 	sync->timeline_value = sync_in.timeline_value;
+ 
+ 	return 0;
++
++free_sync:
++	xe_sync_entry_cleanup(sync);
++	return err;
+ }
+ ALLOW_ERROR_INJECTION(xe_sync_entry_parse, ERRNO);
+ 
+-- 
+2.43.0
+

--- a/backport/patches/fixes/base/0001-drm-xe-xe2_hpg-Drop-invalid-workaround-Wa_1501059973.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-xe2_hpg-Drop-invalid-workaround-Wa_1501059973.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Roper <matthew.d.roper@intel.com>
+Date: Mon, 23 Feb 2026 16:11:33 -0800
+Subject: drm/xe/xe2_hpg: Drop invalid workaround Wa_15010599737
+
+Wa_15010599737 was a workaround originally proposed (and ultimately
+rejected) for DG2-G10.  There's no record of it ever being relevant or
+even considered for any other platforms.
+
+The specific bit this workaround was setting is documented as "This bit
+should be set to 1 for the DX9 API and 0 for all other APIs" which means
+that it should almost always be left at the default value of 0 on Linux.
+The register itself is directly accessible from userspace, so in the
+special cases where it might be relevant (e.g., Wine/Proton running
+Windows DX9 apps), the userspace drivers already have the ability to
+change the setting without involvement of the kernel.
+
+Fixes: 7f3ee7d88058 ("drm/xe/xe2hpg: Add initial GT workarounds")
+Reviewed-by: Balasubramani Vivekanandan <balasubramani.vivekanandan@intel.com>
+Link: https://patch.msgid.link/20260223-forupstream-wa_cleanup-v3-2-7f201eb2f172@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(backported from commit 1046bc7b416814833a43af8e66c52b0ea71c2021 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_wa.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_wa.c b/drivers/gpu/drm/xe/xe_wa.c
+index 7c807e3017bb..693a30ed6ad6 100644
+--- a/drivers/gpu/drm/xe/xe_wa.c
++++ b/drivers/gpu/drm/xe/xe_wa.c
+@@ -825,10 +825,6 @@ static const struct xe_rtp_entry_sr lrc_was[] = {
+ 	},
+ 
+ 	/* Xe2_HPG */
+-	{ XE_RTP_NAME("15010599737"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(2001), ENGINE_CLASS(RENDER)),
+-	  XE_RTP_ACTIONS(SET(CHICKEN_RASTER_1, DIS_SF_ROUND_NEAREST_EVEN))
+-	},
+ 	{ XE_RTP_NAME("14019386621"),
+ 	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 2002), ENGINE_CLASS(RENDER)),
+ 	  XE_RTP_ACTIONS(SET(VF_SCRATCHPAD, XE2_VFG_TED_CREDIT_INTERFACE_DISABLE))
+-- 
+2.43.0
+

--- a/backport/patches/fixes/sriov/0001-drm-xe-Remove-never-used-code-in-xe_vm_create.patch
+++ b/backport/patches/fixes/sriov/0001-drm-xe-Remove-never-used-code-in-xe_vm_create.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gwan-gyeong Mun <gwan-gyeong.mun@intel.com>
+Date: Wed, 5 Nov 2025 03:13:11 +0200
+Subject: drm/xe: Remove never used code in xe_vm_create()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Clang is not happy with set but unused variable (this is visible
+with `make LLVM=1` build:
+
+  drivers/gpu/drm/xe/xe_vm.c:1462:11: error: variable 'number_tiles' set
+  but not used [-Werror,-Wunused-but-set-variable]
+
+The use of this variable was removed in the commit mentioned below as
+"Fixes:" but only its declaration and update remain.
+It seems like the variable is not used along with the assignment that
+does not have side effects as far as I can see.
+Remove those altogether.
+
+Fixes: cb99e12ba8cb ("drm/xe: Decouple bind queue last fence from TLB invalidations")
+Signed-off-by: Gwan-gyeong Mun <gwan-gyeong.mun@intel.com>
+Reviewed-by: Michał Winiarski <michal.winiarski@intel.com>
+Link: https://patch.msgid.link/20251105011311.3177875-1-gwan-gyeong.mun@intel.com
+Signed-off-by: Michał Winiarski <michal.winiarski@intel.com>
+(cherry-picked from commit 424e2cce078255c1ccaf7d30ec1508ea5d1b89b1 linux-next)
+Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>
+---
+ drivers/gpu/drm/xe/xe_vm.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 11bb90a54bbb..9ebb8a399c76 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -1742,7 +1742,7 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
+ 	struct xe_validation_ctx ctx;
+ 	struct drm_exec exec;
+ 	struct xe_vm *vm;
+-	int err, number_tiles = 0;
++	int err;
+ 	struct xe_tile *tile;
+ 	u8 id;
+ 
+@@ -1911,7 +1911,6 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
+ 				goto err_close;
+ 			}
+ 			vm->q[id] = q;
+-			number_tiles++;
+ 		}
+ 	}
+ 
+-- 
+2.43.0
+

--- a/backport/patches/fixes/sriov/0001-drm-xe-queue-Call-fini-on-exec-queue-creation-fail.patch
+++ b/backport/patches/fixes/sriov/0001-drm-xe-queue-Call-fini-on-exec-queue-creation-fail.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tomasz Lis <tomasz.lis@intel.com>
+Date: Thu, 26 Feb 2026 22:26:58 +0100
+Subject: drm/xe/queue: Call fini on exec queue creation fail
+
+Every call to queue init should have a corresponding fini call.
+Skipping this would mean skipping removal of the queue from GuC list
+(which is part of guc_id allocation). A damaged queue stored in
+exec_queue_lookup list would lead to invalid memory reference,
+sooner or later.
+
+Call fini to free guc_id. This must be done before any internal
+LRCs are freed.
+
+Since the finalization with this extra call became very similar to
+__xe_exec_queue_fini(), reuse that. To make this reuse possible,
+alter xe_lrc_put() so it can survive NULL parameters, like other
+similar functions.
+
+v2: Reuse _xe_exec_queue_fini(). Make xe_lrc_put() aware of NULLs.
+
+Fixes: 3c1fa4aa60b1 ("drm/xe: Move queue init before LRC creation")
+Signed-off-by: Tomasz Lis <tomasz.lis@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com> (v1)
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://patch.msgid.link/20260226212701.2937065-2-tomasz.lis@intel.com
+(cherry-picked from commit 393e5fea6f7d7054abc2c3d97a4cfe8306cd6079 linux-next)
+Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>
+---
+ drivers/gpu/drm/xe/xe_exec_queue.c | 23 +++++++++++------------
+ drivers/gpu/drm/xe/xe_lrc.h        |  3 ++-
+ 2 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index 8b472ff65833..bb03e2358f44 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -163,6 +163,16 @@ static struct xe_exec_queue *__xe_exec_queue_alloc(struct xe_device *xe,
+ 	return q;
+ }
+ 
++static void __xe_exec_queue_fini(struct xe_exec_queue *q)
++{
++	int i;
++
++	q->ops->fini(q);
++
++	for (i = 0; i < q->width; ++i)
++		xe_lrc_put(q->lrc[i]);
++}
++
+ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
+ {
+ 	int i, err;
+@@ -220,21 +230,10 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
+ 	return 0;
+ 
+ err_lrc:
+-	for (i = i - 1; i >= 0; --i)
+-		xe_lrc_put(q->lrc[i]);
++	__xe_exec_queue_fini(q);
+ 	return err;
+ }
+ 
+-static void __xe_exec_queue_fini(struct xe_exec_queue *q)
+-{
+-	int i;
+-
+-	q->ops->fini(q);
+-
+-	for (i = 0; i < q->width; ++i)
+-		xe_lrc_put(q->lrc[i]);
+-}
+-
+ struct xe_exec_queue *xe_exec_queue_create(struct xe_device *xe, struct xe_vm *vm,
+ 					   u32 logical_mask, u16 width,
+ 					   struct xe_hw_engine *hwe, u32 flags,
+diff --git a/drivers/gpu/drm/xe/xe_lrc.h b/drivers/gpu/drm/xe/xe_lrc.h
+index 2fb628da5c43..96ae31df3359 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.h
++++ b/drivers/gpu/drm/xe/xe_lrc.h
+@@ -73,7 +73,8 @@ static inline struct xe_lrc *xe_lrc_get(struct xe_lrc *lrc)
+  */
+ static inline void xe_lrc_put(struct xe_lrc *lrc)
+ {
+-	kref_put(&lrc->refcount, xe_lrc_destroy);
++	if (lrc)
++		kref_put(&lrc->refcount, xe_lrc_destroy);
+ }
+ 
+ /**
+-- 
+2.43.0
+

--- a/backport/patches/fixes/sriov/0001-drm-xe-sync-Fix-user-fence-leak-on-alloc-failure.patch
+++ b/backport/patches/fixes/sriov/0001-drm-xe-sync-Fix-user-fence-leak-on-alloc-failure.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shuicheng Lin <shuicheng.lin@intel.com>
+Date: Thu, 19 Feb 2026 23:35:19 +0000
+Subject: drm/xe/sync: Fix user fence leak on alloc failure
+
+When dma_fence_chain_alloc() fails, properly release the user fence
+reference to prevent a memory leak.
+
+Fixes: adda4e855ab6 ("drm/xe: Enforce correct user fence signaling order using")
+Cc: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Shuicheng Lin <shuicheng.lin@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Link: https://patch.msgid.link/20260219233516.2938172-6-shuicheng.lin@intel.com
+(cherry-picked from commit a5d5634cde48a9fcd68c8504aa07f89f175074a0 linux-next)
+Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>
+---
+ drivers/gpu/drm/xe/xe_sync.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
+index f0b0eaf1a709..3926b448dc09 100644
+--- a/drivers/gpu/drm/xe/xe_sync.c
++++ b/drivers/gpu/drm/xe/xe_sync.c
+@@ -214,8 +214,10 @@ int xe_sync_entry_parse(struct xe_device *xe, struct xe_file *xef,
+ 			if (XE_IOCTL_DBG(xe, IS_ERR(sync->ufence)))
+ 				return PTR_ERR(sync->ufence);
+ 			sync->ufence_chain_fence = dma_fence_chain_alloc();
+-			if (!sync->ufence_chain_fence)
+-				return -ENOMEM;
++			if (!sync->ufence_chain_fence) {
++				err = -ENOMEM;
++				goto free_sync;
++			}
+ 			sync->ufence_syncobj = ufence_syncobj;
+ 		}
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -308,6 +308,14 @@ backport/patches/fixes/base/0001-drm-xe-nvm-Manage-nvm-aux-cleanup-with-devres.p
 backport/patches/fixes/base/0001-drm-xe-guc-Fix-CFI-violation-in-debugfs-access.patch
 backport/patches/fixes/sriov/0001-drm-xe-pf-Fix-sysfs-initialization.patch
 backport/patches/fixes/base/0001-drm-xe-bo-Redirect-faults-to-dummy-page-for-wedged-d.patch
+backport/patches/fixes/sriov/0001-drm-xe-Remove-never-used-code-in-xe_vm_create.patch
+backport/patches/fixes/base/0001-drm-xe-sync-Cleanup-partially-initialized-sync-on-pa.patch
+backport/patches/fixes/sriov/0001-drm-xe-sync-Fix-user-fence-leak-on-alloc-failure.patch
+backport/patches/fixes/base/0001-drm-xe-xe2_hpg-Drop-invalid-workaround-Wa_1501059973.patch
+backport/patches/fixes/base/0001-drm-xe-Do-not-preempt-fence-signaling-CS-instruction.patch
+backport/patches/fixes/sriov/0001-drm-xe-queue-Call-fini-on-exec-queue-creation-fail.patch
+backport/patches/fixes/base/0001-drm-xe-gsc-Fix-GSC-proxy-cleanup-on-early-initializa.patch
+backport/patches/fixes/base/0001-drm-xe-reg_sr-Fix-leak-on-xa_store-failure.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Backport multiple bug fixes from upstream.

v2: Including the VF MCR-table initialization patch('drm/xe/vf: Allow VF
    to initialize MCR tables') is required together with:
    `drm/xe/wa: Steer RMW of MCR registers while building default LRC`,
    otherwise VF can hit MCR steering-table warnings during default LRC setup.

Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>