### PR TITLE
drm/xe/xe2_hpg: Backport upstream fix for Wa_16025250150

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-xe2_hpg-Correct-implementation-of-Wa_16025250.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-xe2_hpg-Correct-implementation-of-Wa_16025250.patch
@@ -1,0 +1,52 @@
+From 89536a30e6210a3465bf8f97defb56ac2fa54eac Mon Sep 17 00:00:00 2001
+From: Matt Roper <matthew.d.roper@intel.com>
+Date: Fri, 27 Feb 2026 08:43:41 -0800
+Subject: drm/xe/xe2_hpg: Correct implementation of Wa_16025250150
+
+Wa_16025250150 asks us to set five register fields of the register to
+0x1 each.  However we were just OR'ing this into the existing register
+value (which has a default of 0x4 for each nibble-sized field) resulting
+in final field values of 0x5 instead of the desired 0x1.  Correct the
+RTP programming (use FIELD_SET instead of SET) to ensure each field is
+assigned to exactly the value we want.
+
+Cc: Aradhya Bhatia <aradhya.bhatia@intel.com>
+Cc: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Cc: stable@vger.kernel.org # v6.16+
+Fixes: 7654d51f1fd8 ("drm/xe/xe2hpg: Add Wa_16025250150")
+Reviewed-by: Ngai-Mint Kwan <ngai-mint.kwan@linux.intel.com>
+Link: https://patch.msgid.link/20260227164341.3600098-2-matthew.d.roper@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(backported from commit d139209ef88e48af1f6731cd45440421c757b6b5 linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_wa.c | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_wa.c b/drivers/gpu/drm/xe/xe_wa.c
+index 7c807e301..6cb01e1b8 100644
+--- a/drivers/gpu/drm/xe/xe_wa.c
++++ b/drivers/gpu/drm/xe/xe_wa.c
+@@ -235,12 +235,13 @@ static const struct xe_rtp_entry_sr gt_was[] = {
+ 
+ 	{ XE_RTP_NAME("16025250150"),
+ 	  XE_RTP_RULES(GRAPHICS_VERSION(2001)),
+-	  XE_RTP_ACTIONS(SET(LSN_VC_REG2,
+-			     LSN_LNI_WGT(1) |
+-			     LSN_LNE_WGT(1) |
+-			     LSN_DIM_X_WGT(1) |
+-			     LSN_DIM_Y_WGT(1) |
+-			     LSN_DIM_Z_WGT(1)))
++	  XE_RTP_ACTIONS(FIELD_SET(LSN_VC_REG2,
++				   LSN_LNI_WGT_MASK | LSN_LNE_WGT_MASK |
++				   LSN_DIM_X_WGT_MASK | LSN_DIM_Y_WGT_MASK |
++				   LSN_DIM_Z_WGT_MASK,
++				   LSN_LNI_WGT(1) | LSN_LNE_WGT(1) |
++				   LSN_DIM_X_WGT(1) | LSN_DIM_Y_WGT(1) |
++				   LSN_DIM_Z_WGT(1)))
+ 	},
+ 
+ 	/* Xe2_HPM */
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -316,6 +316,7 @@ backport/patches/fixes/base/0001-drm-xe-Do-not-preempt-fence-signaling-CS-instru
 backport/patches/fixes/sriov/0001-drm-xe-queue-Call-fini-on-exec-queue-creation-fail.patch
 backport/patches/fixes/base/0001-drm-xe-gsc-Fix-GSC-proxy-cleanup-on-early-initializa.patch
 backport/patches/fixes/base/0001-drm-xe-reg_sr-Fix-leak-on-xa_store-failure.patch
+backport/patches/fixes/base/0001-drm-xe-xe2_hpg-Correct-implementation-of-Wa_16025250.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
This backported fix commit addresses the issue introduced by:
7654d51f1fd8 ("drm/xe/xe2hpg: Add Wa_16025250150")

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>