### PR TITLE
.gitignore: Correct the path for kernel_autoconf_md5 file

### DIFF
--- a/backport/.gitignore
+++ b/backport/.gitignore
@@ -1,6 +1,6 @@
 Kconfig.kernel
 Kconfig.versions
-.kernel_autoconf_md5
+src/.kernel_autoconf_md5
 .config
 .config.old
 *~


### PR DESCRIPTION
.kernel_autoconf_md5 path is incorrectly added in .gitignore.
Hence .kernel_autoconf_md5 file is not getting ignored and adding to
release repo.
To avoid this problem, need to add proper path for .kernel_autoconf_md5 file
in .gitignore.

Signed-off-by: Rachapalli Bandi Jagadeesh <jagadeesh.rachapalli.bandi@intel.com>