### PR TITLE
Resolve hunk failure for v6.17.13-260217.28

### DIFF
--- a/patches/0001-drivers-drm-disable-display-by-default-for-xe-oot-module.patch
+++ b/patches/0001-drivers-drm-disable-display-by-default-for-xe-oot-module.patch
@@ -6,23 +6,24 @@ Subject: drivers/gpu: disable display by default for xe oot module
 Disabling display related configs in xe/Kconfig file by default
 for xe only oot module.
 
+V1: Rebase to v6.17.13-260217.28
+
 Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
 ---
  drivers/gpu/drm/xe/Kconfig | 21 +++++++++++----------
  1 file changed, 11 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/Kconfig b/drivers/gpu/drm/xe/Kconfig
-index b51a2bd..c6443c3 100644
+index 14d1741..396ac3c 100644
 --- a/drivers/gpu/drm/xe/Kconfig
 +++ b/drivers/gpu/drm/xe/Kconfig
-@@ -8,18 +8,18 @@ config DRM_XE
+@@ -12,17 +12,17 @@ config DRM_XE
  	select SHMEM
  	select TMPFS
  	select DRM_BUDDY
 -	select DRM_CLIENT_SELECTION
-+	#select DRM_CLIENT_SELECTION
- 	select DRM_EXEC
 -	select DRM_KMS_HELPER
++	#select DRM_CLIENT_SELECTION
 +	#select DRM_KMS_HELPER
  	select DRM_KUNIT_TEST_HELPERS if DRM_XE_KUNIT_TEST != n
 -	select DRM_PANEL
@@ -44,14 +45,13 @@ index b51a2bd..c6443c3 100644
  	select RELAY
  	select IRQ_WORK
  	# xe depends on ACPI_VIDEO when ACPI is enabled
-@@ -51,6 +51,7 @@ config DRM_XE
+@@ -54,6 +54,7 @@ config DRM_XE
  
  config DRM_XE_DISPLAY
  	bool "Enable display support"
 +	depends on n
  	depends on DRM_XE && DRM_XE=m && HAS_IOPORT
- 	select FB_IOMEM_HELPERS
+ 	select FB_IOMEM_HELPERS if DRM_FBDEV_EMULATION
  	select I2C
 -- 
-2.25.1
-
+2.43.0


### PR DESCRIPTION
Removed duplicate DRM_EXEC selection from xe/Kconfig file, which
causes hunk failure. So, rebasing them.

Reference:
    27c0a54e48c6
    drm/xe: Remove duplicate DRM_EXEC selection from Kconfig

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>