### PR TITLE
Makefile: Use autoconf instead of .config

### DIFF
--- a/autotools/Makefile.am
+++ b/autotools/Makefile.am
@@ -66,7 +66,7 @@ DEF_VER=@DOLLAR_SIGN@(shell cat debian/changelog.in | head -1 | cut -d '(' -f 2 
 export KBUILD_ONLYXEDIRS := src/drivers/gpu src/include src/scripts src/drivers/platform src/drivers/mtd
 export KBUILD_XEVFIOPCIDIRS := src/drivers/vfio/pci/xe
 export KBUILD_AUTOTOOLS := m4 AUTHORS  ChangeLog  configure.ac  COPYING  INSTALL Makefile  Makefile.am  NEWS  README compile.sh
-XE_TAR_CONTENT=$(KBUILD_ONLYXEDIRS) $(KBUILD_AUTOTOOLS) $(KBUILD_XEVFIOPCIDIRS) src/Makefile* src/local-symbols src/MAINTAINERS \
+XE_TAR_CONTENT=$(KBUILD_ONLYXEDIRS) $(KBUILD_AUTOTOOLS) $(KBUILD_XEVFIOPCIDIRS) src/Makefile* src/local-symbols src/MAINTAINERS src/local-symbols-autoconf \
 	src/Kconfig src/Kconfig.sources src/Kconfig.package.hacks src/COPYING src/versions src/defconfigs src/backport-include src/kconf src/compat
 
 XE_DKMS_MK_CONTROL=$(BACKPORT_DIR)/scripts/backport-mkdebcontrol

--- a/backport/.gitignore
+++ b/backport/.gitignore
@@ -1,6 +1,6 @@
 Kconfig.kernel
 Kconfig.versions
-.kernel_config_md5
+.kernel_autoconf_md5
 .config
 .config.old
 *~

--- a/backport/Makefile
+++ b/backport/Makefile
@@ -16,9 +16,9 @@ KLIB := /lib/modules/$(shell uname -r)/
 KMODPATH_ARG :=
 endif
 KLIB_BUILD ?= $(KLIB)/build/
-KERNEL_CONFIG := $(KLIB_BUILD)/.config
+export KERNEL_AUTOCONF := $(KLIB_BUILD)/include/generated/autoconf.h
 KERNEL_MAKEFILE := $(KLIB_BUILD)/Makefile
-CONFIG_MD5 := $(shell md5sum $(KERNEL_CONFIG) 2>/dev/null | sed 's/\s.*//')
+AUTOCONF_MD5 := $(shell md5sum $(KERNEL_AUTOCONF) 2>/dev/null | sed 's/\s.*//')
 
 # TARGET_KERNEL_NAME with have info about the kernel we are building against i.e., uname -r
 TARGET_KERNEL_NAME=$(shell echo $(KLIB_BUILD) | cut -d "/" -f 4 2>/dev/null || echo 1)
@@ -50,7 +50,7 @@ default:
 mrproper:
 	@test -f .config && $(MAKE) clean || true
 	@rm -f .config
-	@rm -f .kernel_config_md5 Kconfig.versions Kconfig.kernel
+	@rm -f .kernel_autoconf_md5 Kconfig.versions Kconfig.kernel
 	@rm -f backport-include/backport/autoconf.h
 
 .DEFAULT:
@@ -66,10 +66,10 @@ mrproper:
 	echo "| for more options."							;\
 	echo "\\--"									;\
 	false)
-	@set -e ; test -f $(KERNEL_CONFIG) || (						\
+	@set -e ; test -f $(KERNEL_AUTOCONF) || (						\
 	echo "/--------------"								;\
 	echo "| Your kernel headers are incomplete/not installed."			;\
-	echo "| Please install kernel headers, including a .config"			;\
+	echo "| Please install kernel headers, including a autoconf"			;\
 	echo "| file or use the KLIB/KLIB_BUILD make variables to"			;\
 	echo "| set the kernel to build against, e.g."					;\
 	echo "|   make KLIB=/lib/modules/3.1.7/"					;\
@@ -77,27 +77,26 @@ mrproper:
 	echo "| (that isn't currently running.)"					;\
 	echo "\\--"									;\
 	false)
-	@set -e ; if [ "$$(cat .kernel_config_md5 2>/dev/null)" != "$(CONFIG_MD5)" ]	;\
+	@set -e ; if [ "$$(cat .kernel_autoconf_md5 2>/dev/null)" != "$(AUTOCONF_MD5)" ];\
 	then 										\
 		echo -n "Generating local configuration database from kernel ..."	;\
-		grep -v -f local-symbols $(KERNEL_CONFIG) | grep = | (			\
+		grep -v -f local-symbols-autoconf $(KERNEL_AUTOCONF) | grep CONFIG | (	\
 			while read l ; do						\
-				if [ "$${l:0:7}" != "CONFIG_" ] ; then			\
-					continue					;\
-				fi							;\
-				l=$${l:7}						;\
-				n=$${l%%=*}						;\
-				v=$${l#*=}						;\
-				if [ "$$v" = "m" ] ; then				\
+				l=$${l:15}						;\
+				n=$${l%% *}						;\
+				v=$${l#* }						;\
+				if [[ "$$n" == *"_MODULE" ]] ; then			\
+					n=$${n%%_MODULE}				;\
 					echo config $$n					;\
 					echo '    tristate' 				;\
-				elif [ "$$v" = "y" ] ; then				\
+					echo "    default m"				;\
+				elif [ "$$v" = 1 ] ; then				\
 					echo config $$n					;\
 					echo '    bool'					;\
+					echo "    default y"				;\
 				else							\
 					continue					;\
 				fi							;\
-				echo "    default $$v"					;\
 				echo ""							;\
 			done								\
 		) > Kconfig.kernel							;\
@@ -127,7 +126,7 @@ mrproper:
 		done >> Kconfig.versions						;\
 		echo " done."								;\
 	fi										;\
-	echo "$(CONFIG_MD5)" > .kernel_config_md5
+	echo "$(AUTOCONF_MD5)" > .kernel_autoconf_md5
 	@$(MAKE) -f Makefile.real "$@"
 
 .PHONY: defconfig-help

--- a/gentree.py
+++ b/gentree.py
@@ -1020,6 +1020,16 @@ def process(kerneldir, copy_list_file, git_revision=None,
             f.write('%s=\n' % sym)
         f.close()
         git_debug_snapshot(args, "add symbols files")
+
+    autoconf_symbols = configtree.modify_symbols()
+
+    # write autoconf local symbol list -- needed during creation of Kconfig.kernel
+    if not bpid.integrate:
+        f = open(os.path.join(bpid.target_dir, 'local-symbols-autoconf'), 'w')
+        for sym in autoconf_symbols:
+            f.write('%s\n' % sym)
+        f.close()
+
     # also write Kconfig.local, representing all local symbols
     # with a BACKPORTED_ prefix
     f = open(os.path.join(bpid.target_dir, 'Kconfig.local'), 'w')

--- a/lib/kconfig.py
+++ b/lib/kconfig.py
@@ -213,6 +213,14 @@ class ConfigTree(object):
                     syms.append(m.group('sym'))
         return syms
 
+    def modify_symbols(self):
+        modified_syms = []
+        syms = self.symbols()
+        for sym in syms:
+            modified_syms.append(sym + ' 1')
+            modified_syms.append(sym + '_MODULE 1')
+        return modified_syms
+
     def all_selects(self):
         result = []
         for nf in self._walk(self.rootfile):


### PR DESCRIPTION
Makefile: Use kernel autoconf instead of Kernel .config
Kernel .config has been excluded from copying it to headers deb package
to reduce the deb package size from 6.12 kernel.
Since .config is missing in headers deb package, observing below error
during compilation.
To fix this issue, we can use kernel autoconf.h file which has same
configs as .config but are in different format.
Hence Makefile changes are done in accordance with different format.

Error:
-----------------------------------------------------------------------------
Your kernel headers are incomplete/not installed
-----------------------------------------------------------------------------

Reference:
	aaed5c7739be kbuild: slim down package for building external modules

Signed-off-by: Rachapalli Bandi Jagadeesh <jagadeesh.rachapalli.bandi@intel.com>