### PR TITLE
gitignore: Update to remove automacro.h file

### DIFF
--- a/backport/.gitignore
+++ b/backport/.gitignore
@@ -37,3 +37,4 @@ Makefile.in
 config.log
 config.status
 src/backport-include/backport/backport_auto.h*
+src/backport-include/backport/automacro.h*


### PR DESCRIPTION
Update gitignore file to exclude automacro.h file.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>