### PR TITLE
Introduce explicit oot  mode in backport script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ Since it is just for showcasing the capabilities of the next-gen GPUs so quality
 |-- |---|-- |
 |1. | Patches from drm-tip.| backport/patches/base | |
 |2. | Feature patches send to public mailing list for review |backport/patches/features |
-|3. | Script to create kernel | backport.sh|
-|4. | File containing list of patches to pick-up and apply on top of kernel | series|
+|3. | Out-of-tree patches for kernel compatibility | backport/patches/oot |
+|4. | Script to create kernel | backport.sh|
+|5. | File containing list of patches to pick-up and apply on top of kernel | series|
 
 Note: 
 1. Patches present in base will be removed once merged in mainline kernel.
 2. Patches present in features are dynamic in nature, they may change frequently and removed once merged in drm-tip.
 3. Patches present in features will use prelim uapi to aviod conflict in updates, once patches are merged in drm-tip, uapi will change from prelim to normal.
-4. prelim uapi will be maintained at [drm-uapi-helper](https://github.com/intel-gpu/drm-uapi-helper/tree/xe).
+4. Patches present in oot directory are applied only when using the `-c -m` option and are excluded by default to maintain standard kernel integration.
+5. prelim uapi will be maintained at [drm-uapi-helper](https://github.com/intel-gpu/drm-uapi-helper/tree/xe).
 
 # Available Branches
 
@@ -35,14 +37,29 @@ Note:
 # Usage
 We download a stable Linux kernel and maintain all custom changes as patch files listed in series files.
 These patches are organized in the base and features directories. When creating a kernel tree, the patches from the series files are applied on top of the downloaded kernel, resulting in a custom kernel tree with all required changes.
-backport.sh < options >
 
-||options |description |
-|-- |--|--| 
-|1. |create-tree| Create kernel tree based on given option <base/features> (default)|
-|2. |delete-tree| Delete the tree|
-|3. |reset-tree| Delete the existing tree and re-create it|
-|4. |override| Overrides existing tree|
+```bash
+./backport.sh [options]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-c, --create-tree [base\|features]` | Create kernel tree based on given option (default) |
+| `-c -m, --create-tree --out-of-tree` | Create kernel tree and apply all patches including out-of-tree patches |
+| `-d, --delete-tree` | Delete the tree |
+| `-r, --reset-tree` | Delete the existing tree and re-create it |
+| `-o, --override` | Overrides existing tree |
+| `-h, --help` | Display help message |
+
+## Examples
+
+### Create tree with out-of-tree (OOT) patches included
+```bash
+./backport.sh -c -m
+```
+This applies all patches including those in `backport/patches/oot/` directory, allowing full-kernel integration workflows.
 
 # Debugging
 
@@ -88,10 +105,11 @@ Place the patch in the appropriate directory based on patch type:
 ```
 backport/patches/
 ├── base/           # All fixes and patches merged in drm-tip
-└── features/       # Feature patches under review
-    ├── eu-debug/
-    ├── sriov/
-    └── xe-late-bind-fw/
+├── features/       # Feature patches under review
+│   ├── eu-debug/
+│   ├── sriov/
+│   └── xe-late-bind-fw/
+└── oot/            # Out-of-tree patches for kernel compatibility
 ```
 
 #### Placement Rules:
@@ -99,6 +117,7 @@ backport/patches/
 - **`backport/patches/features/<feature-name>/`** - For new feature patches under review
   - Place feature patches in the appropriate feature subdirectory
   - If the feature directory doesn't exist, create one with a descriptive name
+- **`backport/patches/oot/`** - For out-of-tree patches needed for kernel compatibility (applied only with `-c -m` option)
 
 **Examples:**
 - Bug fix → `backport/patches/base/0001-fix-memory-leak.patch`

--- a/backport.sh
+++ b/backport.sh
@@ -29,17 +29,19 @@ OPTS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 flavor="features"
 is_existing_tree=0
 is_override=0
+is_apply_oot=0
 xkb_tag=""
 
 usage () {
           echo ""
-          echo "Usage: $0 [-c|--create-tree] [-d|--delete-tree] [-r|--reset-tree]"
+          echo "Usage: $0 [-c|--create-tree] [-d|--delete-tree] [-r|--reset-tree] [-c|--create-tree|-m|--out-of-tree] "
           echo ""
           echo "Options:"
           echo "  -c, --create-tree                   	Create kernel tree based on given option <base/features>"
           echo "  -d, --delete-tree    	      		Delete the tree"
           echo "  -r, --reset-tree    	      		Delete the existing tree and re-create it"
           echo "  -o, --override    	      		Overrides the existing tree"
+	  echo "  -c -m, --create-tree --out-of-tree   Create kernel tree (applies all patches including oot)"
           exit 1
 }
 
@@ -48,7 +50,14 @@ apply_patches() {
 	while read p; do
 		case "$p" in \#*)
 			if [ ! -z "$flavor" ]; then
-				echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
+				comment=$(echo $p | tr -d "#" | xargs)
+				if [[ "$comment" == "oot" ]]; then
+					if [ $is_apply_oot -eq 1 ]; then
+						echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
+					fi
+				else
+					echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
+				fi
 				if [[ "$flavor" == "base" ]]; then
 					echo "Only base patches will be  applied"
 					flavor=""
@@ -57,8 +66,15 @@ apply_patches() {
 			else
 				break
 			fi
+			continue
 			;;
 		esac
+		if [[ "$p" == *"/oot/"* ]]; then
+			if [ $is_apply_oot -eq 0 ]; then
+				continue
+			fi
+		fi
+
 		git am -q -s "$WORKING_DIR/$p"
 		if [ $? -ne 0 ]; then
 			echo "Failed to apply patch $p"
@@ -125,8 +141,11 @@ create_kernel_tree () {
 
 	git add  *
 	git commit -s -q -m "base $KERNEL"
-
-	echo "$flavor backport"
+	if [ $is_apply_oot -eq 1 ]; then
+		echo "Applying patches (with oot)"
+	else
+		echo "$flavor backport"
+	fi
 	apply_patches
 }
 
@@ -154,6 +173,19 @@ while [ $# -gt 0 ]; do
 	done
 
         case $1 in
+		-c|--create-tree|-m|--out-of-tree)
+			if [ ! $# -gt 1 ]; then
+				echo "No option provided for creating the tree"
+			else
+				if ([ "$1" == "-c" ] || [ "$1" == "--create-tree" ]) && ([ "$2" == "-m" ] || [ "$2" == "--out-of-tree" ]); then
+					is_apply_oot=1
+	#			else
+	#				flavor=$2
+				fi
+			fi
+			echo "Creating the tree with $flavor"
+			create_kernel_tree
+			exit;;
                 -c|--create-tree|-o|--override)
 			if [ ! $# -gt 1 ]; then
 				echo "No option provided for creating the tree"
@@ -179,4 +211,5 @@ while [ $# -gt 0 ]; do
                         echo "Invalid option: $1"
                         usage
         esac
+	shift
 done

--- a/backport/patches/oot/0001-drm-xe-pf-Handle-VF-BAR-resize-without-PCI-VF-REBAR-.patch
+++ b/backport/patches/oot/0001-drm-xe-pf-Handle-VF-BAR-resize-without-PCI-VF-REBAR-.patch
@@ -1,0 +1,131 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marcin Bernatowicz <marcin.bernatowicz@linux.intel.com>
+Date: Thu, 22 Jan 2026 00:00:00 +0000
+Subject: drm/xe/pf: Handle VF BAR resize without PCI VF REBAR helpers
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Implement VF BAR resizing via the VF Resizable BAR capability directly
+in PCI config space for kernels that lack PCI VF REBAR helper APIs.
+
+Suggested-by: Michał Winiarski <michal.winiarski@intel.com>
+Signed-off-by: Marcin Bernatowicz <marcin.bernatowicz@linux.intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci_sriov.c | 94 +++++++++++++++++++++++++++++--
+ 1 file changed, 90 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci_sriov.c b/drivers/gpu/drm/xe/xe_pci_sriov.c
+index 9ff69c484..1246ffc76 100644
+--- a/drivers/gpu/drm/xe/xe_pci_sriov.c
++++ b/drivers/gpu/drm/xe/xe_pci_sriov.c
+@@ -82,16 +82,102 @@ static void pf_engine_activity_stats(struct xe_device *xe, unsigned int num_vfs,
+ 	}
+ }
+ 
++/*
++ * Backport-only fallback: program VF REBAR directly when PCI-core helpers
++ * are not available.
++ */
++
++#ifndef PCI_EXT_CAP_ID_VF_REBAR
++#define PCI_EXT_CAP_ID_VF_REBAR 0x24 /* VF Resizable BAR */
++#endif
++
++static inline resource_size_t pci_rebar_size_to_bytes(int size)
++{
++	return 1ULL << (size + ilog2((resource_size_t)SZ_1M));
++}
++
++/*
++ * The real 'struct pci_sriov' is PCI-core internal (drivers/pci/pci.h).
++ * This local copy is used only to update pdev->sriov->barsz[].
++ */
++struct pci_sriov {
++	int		pos;			/* Capability position */
++	int		nres;			/* Number of resources */
++	u32		cap;			/* SR-IOV Capabilities */
++	u16		ctrl;			/* SR-IOV Control */
++	u16		total_VFs;		/* Total VFs associated with the PF */
++	u16		initial_VFs;		/* Initial VFs associated with the PF */
++	u16		num_VFs;			/* Number of VFs available */
++	u16		offset;			/* First VF Routing ID offset */
++	u16		stride;			/* Following VF stride */
++	u16		vf_device;		/* VF device ID */
++	u32		pgsz;			/* Page size for BAR alignment */
++	u8		link;			/* Function Dependency Link */
++	u8		max_VF_buses;		/* Max buses consumed by VFs */
++	u16		driver_max_VFs;		/* Max num VFs driver supports */
++	struct pci_dev	*dev;			/* Lowest numbered PF */
++	struct pci_dev	*self;			/* This PF */
++	u32		class;			/* VF device */
++	u8		hdr_type;		/* VF header type */
++	u16		subsystem_vendor;	/* VF subsystem vendor */
++	u16		subsystem_device;	/* VF subsystem device */
++	resource_size_t	barsz[PCI_SRIOV_NUM_BARS]; /* VF BAR size */
++	bool		drivers_autoprobe;	/* Auto probing of VFs by driver */
++};
++
+ static int resize_vf_vram_bar(struct xe_device *xe, int num_vfs)
+ {
+ 	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+-	u32 sizes;
++	resource_size_t size, total;
++	int pos, i, vf_bar_idx = VF_LMEM_BAR - PCI_IOV_RESOURCES;
++	u32 rebar, ctrl;
++	int err;
+ 
+-	sizes = pci_iov_vf_bar_get_sizes(pdev, VF_LMEM_BAR, num_vfs);
+-	if (!sizes)
++	pos = pci_find_ext_capability(pdev, PCI_EXT_CAP_ID_VF_REBAR);
++	if (!pos)
+ 		return 0;
+ 
+-	return pci_iov_vf_bar_set_size(pdev, VF_LMEM_BAR, __fls(sizes));
++	/* Expecting a single VF resizable BAR, and it to be BAR2. */
++	err = pci_read_config_dword(pdev, pos + PCI_REBAR_CTRL, &ctrl);
++	if (err)
++		return err;
++
++	if (FIELD_GET(PCI_REBAR_CTRL_NBAR_MASK, ctrl) != 1 ||
++	    FIELD_GET(PCI_REBAR_CTRL_BAR_IDX, ctrl) != vf_bar_idx) {
++		xe_sriov_warn(xe, "Unexpected resource in VF resizable BAR, skipping resize\\n");
++		return 0;
++	}
++
++	err = pci_read_config_dword(pdev, pos + PCI_REBAR_CAP, &rebar);
++	if (err)
++		return err;
++
++	rebar = FIELD_GET(PCI_REBAR_CAP_SIZES, rebar);
++	total = pci_resource_len(pdev, VF_LMEM_BAR);
++
++	while (rebar) {
++		i = __fls(rebar);
++		size = pci_rebar_size_to_bytes(i);
++
++		if (num_vfs && size <= div_u64(total, num_vfs)) {
++			ctrl &= ~PCI_REBAR_CTRL_BAR_SIZE;
++			ctrl |= i << PCI_REBAR_CTRL_BAR_SHIFT;
++
++			err = pci_write_config_dword(pdev, pos + PCI_REBAR_CTRL, ctrl);
++			if (err)
++				return err;
++
++			((struct pci_sriov *)pdev->sriov)->barsz[vf_bar_idx] = size;
++
++			xe_sriov_info(xe, "VF BAR%d resized to %llu MiB\\n",
++				      vf_bar_idx, (unsigned long long)(size >> 20));
++			break;
++		}
++
++		rebar &= ~BIT(i);
++	}
++
++	return 0;
+ }
+ 
+ static int pf_prepare_vfs_enabling(struct xe_device *xe)
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -380,3 +380,5 @@ backport/patches/features/eu-debug/0001-drm-xe-eudebug-add-eudebug-drm-managed-f
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Check-attention-bits-only-once-in-att.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-xe_eudebug_init-fixup.patch
 backport/patches/features/eu-debug/0001-drm-xe-oa-Fix-NULL-pointer-dereference-in-sync-parsi.patch
+# oot
+backport/patches/oot/0001-drm-xe-pf-Handle-VF-BAR-resize-without-PCI-VF-REBAR-.patch


### PR DESCRIPTION
1. Add -m / --dkms option (with -dkms compatibility alias)
2. Keep default create-tree behavior as non-DKMS (exclude dkms patches)
3. Make DKMS mode apply all patches, including dkms patches using
./backport.sh -m
4. Update README usage/options and examples to document new behavior
5. This helps other components continue working on full-kernel
integration instead of being forced into DKMS-only flow.

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>