### PR TITLE
backport/compat: Fix hrtimer_setup to set callback function

### DIFF
--- a/backport/compat/hrtimer.c
+++ b/backport/compat/hrtimer.c
@@ -43,6 +43,7 @@ void hrtimer_setup(struct hrtimer *timer, enum hrtimer_restart (*function)(struc
                    clockid_t clock_id, enum hrtimer_mode mode)
 {
         hrtimer_init(timer, clock_id, mode);
+        timer->function = function;
 }
 EXPORT_SYMBOL_GPL(hrtimer_setup);
 


### PR DESCRIPTION
The hrtimer_setup() backport was incomplete - it called hrtimer_init()
but didn't set timer->function, causing NULL pointer warnings when
hrtimer_start_range_ns() validated the callback.

In kernel 6.6, hrtimer_init() zeros the entire timer structure including
the function pointer. The backport now properly sets timer->function
after initialization, matching the expected behavior of hrtimer_setup()
introduced in kernel 6.13.

Fixes xe_oa test warning: "WARNING at kernel/time/hrtimer.c:1337"

Error:
-------------------------------------------------------------------------------
WARNING: at kernel/time/hrtimer.c:1337 hrtimer_start_range_ns+0x3c0/0x550
RIP: 0010:hrtimer_start_range_ns+0x3c0/0x550
Call Trace:
 <TASK>
 ? xe_mmio_write32+0xe2/0x130 [xe]
 systemd-journald[500]: Compressed data object 1020 -> 561 using ZSTD
 xe_oa_enable_locked+0x317/0x340 [xe]
 xe_oa_stream_open_ioctl+0xad9/0xef0 [xe]
 ? __pfx_xe_observation_ioctl+0x10/0x10 [xe]
 xe_observation_ioctl+0x76/0xd0 [xe]
 drm_ioctl_kernel+0xe5/0x1a0
 drm_ioctl+0x2da/0x560
 ? __pfx_xe_observation_ioctl+0x10/0x10 [xe]
-------------------------------------------------------------------------------

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>