### PR TITLE
drm/xe/pf: Allow changing VF VRAM quota via sysfs

### DIFF
--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-documentation-for-vram_quota.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-documentation-for-vram_quota.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:52 +0100
+Subject: drm/xe/pf: Add documentation for vram_quota
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add initial documentation for recently added VRAM provisioning
+Xe driver specific SR-IOV sysfs files under device/sriov_admin.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Acked-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-11-michal.wajdeczko@intel.com
+(cherry-picked from commit 9ca192cbcd5b9baefdc3c4a0d2740e04a427cd18 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ .../ABI/testing/sysfs-driver-intel-xe-sriov   | 31 +++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/Documentation/ABI/testing/sysfs-driver-intel-xe-sriov b/Documentation/ABI/testing/sysfs-driver-intel-xe-sriov
+index 2fd7e9b7bacc0..326aa09d74440 100644
+--- a/Documentation/ABI/testing/sysfs-driver-intel-xe-sriov
++++ b/Documentation/ABI/testing/sysfs-driver-intel-xe-sriov
+@@ -129,6 +129,37 @@ Description:
+ 			-EIO if FW refuses to change the provisioning.
+ 
+ 
++What:		/sys/bus/pci/drivers/xe/.../sriov_admin/.bulk_profile/vram_quota
++What:		/sys/bus/pci/drivers/xe/.../sriov_admin/vf<n>/profile/vram_quota
++Date:		February 2026
++KernelVersion:	7.0
++Contact:	intel-xe@lists.freedesktop.org
++Description:
++		These files allow to perform initial VFs VRAM provisioning prior to VFs
++		enabling or to change VFs VRAM provisioning once the VFs are enabled.
++		Any non-zero initial VRAM provisioning will block VFs auto-provisioning.
++		Without initial VRAM provisioning those files will show result of the
++		VRAM auto-provisioning performed by the PF once the VFs are enabled.
++		Once the VFs are disabled, all VRAM provisioning will be released.
++		These files are visible only on discrete Intel Xe platforms with VRAM
++		and are writeable only if dynamic VFs VRAM provisioning is supported.
++
++		.bulk_profile/vram_quota: (WO) unsigned integer
++			The amount of the provisioned VRAM in [bytes] for each VF.
++			Actual quota value might be aligned per HW/FW requirements.
++
++		profile/vram_quota: (RW) unsigned integer
++			The amount of the provisioned VRAM in [bytes] for this VF.
++			Actual quota value might be aligned per HW/FW requirements.
++
++			Default is 0 (unprovisioned).
++
++		Writes to these attributes may fail with errors like:
++			-EINVAL if provided input is malformed or not recognized,
++			-EPERM if change is not applicable on given HW/FW,
++			-EIO if FW refuses to change the provisioning.
++
++
+ What:		/sys/bus/pci/drivers/xe/.../sriov_admin/vf<n>/stop
+ Date:		October 2025
+ KernelVersion:	6.19
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-functions-for-VRAM-provisioning.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-functions-for-VRAM-provisioning.patch
@@ -1,0 +1,164 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:45 +0100
+Subject: drm/xe/pf: Add functions for VRAM provisioning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We already have functions to configure VF LMEM (aka VRAM) on the
+tile/GT level, used by the auto-provisioning and debugfs, but we
+also need functions that will work on the device level that will
+configure VRAM on all tiles at once.
+
+We will use these new functions in upcoming patch.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-4-michal.wajdeczko@intel.com
+(cherry-picked from commit 5ae3c886a1f5d54fbd5e477bcbfb4f3154a7247e linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_sriov_pf_provision.c | 106 +++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_sriov_pf_provision.h |   4 +
+ 2 files changed, 110 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_provision.c b/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
+index 01470c42e8a72..f22ff65c59aa0 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
+@@ -7,6 +7,7 @@
+ #include "xe_device.h"
+ #include "xe_gt_sriov_pf_config.h"
+ #include "xe_gt_sriov_pf_policy.h"
++#include "xe_lmtt.h"
+ #include "xe_sriov.h"
+ #include "xe_sriov_pf_helpers.h"
+ #include "xe_sriov_pf_provision.h"
+@@ -436,3 +437,108 @@ int xe_sriov_pf_provision_query_vf_priority(struct xe_device *xe, unsigned int v
+ 
+ 	return !count ? -ENODATA : 0;
+ }
++
++static u64 vram_per_tile(struct xe_tile *tile, u64 total)
++{
++	struct xe_device *xe = tile->xe;
++	unsigned int tcount = xe->info.tile_count;
++	u64 alignment = xe_lmtt_page_size(&tile->sriov.pf.lmtt);
++
++	total = round_up(total, tcount * alignment);
++	return div_u64(total, tcount);
++}
++
++/**
++ * xe_sriov_pf_provision_bulk_apply_vram() - Change VRAM provisioning for all VFs.
++ * @xe: the PF &xe_device
++ * @size: the VRAM size in [bytes] to set
++ *
++ * Change all VFs VRAM (LMEM) provisioning on all tiles.
++ *
++ * This function can only be called on PF.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_sriov_pf_provision_bulk_apply_vram(struct xe_device *xe, u64 size)
++{
++	unsigned int num_vfs = xe_sriov_pf_get_totalvfs(xe);
++	struct xe_tile *tile;
++	unsigned int id;
++	int result = 0;
++	int err;
++
++	xe_assert(xe, xe_device_has_lmtt(xe));
++
++	guard(mutex)(xe_sriov_pf_master_mutex(xe));
++
++	for_each_tile(tile, xe, id) {
++		err = xe_gt_sriov_pf_config_bulk_set_lmem_locked(tile->primary_gt,
++								 VFID(1), num_vfs,
++								 vram_per_tile(tile, size));
++		result = result ?: err;
++	}
++
++	return result;
++}
++
++/**
++ * xe_sriov_pf_provision_apply_vf_vram() - Change single VF VRAM allocation.
++ * @xe: the PF &xe_device
++ * @vfid: the VF identifier (can't be 0 == PFID)
++ * @size: VRAM size to set
++ *
++ * Change VF's VRAM provisioning on all tiles/GTs.
++ *
++ * This function can only be called on PF.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_sriov_pf_provision_apply_vf_vram(struct xe_device *xe, unsigned int vfid, u64 size)
++{
++	struct xe_tile *tile;
++	unsigned int id;
++	int result = 0;
++	int err;
++
++	xe_assert(xe, vfid);
++	xe_assert(xe, xe_device_has_lmtt(xe));
++
++	guard(mutex)(xe_sriov_pf_master_mutex(xe));
++
++	for_each_tile(tile, xe, id) {
++		err = xe_gt_sriov_pf_config_set_lmem_locked(tile->primary_gt, vfid,
++							    vram_per_tile(tile, size));
++		result = result ?: err;
++	}
++
++	return result;
++}
++
++/**
++ * xe_sriov_pf_provision_query_vf_vram() - Query VF's VRAM allocation.
++ * @xe: the PF &xe_device
++ * @vfid: the VF identifier (can't be 0 == PFID)
++ * @size: placeholder for the returned VRAM size
++ *
++ * Query VF's VRAM provisioning from all tiles/GTs.
++ *
++ * This function can only be called on PF.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_sriov_pf_provision_query_vf_vram(struct xe_device *xe, unsigned int vfid, u64 *size)
++{
++	struct xe_tile *tile;
++	unsigned int id;
++	u64 total = 0;
++
++	xe_assert(xe, vfid);
++
++	guard(mutex)(xe_sriov_pf_master_mutex(xe));
++
++	for_each_tile(tile, xe, id)
++		total += xe_gt_sriov_pf_config_get_lmem_locked(tile->primary_gt, vfid);
++
++	*size = total;
++	return 0;
++}
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_provision.h b/drivers/gpu/drm/xe/xe_sriov_pf_provision.h
+index bccf23d51396b..f26f49539697b 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_provision.h
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_provision.h
+@@ -24,6 +24,10 @@ int xe_sriov_pf_provision_bulk_apply_priority(struct xe_device *xe, u32 prio);
+ int xe_sriov_pf_provision_apply_vf_priority(struct xe_device *xe, unsigned int vfid, u32 prio);
+ int xe_sriov_pf_provision_query_vf_priority(struct xe_device *xe, unsigned int vfid, u32 *prio);
+ 
++int xe_sriov_pf_provision_bulk_apply_vram(struct xe_device *xe, u64 size);
++int xe_sriov_pf_provision_apply_vf_vram(struct xe_device *xe, unsigned int vfid, u64 size);
++int xe_sriov_pf_provision_query_vf_vram(struct xe_device *xe, unsigned int vfid, u64 *size);
++
+ int xe_sriov_pf_provision_vfs(struct xe_device *xe, unsigned int num_vfs);
+ int xe_sriov_pf_unprovision_vfs(struct xe_device *xe, unsigned int num_vfs);
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-locked-variants-of-VRAM-configuration-.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-locked-variants-of-VRAM-configuration-.patch
@@ -1,0 +1,155 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:44 +0100
+Subject: drm/xe/pf: Add locked variants of VRAM configuration
+ functions
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We already have few functions to configure LMEM (aka VRAM) but they
+all are taking master mutex. Split them and expose locked variants
+to allow use by the caller who already hold this mutex.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-3-michal.wajdeczko@intel.com
+(cherry-picked from commit 146f25b40ce4b97b193ec19ae747629e44dfdce9 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 77 ++++++++++++++++++++--
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h |  4 ++
+ 2 files changed, 74 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index f9f4408ff1886..f2d60b94f2ba5 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1620,7 +1620,7 @@ int xe_gt_sriov_pf_config_set_lmem(struct xe_gt *gt, unsigned int vfid, u64 size
+ }
+ 
+ /**
+- * xe_gt_sriov_pf_config_bulk_set_lmem - Provision many VFs with LMEM.
++ * xe_gt_sriov_pf_config_bulk_set_lmem_locked() - Provision many VFs with LMEM.
+  * @gt: the &xe_gt (can't be media)
+  * @vfid: starting VF identifier (can't be 0)
+  * @num_vfs: number of VFs to provision
+@@ -1630,31 +1630,94 @@ int xe_gt_sriov_pf_config_set_lmem(struct xe_gt *gt, unsigned int vfid, u64 size
+  *
+  * Return: 0 on success or a negative error code on failure.
+  */
+-int xe_gt_sriov_pf_config_bulk_set_lmem(struct xe_gt *gt, unsigned int vfid,
+-					unsigned int num_vfs, u64 size)
++int xe_gt_sriov_pf_config_bulk_set_lmem_locked(struct xe_gt *gt, unsigned int vfid,
++					       unsigned int num_vfs, u64 size)
+ {
+ 	unsigned int n;
+ 	int err = 0;
+ 
+-	xe_gt_assert(gt, vfid);
++	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
++	xe_gt_assert(gt, xe_device_has_lmtt(gt_to_xe(gt)));
++	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+ 	xe_gt_assert(gt, xe_gt_is_main_type(gt));
++	xe_gt_assert(gt, vfid);
+ 
+ 	if (!num_vfs)
+ 		return 0;
+ 
+-	mutex_lock(xe_gt_sriov_pf_master_mutex(gt));
+ 	for (n = vfid; n < vfid + num_vfs; n++) {
+ 		err = pf_provision_vf_lmem(gt, n, size);
+ 		if (err)
+ 			break;
+ 	}
+-	mutex_unlock(xe_gt_sriov_pf_master_mutex(gt));
+ 
+ 	return pf_config_bulk_set_u64_done(gt, vfid, num_vfs, size,
+-					   xe_gt_sriov_pf_config_get_lmem,
++					   pf_get_vf_config_lmem,
+ 					   "LMEM", n, err);
+ }
+ 
++/**
++ * xe_gt_sriov_pf_config_bulk_set_lmem() - Provision many VFs with LMEM.
++ * @gt: the &xe_gt (can't be media)
++ * @vfid: starting VF identifier (can't be 0)
++ * @num_vfs: number of VFs to provision
++ * @size: requested LMEM size
++ *
++ * This function can only be called on PF.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_gt_sriov_pf_config_bulk_set_lmem(struct xe_gt *gt, unsigned int vfid,
++					unsigned int num_vfs, u64 size)
++{
++	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
++
++	return xe_gt_sriov_pf_config_bulk_set_lmem_locked(gt, vfid, num_vfs, size);
++}
++
++/**
++ * xe_gt_sriov_pf_config_get_lmem_locked() - Get VF's LMEM quota.
++ * @gt: the &xe_gt
++ * @vfid: the VF identifier (can't be 0 == PFID)
++ *
++ * This function can only be called on PF.
++ *
++ * Return: VF's LMEM quota.
++ */
++u64 xe_gt_sriov_pf_config_get_lmem_locked(struct xe_gt *gt, unsigned int vfid)
++{
++	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
++	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
++	xe_gt_assert(gt, vfid);
++
++	return pf_get_vf_config_lmem(gt, vfid);
++}
++
++/**
++ * xe_gt_sriov_pf_config_set_lmem_locked() - Provision VF with LMEM.
++ * @gt: the &xe_gt (can't be media)
++ * @vfid: the VF identifier (can't be 0 == PFID)
++ * @size: requested LMEM size
++ *
++ * This function can only be called on PF.
++ */
++int xe_gt_sriov_pf_config_set_lmem_locked(struct xe_gt *gt, unsigned int vfid, u64 size)
++{
++	int err;
++
++	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
++	xe_gt_assert(gt, xe_device_has_lmtt(gt_to_xe(gt)));
++	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
++	xe_gt_assert(gt, xe_gt_is_main_type(gt));
++	xe_gt_assert(gt, vfid);
++
++	err = pf_provision_vf_lmem(gt, vfid, size);
++
++	return pf_config_set_u64_done(gt, vfid, size,
++				      pf_get_vf_config_lmem(gt, vfid),
++				      "LMEM", err);
++}
++
+ static struct xe_bo *pf_get_vf_config_lmem_obj(struct xe_gt *gt, unsigned int vfid)
+ {
+ 	struct xe_gt_sriov_config *config = pf_pick_vf_config(gt, vfid);
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
+index 4975730423d72..88f71e0a6d4a6 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
+@@ -36,6 +36,10 @@ int xe_gt_sriov_pf_config_set_lmem(struct xe_gt *gt, unsigned int vfid, u64 size
+ int xe_gt_sriov_pf_config_set_fair_lmem(struct xe_gt *gt, unsigned int vfid, unsigned int num_vfs);
+ int xe_gt_sriov_pf_config_bulk_set_lmem(struct xe_gt *gt, unsigned int vfid, unsigned int num_vfs,
+ 					u64 size);
++u64 xe_gt_sriov_pf_config_get_lmem_locked(struct xe_gt *gt, unsigned int vfid);
++int xe_gt_sriov_pf_config_set_lmem_locked(struct xe_gt *gt, unsigned int vfid, u64 size);
++int xe_gt_sriov_pf_config_bulk_set_lmem_locked(struct xe_gt *gt, unsigned int vfid,
++					       unsigned int num_vfs, u64 size);
+ struct xe_bo *xe_gt_sriov_pf_config_get_lmem_obj(struct xe_gt *gt, unsigned int vfid);
+ 
+ u32 xe_gt_sriov_pf_config_get_exec_quantum(struct xe_gt *gt, unsigned int vfid);
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Allow-to-change-VFs-VRAM-quota-using-sysfs.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Allow-to-change-VFs-VRAM-quota-using-sysfs.patch
@@ -1,0 +1,145 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:46 +0100
+Subject: drm/xe/pf: Allow to change VFs VRAM quota using sysfs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On current discrete platforms, PF will provision all VFs with a fair
+amount of the VRAM (LMEM) during VFs enabling. However, in some cases
+this automatic VRAM provisioning might be either non-reproducible or
+sub-optimal. This could break VF's migration or impact performance.
+
+Expose per-VF VRAM quota read-write sysfs attributes to allow admin
+change default VRAM provisioning performed by the PF.
+
+ /sys/bus/pci/drivers/xe/BDF/
+ ├── sriov_admin/
+     ├── .bulk_profile
+     │   └── vram_quota                 [RW] unsigned integer
+     ├── vf1/
+     │   └── profile
+     │       └── vram_quota             [RW] unsigned integer
+     ├── vf2/
+     │   └── profile
+     │       └── vram_quota             [RW] unsigned integer
+
+Above values represent total provisioned VRAM from all tiles where
+VFs were assigned, and currently it's from all tiles always.
+
+Note that changing VRAM provisioning is only possible when VF is
+not running, otherwise GuC will complain. To make sure that given
+VF is idle, triggering VF FLR might be needed.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Acked-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-5-michal.wajdeczko@intel.com
+(cherry-picked from commit b1d2746aa5af17d1c901c36564e52da5c6bedae5 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_sriov_pf_sysfs.c | 31 ++++++++++++++++++++++++--
+ 1 file changed, 29 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_sysfs.c b/drivers/gpu/drm/xe/xe_sriov_pf_sysfs.c
+index 82a1055985ba..aa05c143a4d6 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_sysfs.c
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_sysfs.c
+@@ -9,6 +9,7 @@
+ #include <drm/drm_managed.h>
+ 
+ #include "xe_assert.h"
++#include "xe_device.h"
+ #include "xe_pci_sriov.h"
+ #include "xe_pm.h"
+ #include "xe_sriov.h"
+@@ -44,7 +45,8 @@ static int emit_choice(char *buf, int choice, const char * const *array, size_t
+  *     ├── .bulk_profile
+  *     │   ├── exec_quantum_ms
+  *     │   ├── preempt_timeout_us
+- *     │   └── sched_priority
++ *     │   ├── sched_priority
++ *     │   └── vram_quota
+  *     ├── pf/
+  *     │   ├── ...
+  *     │   ├── device -> ../../../BDF
+@@ -59,7 +61,8 @@ static int emit_choice(char *buf, int choice, const char * const *array, size_t
+  *     │   └── profile
+  *     │       ├── exec_quantum_ms
+  *     │       ├── preempt_timeout_us
+- *     │       └── sched_priority
++ *     │       ├── sched_priority
++ *     │       └── vram_quota
+  *     ├── vf2/
+  *     :
+  *     └── vfN/
+@@ -132,6 +135,7 @@ static XE_SRIOV_DEV_ATTR_WO(NAME)
+ 
+ DEFINE_SIMPLE_BULK_PROVISIONING_SRIOV_DEV_ATTR_WO(exec_quantum_ms, eq, u32);
+ DEFINE_SIMPLE_BULK_PROVISIONING_SRIOV_DEV_ATTR_WO(preempt_timeout_us, pt, u32);
++DEFINE_SIMPLE_BULK_PROVISIONING_SRIOV_DEV_ATTR_WO(vram_quota, vram, u64);
+ 
+ static const char * const sched_priority_names[] = {
+ 	[GUC_SCHED_PRIORITY_LOW] = "low",
+@@ -181,12 +185,26 @@ static struct attribute *bulk_profile_dev_attrs[] = {
+ 	&xe_sriov_dev_attr_exec_quantum_ms.attr,
+ 	&xe_sriov_dev_attr_preempt_timeout_us.attr,
+ 	&xe_sriov_dev_attr_sched_priority.attr,
++	&xe_sriov_dev_attr_vram_quota.attr,
+ 	NULL
+ };
+ 
++static umode_t profile_dev_attr_is_visible(struct kobject *kobj,
++					   struct attribute *attr, int index)
++{
++	struct xe_sriov_kobj *vkobj = to_xe_sriov_kobj(kobj);
++
++	if (attr == &xe_sriov_dev_attr_vram_quota.attr &&
++	    !xe_device_has_lmtt(vkobj->xe))
++		return 0;
++
++	return attr->mode;
++}
++
+ static const struct attribute_group bulk_profile_dev_attr_group = {
+ 	.name = ".bulk_profile",
+ 	.attrs = bulk_profile_dev_attrs,
++	.is_visible = profile_dev_attr_is_visible,
+ };
+ 
+ static const struct attribute_group *xe_sriov_dev_attr_groups[] = {
+@@ -228,6 +246,7 @@ static XE_SRIOV_VF_ATTR(NAME)
+ 
+ DEFINE_SIMPLE_PROVISIONING_SRIOV_VF_ATTR(exec_quantum_ms, eq, u32, "%u\n");
+ DEFINE_SIMPLE_PROVISIONING_SRIOV_VF_ATTR(preempt_timeout_us, pt, u32, "%u\n");
++DEFINE_SIMPLE_PROVISIONING_SRIOV_VF_ATTR(vram_quota, vram, u64, "%llu\n");
+ 
+ static ssize_t xe_sriov_vf_attr_sched_priority_show(struct xe_device *xe, unsigned int vfid,
+ 						    char *buf)
+@@ -274,6 +293,7 @@ static struct attribute *profile_vf_attrs[] = {
+ 	&xe_sriov_vf_attr_exec_quantum_ms.attr,
+ 	&xe_sriov_vf_attr_preempt_timeout_us.attr,
+ 	&xe_sriov_vf_attr_sched_priority.attr,
++	&xe_sriov_vf_attr_vram_quota.attr,
+ 	NULL
+ };
+ 
+@@ -286,6 +306,13 @@ static umode_t profile_vf_attr_is_visible(struct kobject *kobj,
+ 	    !sched_priority_change_allowed(vkobj->vfid))
+ 		return attr->mode & 0444;
+ 
++	if (attr == &xe_sriov_vf_attr_vram_quota.attr) {
++		if (!IS_DGFX(vkobj->xe) || vkobj->vfid == PFID)
++			return 0;
++		if (!xe_device_has_lmtt(vkobj->xe))
++			return attr->mode & 0444;
++	}
++
+ 	return attr->mode;
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Don-t-check-for-empty-config.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Don-t-check-for-empty-config.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:49 +0100
+Subject: drm/xe/pf: Don't check for empty config
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We already turn off VFs auto-provisioning once we detect manual VFs
+provisioning over the debugfs, so we can skip additional check for
+all VFs configs being still empty.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-8-michal.wajdeczko@intel.com
+(cherry-picked from commit 62acbb1dd5c281ad708f7985031230b0268ddc61 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_sriov_pf_provision.c | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_provision.c b/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
+index f22ff65c59aa0..abe3677d33edf 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
+@@ -33,17 +33,6 @@ static bool pf_auto_provisioning_mode(struct xe_device *xe)
+ 	return xe->sriov.pf.provision.mode == XE_SRIOV_PROVISIONING_MODE_AUTO;
+ }
+ 
+-static bool pf_needs_provisioning(struct xe_gt *gt, unsigned int num_vfs)
+-{
+-	unsigned int n;
+-
+-	for (n = 1; n <= num_vfs; n++)
+-		if (!xe_gt_sriov_pf_config_is_empty(gt, n))
+-			return false;
+-
+-	return true;
+-}
+-
+ static int pf_provision_vfs(struct xe_device *xe, unsigned int num_vfs)
+ {
+ 	struct xe_gt *gt;
+@@ -52,8 +41,6 @@ static int pf_provision_vfs(struct xe_device *xe, unsigned int num_vfs)
+ 	int err;
+ 
+ 	for_each_gt(gt, xe, id) {
+-		if (!pf_needs_provisioning(gt, num_vfs))
+-			return -EUCLEAN;
+ 		err = xe_gt_sriov_pf_config_set_fair(gt, VFID(1), num_vfs);
+ 		result = result ?: err;
+ 	}
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Expose-LMTT-page-size.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Expose-LMTT-page-size.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:43 +0100
+Subject: drm/xe/pf: Expose LMTT page size
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The underlying LMTT implementation already provides the info about
+the page size it is using.  There is no need to have a separate
+helper function that is making assumption about the required size.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Cc: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-2-michal.wajdeczko@intel.com
+(cherry-picked from commit 2d892455f38b82fb4e93f45e7a8e8ea41683ca78 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c |  3 +--
+ drivers/gpu/drm/xe/xe_lmtt.c               | 17 +++++++++++++++++
+ drivers/gpu/drm/xe/xe_lmtt.h               |  1 +
+ 3 files changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 8078b7f8bcd1e..f9f4408ff1886 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1339,8 +1339,7 @@ int xe_gt_sriov_pf_config_set_fair_dbs(struct xe_gt *gt, unsigned int vfid,
+ 
+ static u64 pf_get_lmem_alignment(struct xe_gt *gt)
+ {
+-	/* this might be platform dependent */
+-	return SZ_2M;
++	return xe_lmtt_page_size(&gt->tile->sriov.pf.lmtt);
+ }
+ 
+ static u64 pf_get_min_spare_lmem(struct xe_gt *gt)
+diff --git a/drivers/gpu/drm/xe/xe_lmtt.c b/drivers/gpu/drm/xe/xe_lmtt.c
+index 4dc1de482eeed..a7d39956a7611 100644
+--- a/drivers/gpu/drm/xe/xe_lmtt.c
++++ b/drivers/gpu/drm/xe/xe_lmtt.c
+@@ -54,6 +54,23 @@ static u64 lmtt_page_size(struct xe_lmtt *lmtt)
+ 	return BIT_ULL(lmtt->ops->lmtt_pte_shift(0));
+ }
+ 
++/**
++ * xe_lmtt_page_size() - Get LMTT page size.
++ * @lmtt: the &xe_lmtt
++ *
++ * This function shall be called only by PF.
++ *
++ * Return: LMTT page size.
++ */
++u64 xe_lmtt_page_size(struct xe_lmtt *lmtt)
++{
++	lmtt_assert(lmtt, IS_SRIOV_PF(lmtt_to_xe(lmtt)));
++	lmtt_assert(lmtt, xe_device_has_lmtt(lmtt_to_xe(lmtt)));
++	lmtt_assert(lmtt, lmtt->ops);
++
++	return lmtt_page_size(lmtt);
++}
++
+ static struct xe_lmtt_pt *lmtt_pt_alloc(struct xe_lmtt *lmtt, unsigned int level)
+ {
+ 	unsigned int num_entries = level ? lmtt->ops->lmtt_pte_num(level) : 0;
+diff --git a/drivers/gpu/drm/xe/xe_lmtt.h b/drivers/gpu/drm/xe/xe_lmtt.h
+index 75a234fbf3670..8fa387b38c520 100644
+--- a/drivers/gpu/drm/xe/xe_lmtt.h
++++ b/drivers/gpu/drm/xe/xe_lmtt.h
+@@ -20,6 +20,7 @@ int xe_lmtt_prepare_pages(struct xe_lmtt *lmtt, unsigned int vfid, u64 range);
+ int xe_lmtt_populate_pages(struct xe_lmtt *lmtt, unsigned int vfid, struct xe_bo *bo, u64 offset);
+ void xe_lmtt_drop_pages(struct xe_lmtt *lmtt, unsigned int vfid);
+ u64 xe_lmtt_estimate_pt_size(struct xe_lmtt *lmtt, u64 size);
++u64 xe_lmtt_page_size(struct xe_lmtt *lmtt);
+ #else
+ static inline int xe_lmtt_init(struct xe_lmtt *lmtt) { return 0; }
+ static inline void xe_lmtt_init_hw(struct xe_lmtt *lmtt) { }
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Prefer-guard-mutex-when-doing-fair-LMEM-pr.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Prefer-guard-mutex-when-doing-fair-LMEM-pr.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:50 +0100
+Subject: drm/xe/pf: Prefer guard(mutex) when doing fair LMEM
+ provisioning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We will add more code there and with guard() it will easier to
+avoid mistakes in unlocking.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-9-michal.wajdeczko@intel.com
+(cherry-picked from commit 67a716b693f96177be253c1fa6a205db743d5445 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 2eca97c0d152e..e2a025db35e10 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1830,10 +1830,9 @@ int xe_gt_sriov_pf_config_set_fair_lmem(struct xe_gt *gt, unsigned int vfid,
+ 	if (!xe_device_has_lmtt(gt_to_xe(gt)))
+ 		return 0;
+ 
+-	mutex_lock(xe_gt_sriov_pf_master_mutex(gt));
+-	fair = pf_estimate_fair_lmem(gt, num_vfs);
+-	mutex_unlock(xe_gt_sriov_pf_master_mutex(gt));
++	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
+ 
++	fair = pf_estimate_fair_lmem(gt, num_vfs);
+ 	if (!fair)
+ 		return -ENOSPC;
+ 
+@@ -1843,7 +1842,7 @@ int xe_gt_sriov_pf_config_set_fair_lmem(struct xe_gt *gt, unsigned int vfid,
+ 		xe_gt_sriov_info(gt, "Using non-profile provisioning (%s %llu vs %llu)\n",
+ 				 "VRAM", fair, profile);
+ 
+-	return xe_gt_sriov_pf_config_bulk_set_lmem(gt, vfid, num_vfs, fair);
++	return xe_gt_sriov_pf_config_bulk_set_lmem_locked(gt, vfid, num_vfs, fair);
+ }
+ 
+ /**
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Skip-VRAM-auto-provisioning-if-already-pro.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Skip-VRAM-auto-provisioning-if-already-pro.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:51 +0100
+Subject: drm/xe/pf: Skip VRAM auto-provisioning if already provisioned
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In case VF's VRAM provisioning using sysfs is done by the admin
+prior to VFs enabling, this provisioning will be lost as PF will
+run VRAM auto-provisioning anyway. To avoid that skip this auto-
+provisioning if any VF has been already provisioned with VRAM.
+
+To help admin find any mistakes, add diagnostics messages about
+which VFs were provisioned with VRAM and which were missed.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-10-michal.wajdeczko@intel.com
+(cherry-picked from commit d039fa856ee190ae8cd799800972137a00b55d43 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 56 ++++++++++++++++++++++
+ 1 file changed, 56 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index e2a025db35e10..5d85f086c0bbd 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1807,6 +1807,59 @@ static u64 pf_profile_fair_lmem(struct xe_gt *gt, unsigned int num_vfs)
+ 	return ALIGN_DOWN(fair, alignment);
+ }
+ 
++static void __pf_show_provisioning_lmem(struct xe_gt *gt, unsigned int first_vf,
++					unsigned int num_vfs, bool provisioned)
++{
++	unsigned int allvfs = 1 + xe_gt_sriov_pf_get_totalvfs(gt); /* PF plus VFs */
++	unsigned long *bitmap __free(bitmap) = bitmap_zalloc(allvfs, GFP_KERNEL);
++	unsigned int weight;
++	unsigned int n;
++
++	if (!bitmap)
++		return;
++
++	for (n = first_vf; n < first_vf + num_vfs; n++) {
++		if (!!pf_get_vf_config_lmem(gt, VFID(n)) == provisioned)
++			bitmap_set(bitmap, n, 1);
++	}
++
++	weight = bitmap_weight(bitmap, allvfs);
++	if (!weight)
++		return;
++
++	xe_gt_sriov_info(gt, "VF%s%*pbl %s provisioned with VRAM\n",
++			 weight > 1 ? "s " : "", allvfs, bitmap,
++			 provisioned ? "already" : "not");
++}
++
++static void pf_show_all_provisioned_lmem(struct xe_gt *gt)
++{
++	__pf_show_provisioning_lmem(gt, VFID(1), xe_gt_sriov_pf_get_totalvfs(gt), true);
++}
++
++static void pf_show_unprovisioned_lmem(struct xe_gt *gt, unsigned int first_vf,
++				       unsigned int num_vfs)
++{
++	__pf_show_provisioning_lmem(gt, first_vf, num_vfs, false);
++}
++
++static bool pf_needs_provision_lmem(struct xe_gt *gt, unsigned int first_vf,
++				    unsigned int num_vfs)
++{
++	unsigned int vfid;
++
++	for (vfid = first_vf; vfid < first_vf + num_vfs; vfid++) {
++		if (pf_get_vf_config_lmem(gt, vfid)) {
++			pf_show_all_provisioned_lmem(gt);
++			pf_show_unprovisioned_lmem(gt, first_vf, num_vfs);
++			return false;
++		}
++	}
++
++	pf_show_all_provisioned_lmem(gt);
++	return true;
++}
++
+ /**
+  * xe_gt_sriov_pf_config_set_fair_lmem - Provision many VFs with fair LMEM.
+  * @gt: the &xe_gt (can't be media)
+@@ -1832,6 +1885,9 @@ int xe_gt_sriov_pf_config_set_fair_lmem(struct xe_gt *gt, unsigned int vfid,
+ 
+ 	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
+ 
++	if (!pf_needs_provision_lmem(gt, vfid, num_vfs))
++		return 0;
++
+ 	fair = pf_estimate_fair_lmem(gt, num_vfs);
+ 	if (!fair)
+ 		return -ENOSPC;
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-VRAM-auto-provision.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-VRAM-auto-provision.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 18 Feb 2026 21:55:47 +0100
+Subject: drm/xe/pf: Use migration-friendly VRAM auto-provisioning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Instead of trying very hard to find the largest fair VRAM (aka LMEM)
+size that could be allocated for VFs on the current tile, pick some
+smaller rounded down to power-of-two value that is more likely to be
+provisioned in the same manner by the other PF instances.
+
+In some cases, the outcome of above calculation might not be optimal,
+but it's expected that admin will do fine-tuning using sysfs files.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260218205553.3561-6-michal.wajdeczko@intel.com
+(cherry-picked from commit 81d417d56a23f94b288587af59111f20aaf83c03 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 29 ++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index f2d60b94f2ba5..2eca97c0d152e 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1785,6 +1785,28 @@ static u64 pf_estimate_fair_lmem(struct xe_gt *gt, unsigned int num_vfs)
+ 	return fair;
+ }
+ 
++static u64 pf_profile_fair_lmem(struct xe_gt *gt, unsigned int num_vfs)
++{
++	struct xe_tile *tile = gt_to_tile(gt);
++	bool admin_only_pf = xe_sriov_pf_admin_only(tile->xe);
++	u64 usable = xe_vram_region_usable_size(tile->mem.vram);
++	u64 spare = pf_get_min_spare_lmem(gt);
++	u64 available = usable > spare ? usable - spare : 0;
++	u64 shareable = ALIGN_DOWN(available, SZ_1G);
++	u64 alignment = pf_get_lmem_alignment(gt);
++	u64 fair;
++
++	if (admin_only_pf)
++		fair = div_u64(shareable, num_vfs);
++	else
++		fair = div_u64(shareable, 1 + num_vfs);
++
++	if (!admin_only_pf && fair)
++		fair = rounddown_pow_of_two(fair);
++
++	return ALIGN_DOWN(fair, alignment);
++}
++
+ /**
+  * xe_gt_sriov_pf_config_set_fair_lmem - Provision many VFs with fair LMEM.
+  * @gt: the &xe_gt (can't be media)
+@@ -1798,6 +1820,7 @@ static u64 pf_estimate_fair_lmem(struct xe_gt *gt, unsigned int num_vfs)
+ int xe_gt_sriov_pf_config_set_fair_lmem(struct xe_gt *gt, unsigned int vfid,
+ 					unsigned int num_vfs)
+ {
++	u64 profile;
+ 	u64 fair;
+ 
+ 	xe_gt_assert(gt, vfid);
+@@ -1814,6 +1837,12 @@ int xe_gt_sriov_pf_config_set_fair_lmem(struct xe_gt *gt, unsigned int vfid,
+ 	if (!fair)
+ 		return -ENOSPC;
+ 
++	profile = pf_profile_fair_lmem(gt, num_vfs);
++	fair = min(fair, profile);
++	if (fair < profile)
++		xe_gt_sriov_info(gt, "Using non-profile provisioning (%s %llu vs %llu)\n",
++				 "VRAM", fair, profile);
++
+ 	return xe_gt_sriov_pf_config_bulk_set_lmem(gt, vfid, num_vfs, fair);
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-context-IDs-auto-pr.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-context-IDs-auto-pr.patch
@@ -1,0 +1,103 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 5 Nov 2025 19:32:50 +0100
+Subject: drm/xe/pf: Use migration-friendly context IDs
+ auto-provisioning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Instead of trying very hard to find the largest fair number of GuC
+context IDs that could be allocated for VFs on the current GT, pick
+some smaller rounded down to power-of-two value that is more likely
+to be provisioned in the same manner by the other PF instance:
+
+ num VFs | num contexts
+ --------+-------------
+  63..32 | 1024
+  31..16 | 2048
+  15..8  | 4096
+   7..4  | 8192
+   3..2  | 16384
+      1  | 32768 (regular PF)
+      1  | 64512 (admin only PF)
+
+Add also helper function to determine if the PF is admin-only,
+and for now use .probe_display flag for that.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20251105183253.863-2-michal.wajdeczko@intel.com
+(cherry-picked from commit 8fb1d7d3cf643d62fd84eca225562467c1e9b770 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 16 ++++++++++++++++
+ drivers/gpu/drm/xe/xe_sriov_pf_helpers.h   | 11 +++++++++++
+ 2 files changed, 27 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 5d85f086c0bbd..033548675d72b 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1042,6 +1042,16 @@ int xe_gt_sriov_pf_config_bulk_set_ctxs(struct xe_gt *gt, unsigned int vfid,
+ 					   "GuC context IDs", no_unit, n, err);
+ }
+ 
++static u32 pf_profile_fair_ctxs(struct xe_gt *gt, unsigned int num_vfs)
++{
++	bool admin_only_pf = xe_sriov_pf_admin_only(gt_to_xe(gt));
++
++	if (admin_only_pf && num_vfs == 1)
++		return ALIGN_DOWN(GUC_ID_MAX, SZ_1K);
++
++	return rounddown_pow_of_two(GUC_ID_MAX / num_vfs);
++}
++
+ static u32 pf_estimate_fair_ctxs(struct xe_gt *gt, unsigned int num_vfs)
+ {
+ 	struct xe_guc_id_mgr *idm = &gt->uc.guc.submission_state.idm;
+@@ -1074,6 +1084,7 @@ static u32 pf_estimate_fair_ctxs(struct xe_gt *gt, unsigned int num_vfs)
+ int xe_gt_sriov_pf_config_set_fair_ctxs(struct xe_gt *gt, unsigned int vfid,
+ 					unsigned int num_vfs)
+ {
++	u32 profile = pf_profile_fair_ctxs(gt, num_vfs);
+ 	u32 fair;
+ 
+ 	xe_gt_assert(gt, vfid);
+@@ -1086,6 +1097,11 @@ int xe_gt_sriov_pf_config_set_fair_ctxs(struct xe_gt *gt, unsigned int vfid,
+ 	if (!fair)
+ 		return -ENOSPC;
+ 
++	fair = min(fair, profile);
++	if (fair < profile)
++		xe_gt_sriov_info(gt, "Using non-profile provisioning (%s %u vs %u)\n",
++				 "GuC context IDs", fair, profile);
++
+ 	return xe_gt_sriov_pf_config_bulk_set_ctxs(gt, vfid, num_vfs, fair);
+ }
+ 
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_helpers.h b/drivers/gpu/drm/xe/xe_sriov_pf_helpers.h
+index a348fd31a91f3..9054fdc345974 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_helpers.h
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_helpers.h
+@@ -48,6 +48,17 @@ static inline unsigned int xe_sriov_pf_num_vfs(const struct xe_device *xe)
+ 	return pci_num_vf(to_pci_dev(xe->drm.dev));
+ }
+ 
++/**
++ * xe_sriov_pf_admin_only() - Check if PF is mainly used for VFs administration.
++ * @xe: the PF &xe_device
++ *
++ * Return: True if PF is mainly used for VFs administration.
++ */
++static inline bool xe_sriov_pf_admin_only(const struct xe_device *xe)
++{
++	return !xe->info.probe_display;
++}
++
+ static inline struct mutex *xe_sriov_pf_master_mutex(struct xe_device *xe)
+ {
+ 	xe_assert(xe, IS_SRIOV_PF(xe));
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-doorbells-auto-prov.patch
+++ b/backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-doorbells-auto-prov.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Wed, 5 Nov 2025 19:32:51 +0100
+Subject: drm/xe/pf: Use migration-friendly doorbells auto-provisioning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Instead of trying very hard to find the largest fair number of GuC
+doorbell IDs that could be allocated for VFs on the current GT, pick
+some smaller rounded down to power-of-two value that is more likely
+to be provisioned in the same manner by the other PF instance:
+
+  num VFs | num doorbells
+  --------+--------------
+   63..32 | 4
+   31..16 | 8
+   15..8  | 16
+    7..4  | 32
+    3..2  | 64
+       1  | 128 (regular PF)
+       1  | 240 (admin only PF)
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20251105183253.863-3-michal.wajdeczko@intel.com
+(cherry-picked from commit bfbcf66186b535382f090fa2e55bcaea2123c8a0 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 033548675d72b..b44eed2ebe97a 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1306,6 +1306,17 @@ int xe_gt_sriov_pf_config_bulk_set_dbs(struct xe_gt *gt, unsigned int vfid,
+ 					   "GuC doorbell IDs", no_unit, n, err);
+ }
+ 
++static u32 pf_profile_fair_dbs(struct xe_gt *gt, unsigned int num_vfs)
++{
++	bool admin_only_pf = xe_sriov_pf_admin_only(gt_to_xe(gt));
++
++	/* XXX: preliminary */
++	if (admin_only_pf && num_vfs == 1)
++		return GUC_NUM_DOORBELLS - SZ_16;
++
++	return rounddown_pow_of_two(GUC_NUM_DOORBELLS / (num_vfs + 1));
++}
++
+ static u32 pf_estimate_fair_dbs(struct xe_gt *gt, unsigned int num_vfs)
+ {
+ 	struct xe_guc_db_mgr *dbm = &gt->uc.guc.dbm;
+@@ -1338,6 +1349,7 @@ static u32 pf_estimate_fair_dbs(struct xe_gt *gt, unsigned int num_vfs)
+ int xe_gt_sriov_pf_config_set_fair_dbs(struct xe_gt *gt, unsigned int vfid,
+ 				       unsigned int num_vfs)
+ {
++	u32 profile = pf_profile_fair_dbs(gt, num_vfs);
+ 	u32 fair;
+ 
+ 	xe_gt_assert(gt, vfid);
+@@ -1350,6 +1362,11 @@ int xe_gt_sriov_pf_config_set_fair_dbs(struct xe_gt *gt, unsigned int vfid,
+ 	if (!fair)
+ 		return -ENOSPC;
+ 
++	fair = min(fair, profile);
++	if (fair < profile)
++		xe_gt_sriov_info(gt, "Using non-profile provisioning (%s %u vs %u)\n",
++				 "GuC doorbell IDs", fair, profile);
++
+ 	return xe_gt_sriov_pf_config_bulk_set_dbs(gt, vfid, num_vfs, fair);
+ }
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -268,6 +268,18 @@ backport/patches/features/vf-double-migration/0001-drm-xe-vf-Requeue-recovery-on
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Add-debugfs-entries-to-test-VF-double-migr.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Fix-queuing-of-recovery-work.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Reset-recovery_queued-after-issuing-RESFIX.patch
+# features/vf-vram-provision
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Expose-LMTT-page-size.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-locked-variants-of-VRAM-configuration-.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-functions-for-VRAM-provisioning.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Allow-to-change-VFs-VRAM-quota-using-sysfs.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-VRAM-auto-provision.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Don-t-check-for-empty-config.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Prefer-guard-mutex-when-doing-fair-LMEM-pr.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Skip-VRAM-auto-provisioning-if-already-pro.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-documentation-for-vram_quota.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-context-IDs-auto-pr.patch
+backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-doorbells-auto-prov.patch
 # fixes
 backport/patches/fixes/base/0001-drm-me-gsc-mei-interrupt-top-half-should-be-in-irq-d.patch
 backport/patches/fixes/base/0001-drm-xe-Adjust-long-running-workload-timeslices-to-re.patch


### PR DESCRIPTION
Add sysfs support to configure VRAM quota for VFs in the Xe driver.

Expose per-VF and bulk VRAM quota controls under sriov_admin.
Allow updates only when LMTT is enabled and ensure safe
provisioning with proper accounting.

Also include helpers for VRAM configuration, fair auto-provisioning,
and basic test coverage.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>