### PR TITLE
drm/xe: Add VM_BIND DECOMPRESS support

### DIFF
--- a/backport/patches/base/0001-drm-xe-add-VM_BIND-DECOMPRESS-uapi-flag.patch
+++ b/backport/patches/base/0001-drm-xe-add-VM_BIND-DECOMPRESS-uapi-flag.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nitin Gote <nitin.r.gote@intel.com>
+Date: Wed, 4 Mar 2026 18:08:00 +0530
+Subject: drm/xe: add VM_BIND DECOMPRESS uapi flag
+
+Add a new VM_BIND flag, DRM_XE_VM_BIND_FLAG_DECOMPRESS, that lets userspace
+express intent for the driver to perform on-device in-place decompression
+for the GPU mapping created by a MAP bind operation.
+
+This flag is used by subsequent driver changes to trigger scheduling of
+GPU work that resolves compressed VRAM pages into an uncompressed PAT
+VM mapping.
+
+Behavior and semantics:
+- Valid only for DRM_XE_VM_BIND_OP_MAP. IOCTLs using this flag on other ops
+  are rejected (-EINVAL).
+- The bind's pat_index must select the device "no-compression" PAT entry;
+  otherwise the ioctl is rejected (-EINVAL).
+- Only meaningful for VRAM-backed BOs on devices that support Flat CCS and
+  the required hardware generation (driver will return -EOPNOTSUPP if not).
+- On success the driver schedules a migrate/resolve and installs the
+  returned dma_fence into the BO's kernel reservation
+  (DMA_RESV_USAGE_KERNEL).
+
+Compute PR: https://github.com/intel/compute-runtime/pull/898
+
+v3: Rebase on latest drm-tip and add compute pr info
+
+v2: Add kernel doc (Matt)
+
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Matthew Auld <matthew.auld@intel.com>
+Cc: Mrozek, Michal <michal.mrozek@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Nitin Gote <nitin.r.gote@intel.com>
+Acked-by: Michal Mrozek <michal.mrozek@intel.com>
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://patch.msgid.link/20260304123758.3050386-6-nitin.r.gote@intel.com
+(backported from commit 2270bd7124f4d25497d58c293cd40ea014ddaf01 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ include/uapi/drm/xe_drm.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index e2426413488fe..304c17bc8ced2 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -1003,6 +1003,13 @@ struct drm_xe_vm_destroy {
+  *    valid on VMs with DRM_XE_VM_CREATE_FLAG_FAULT_MODE set. The CPU address
+  *    mirror flag are only valid for DRM_XE_VM_BIND_OP_MAP operations, the BO
+  *    handle MBZ, and the BO offset MBZ.
++ *  - DRM_XE_VM_BIND_FLAG_DECOMPRESS - Request on-device decompression for a MAP.
++ *    When set on a MAP bind operation, request the driver schedule an on-device
++ *    in-place decompression (via the migrate/resolve path) for the GPU mapping
++ *    created by this bind. Only valid for DRM_XE_VM_BIND_OP_MAP; usage on
++ *    other ops is rejected. The bind's pat_index must select the device's
++ *    "no-compression" PAT. Only meaningful for VRAM-backed BOs on devices that
++ *    support Flat CCS and the required HW generation XE2+.
+  */
+ struct drm_xe_vm_bind_op {
+ 	/** @extensions: Pointer to the first extension struct, if any */
+@@ -1105,6 +1112,7 @@ struct drm_xe_vm_bind_op {
+ #define DRM_XE_VM_BIND_FLAG_DUMPABLE	(1 << 3)
+ #define DRM_XE_VM_BIND_FLAG_CHECK_PXP	(1 << 4)
+ #define DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR	(1 << 5)
++#define DRM_XE_VM_BIND_FLAG_DECOMPRESS	(1 << 6)
+ 	/** @flags: Bind flags */
+ 	__u32 flags;
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-add-xe_migrate_resolve-wrapper-and-is_vram_re.patch
+++ b/backport/patches/base/0001-drm-xe-add-xe_migrate_resolve-wrapper-and-is_vram_re.patch
@@ -1,0 +1,167 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nitin Gote <nitin.r.gote@intel.com>
+Date: Wed, 4 Mar 2026 18:08:01 +0530
+Subject: drm/xe: add xe_migrate_resolve wrapper and is_vram_resolve
+ support
+
+Introduce an internal __xe_migrate_copy(..., is_vram_resolve) path and
+expose a small wrapper xe_migrate_resolve() that calls it with
+is_vram_resolve=true.
+
+For resolve/decompression operations we must ensure the copy code uses
+the compression PAT index when appropriate; this change centralizes that
+behavior and allows callers to schedule a resolve (decompress) operation
+via the migrate API.
+
+v3: Fix kernel-doc warnings
+
+v2: (Matt)
+  - Simplify xe_migrate_resolve(), use single BO/resource;
+    remove copy_only_ccs argument as it's always false.
+
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Matthew Auld <matthew.auld@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Nitin Gote <nitin.r.gote@intel.com>
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://patch.msgid.link/20260304123758.3050386-7-nitin.r.gote@intel.com
+(cherry-picked from commit be97fd06458d66a53aefb6d9429db0df734c81c0 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_migrate.c | 90 +++++++++++++++++++++++----------
+ drivers/gpu/drm/xe/xe_migrate.h |  4 ++
+ 2 files changed, 67 insertions(+), 27 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
+index 478dd07d989db..f3940fc175c88 100644
+--- a/drivers/gpu/drm/xe/xe_migrate.c
++++ b/drivers/gpu/drm/xe/xe_migrate.c
+@@ -764,31 +764,13 @@ static u32 xe_migrate_ccs_copy(struct xe_migrate *m,
+ 	return flush_flags;
+ }
+ 
+-/**
+- * xe_migrate_copy() - Copy content of TTM resources.
+- * @m: The migration context.
+- * @src_bo: The buffer object @src is currently bound to.
+- * @dst_bo: If copying between resources created for the same bo, set this to
+- * the same value as @src_bo. If copying between buffer objects, set it to
+- * the buffer object @dst is currently bound to.
+- * @src: The source TTM resource.
+- * @dst: The dst TTM resource.
+- * @copy_only_ccs: If true copy only CCS metadata
+- *
+- * Copies the contents of @src to @dst: On flat CCS devices,
+- * the CCS metadata is copied as well if needed, or if not present,
+- * the CCS metadata of @dst is cleared for security reasons.
+- *
+- * Return: Pointer to a dma_fence representing the last copy batch, or
+- * an error pointer on failure. If there is a failure, any copy operation
+- * started by the function call has been synced.
+- */
+-struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
+-				  struct xe_bo *src_bo,
+-				  struct xe_bo *dst_bo,
+-				  struct ttm_resource *src,
+-				  struct ttm_resource *dst,
+-				  bool copy_only_ccs)
++static struct dma_fence *__xe_migrate_copy(struct xe_migrate *m,
++					   struct xe_bo *src_bo,
++					   struct xe_bo *dst_bo,
++					   struct ttm_resource *src,
++					   struct ttm_resource *dst,
++					   bool copy_only_ccs,
++					   bool is_vram_resolve)
+ {
+ 	struct xe_gt *gt = m->tile->primary_gt;
+ 	struct xe_device *xe = gt_to_xe(gt);
+@@ -809,8 +791,15 @@ struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
+ 	bool copy_ccs = xe_device_has_flat_ccs(xe) &&
+ 		xe_bo_needs_ccs_pages(src_bo) && xe_bo_needs_ccs_pages(dst_bo);
+ 	bool copy_system_ccs = copy_ccs && (!src_is_vram || !dst_is_vram);
+-	bool use_comp_pat = type_device && xe_device_has_flat_ccs(xe) &&
+-		GRAPHICS_VER(xe) >= 20 && src_is_vram && !dst_is_vram;
++
++	/*
++	 * For decompression operation, always use the compression PAT index.
++	 * Otherwise, only use the compression PAT index for device memory
++	 * when copying from VRAM to system memory.
++	 */
++	bool use_comp_pat = is_vram_resolve || (type_device &&
++			    xe_device_has_flat_ccs(xe) &&
++			    GRAPHICS_VER(xe) >= 20 && src_is_vram && !dst_is_vram);
+ 
+ 	/* Copying CCS between two different BOs is not supported yet. */
+ 	if (XE_WARN_ON(copy_ccs && src_bo != dst_bo))
+@@ -965,6 +954,53 @@ struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
+ 	return fence;
+ }
+ 
++/**
++ * xe_migrate_copy() - Copy content of TTM resources.
++ * @m: The migration context.
++ * @src_bo: The buffer object @src is currently bound to.
++ * @dst_bo: If copying between resources created for the same bo, set this to
++ * the same value as @src_bo. If copying between buffer objects, set it to
++ * the buffer object @dst is currently bound to.
++ * @src: The source TTM resource.
++ * @dst: The dst TTM resource.
++ * @copy_only_ccs: If true copy only CCS metadata
++ *
++ * Copies the contents of @src to @dst: On flat CCS devices,
++ * the CCS metadata is copied as well if needed, or if not present,
++ * the CCS metadata of @dst is cleared for security reasons.
++ *
++ * Return: Pointer to a dma_fence representing the last copy batch, or
++ * an error pointer on failure. If there is a failure, any copy operation
++ * started by the function call has been synced.
++ */
++struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
++				  struct xe_bo *src_bo,
++				  struct xe_bo *dst_bo,
++				  struct ttm_resource *src,
++				  struct ttm_resource *dst,
++				  bool copy_only_ccs)
++{
++	return __xe_migrate_copy(m, src_bo, dst_bo, src, dst, copy_only_ccs, false);
++}
++
++/**
++ * xe_migrate_resolve() - Resolve and decompress a buffer object if required.
++ * @m: The migrate context
++ * @bo: The buffer object to resolve
++ * @res: The reservation object
++ *
++ * Wrapper around __xe_migrate_copy() with is_vram_resolve set to true
++ * to trigger decompression if needed.
++ *
++ * Return: A dma_fence that signals on completion, or an ERR_PTR on failure.
++ */
++struct dma_fence *xe_migrate_resolve(struct xe_migrate *m,
++				     struct xe_bo *bo,
++				     struct ttm_resource *res)
++{
++	return __xe_migrate_copy(m, bo, bo, res, res, false, true);
++}
++
+ /**
+  * xe_migrate_lrc() - Get the LRC from migrate context.
+  * @migrate: Migrate context.
+diff --git a/drivers/gpu/drm/xe/xe_migrate.h b/drivers/gpu/drm/xe/xe_migrate.h
+index ca9383ebbe9c1..55d8e0176c767 100644
+--- a/drivers/gpu/drm/xe/xe_migrate.h
++++ b/drivers/gpu/drm/xe/xe_migrate.h
+@@ -129,6 +129,10 @@ struct dma_fence *xe_migrate_copy(struct xe_migrate *m,
+ 				  struct ttm_resource *dst,
+ 				  bool copy_only_ccs);
+ 
++struct dma_fence *xe_migrate_resolve(struct xe_migrate *m,
++				     struct xe_bo *bo,
++				     struct ttm_resource *res);
++
+ int xe_migrate_ccs_rw_copy(struct xe_tile *tile, struct xe_exec_queue *q,
+ 			   struct xe_bo *src_bo,
+ 			   enum xe_sriov_vf_ccs_rw_ctxs read_write);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-implement-VM_BIND-decompression-in-vm_bind_io.patch
+++ b/backport/patches/base/0001-drm-xe-implement-VM_BIND-decompression-in-vm_bind_io.patch
@@ -1,0 +1,302 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nitin Gote <nitin.r.gote@intel.com>
+Date: Wed, 4 Mar 2026 18:08:02 +0530
+Subject: drm/xe: implement VM_BIND decompression in vm_bind_ioctl
+
+Implement handling of VM_BIND(..., DECOMPRESS) in xe_vm_bind_ioctl.
+
+Key changes:
+- Parse and record per-op intent (op->map.request_decompress) when the
+  DECOMPRESS flag is present.
+- Use xe_pat_index_get_comp_en() helper to check if a PAT index
+  has compression enabled via the XE2_COMP_EN bit.
+- Validate DECOMPRESS preconditions in the ioctl path:
+  - Only valid for MAP ops.
+  - The provided pat_index must select the device's "no-compression" PAT.
+  - Only meaningful on devices with flat CCS and the required XE2+
+    otherwise return -EOPNOTSUPP.
+  - Use XE_IOCTL_DBG for uAPI sanity checks.
+- Implement xe_bo_decompress():
+  For VRAM BOs run xe_bo_move_notify(), reserve one fence slot,
+  schedule xe_migrate_resolve(), and attach the returned fence
+  with DMA_RESV_USAGE_KERNEL. Non-VRAM cases are silent no-ops.
+- Wire scheduling into vma_lock_and_validate() so VM_BIND will schedule
+  decompression when request_decompress is set.
+- Handle fault-mode VMs by performing decompression synchronously during
+  the bind process, ensuring that the resolve is completed before the bind
+  finishes.
+
+This schedules an in-place GPU resolve (xe_migrate_resolve) for
+decompression.
+
+Compute PR: https://github.com/intel/compute-runtime/pull/898
+IGT PR: https://patchwork.freedesktop.org/series/157553/
+
+v7: Rebase on latest drm-tip and add compute and igt pr info
+
+v6: (Matt Auld)
+   - Rebase as xe_pat_index_get_comp_en() is added in separate
+     patch
+   - Drop vm param from xe_bo_decompress(), instead of it
+     extract tile from bo
+   - Reject decompression on igpu instead of silent skipping
+     to avoid any failure on Xe2+igpu as xe_device_has_flat_ccs()
+     can sometimes be false on igpu due some setting in the BIOS
+     to turn off compression on igpu.
+   - Nits
+
+v5: (Matt)
+   - Correct the condition check of xe_pat_index_get_comp_en
+
+v4: (Matt)
+   - Introduce xe_pat_index_get_comp_en(), which checks
+     XE2_COMP_EN for the pat_index
+   - .interruptible should be true, everything else false
+
+v3: (Matt)
+   - s/xe_bo_schedule_decompress/xe_bo_decompress
+   - skip the decrompress step if the BO isn't in VRAM
+   - start/size not required in xe_bo_schedule_decompress
+   - Use xe_bo_move_notify instead of xe_vm_invalidate_vma
+     with respect to invalidation.
+   - Nits
+
+v2:
+   - Move decompression work out of vm_bind ioctl. (Matt)
+   - Put that work in a small helper at the BO/migrate layer invoke it
+     from vma_lock_and_validate which already runs under drm_exec.
+   - Move lightweight checks to vm_bind_ioctl_check_args (Matthew Auld)
+
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Matthew Auld <matthew.auld@intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Acked-by: Michal Mrozek <michal.mrozek@intel.com>
+Signed-off-by: Nitin Gote <nitin.r.gote@intel.com>
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://patch.msgid.link/20260304123758.3050386-8-nitin.r.gote@intel.com
+(backported from commit 2b484419700a0f563c695312374eb8cd5264b82c linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_bo.c       | 55 ++++++++++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_bo.h       |  2 ++
+ drivers/gpu/drm/xe/xe_vm.c       | 37 +++++++++++++++------
+ drivers/gpu/drm/xe/xe_vm_types.h |  2 ++
+ 4 files changed, 87 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
+index 004572f6838e4..efd3081c6b90d 100644
+--- a/drivers/gpu/drm/xe/xe_bo.c
++++ b/drivers/gpu/drm/xe/xe_bo.c
+@@ -3284,6 +3284,61 @@ int xe_gem_mmap_offset_ioctl(struct drm_device *dev, void *data,
+ 	return 0;
+ }
+ 
++/**
++ * xe_bo_decompress - schedule in-place decompress and install fence
++ * @bo: buffer object (caller should hold drm_exec reservations for VM+BO)
++ *
++ * Schedules an in-place resolve via the migrate layer and installs the
++ * returned dma_fence into the BO kernel reservation slot (DMA_RESV_USAGE_KERNEL).
++ * In preempt fence mode, this operation interrupts hardware execution
++ * which is expensive. Page fault mode is recommended for better performance.
++ *
++ * The resolve path only runs for VRAM-backed buffers (currently dGPU-only);
++ * iGPU/system-memory objects fail the resource check and bypass the resolve.
++ *
++ * Returns 0 on success, negative errno on error.
++ */
++int xe_bo_decompress(struct xe_bo *bo)
++{
++	struct xe_device *xe = xe_bo_device(bo);
++	struct xe_tile *tile = xe_device_get_root_tile(xe);
++	struct dma_fence *decomp_fence = NULL;
++	struct ttm_operation_ctx op_ctx = {
++		.interruptible = true,
++		.no_wait_gpu = false,
++		.gfp_retry_mayfail = false,
++	};
++	int err = 0;
++
++	/* Silently skip decompression for non-VRAM buffers */
++	if (!bo->ttm.resource || !mem_type_is_vram(bo->ttm.resource->mem_type))
++		return 0;
++
++	/* Notify before scheduling resolve */
++	err = xe_bo_move_notify(bo, &op_ctx);
++	if (err)
++		return err;
++
++	/* Reserve fence slot before scheduling */
++	err = dma_resv_reserve_fences(bo->ttm.base.resv, 1);
++	if (err)
++		return err;
++
++	/* Schedule the in-place decompression */
++	decomp_fence = xe_migrate_resolve(tile->migrate,
++					  bo,
++					  bo->ttm.resource);
++
++	if (IS_ERR(decomp_fence))
++		return PTR_ERR(decomp_fence);
++
++	/* Install kernel-usage fence */
++	dma_resv_add_fence(bo->ttm.base.resv, decomp_fence, DMA_RESV_USAGE_KERNEL);
++	dma_fence_put(decomp_fence);
++
++	return 0;
++}
++
+ /**
+  * xe_bo_lock() - Lock the buffer object's dma_resv object
+  * @bo: The struct xe_bo whose lock is to be taken
+diff --git a/drivers/gpu/drm/xe/xe_bo.h b/drivers/gpu/drm/xe/xe_bo.h
+index 9be762e2f2511..0c3e1e406b7e2 100644
+--- a/drivers/gpu/drm/xe/xe_bo.h
++++ b/drivers/gpu/drm/xe/xe_bo.h
+@@ -307,6 +307,8 @@ int xe_bo_dumb_create(struct drm_file *file_priv,
+ 
+ bool xe_bo_needs_ccs_pages(struct xe_bo *bo);
+ 
++int xe_bo_decompress(struct xe_bo *bo);
++
+ static inline size_t xe_bo_ccs_pages_start(struct xe_bo *bo)
+ {
+ 	return PAGE_ALIGN(xe_bo_size(bo));
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index f3c59afd195f7..8e8df7e229734 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -2468,6 +2468,7 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_vma_ops *vops,
+ 			op->map.is_cpu_addr_mirror = flags &
+ 				DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR;
+ 			op->map.dumpable = flags & DRM_XE_VM_BIND_FLAG_DUMPABLE;
++			op->map.request_decompress = flags & DRM_XE_VM_BIND_FLAG_DECOMPRESS;
+ 			op->map.pat_index = pat_index;
+ 			op->map.invalidate_on_bind =
+ 				__xe_vm_needs_clear_scratch_pages(vm, flags);
+@@ -2970,7 +2971,7 @@ static void vm_bind_ioctl_ops_unwind(struct xe_vm *vm,
+ }
+ 
+ static int vma_lock_and_validate(struct drm_exec *exec, struct xe_vma *vma,
+-				 bool res_evict, bool validate)
++				 bool res_evict, bool validate, bool request_decompress)
+ {
+ 	struct xe_bo *bo = xe_vma_bo(vma);
+ 	struct xe_vm *vm = xe_vma_vm(vma);
+@@ -2983,6 +2984,12 @@ static int vma_lock_and_validate(struct drm_exec *exec, struct xe_vma *vma,
+ 			err = xe_bo_validate(bo, vm,
+ 					     !xe_vm_in_preempt_fence_mode(vm) &&
+ 					     res_evict, exec);
++
++		if (err)
++			return err;
++
++		if (request_decompress)
++			err = xe_bo_decompress(bo);
+ 	}
+ 
+ 	return err;
+@@ -3073,7 +3080,8 @@ static int op_lock_and_prep(struct drm_exec *exec, struct xe_vm *vm,
+ 			err = vma_lock_and_validate(exec, op->map.vma,
+ 						    res_evict,
+ 						    !xe_vm_in_fault_mode(vm) ||
+-						    op->map.immediate);
++						    op->map.immediate,
++						    op->map.request_decompress);
+ 		break;
+ 	case DRM_GPUVA_OP_REMAP:
+ 		err = check_ufence(gpuva_to_vma(op->base.remap.unmap->va));
+@@ -3082,13 +3090,13 @@ static int op_lock_and_prep(struct drm_exec *exec, struct xe_vm *vm,
+ 
+ 		err = vma_lock_and_validate(exec,
+ 					    gpuva_to_vma(op->base.remap.unmap->va),
+-					    res_evict, false);
++					    res_evict, false, false);
+ 		if (!err && op->remap.prev)
+ 			err = vma_lock_and_validate(exec, op->remap.prev,
+-						    res_evict, true);
++						    res_evict, true, false);
+ 		if (!err && op->remap.next)
+ 			err = vma_lock_and_validate(exec, op->remap.next,
+-						    res_evict, true);
++						    res_evict, true, false);
+ 		break;
+ 	case DRM_GPUVA_OP_UNMAP:
+ 		err = check_ufence(gpuva_to_vma(op->base.unmap.va));
+@@ -3097,7 +3105,7 @@ static int op_lock_and_prep(struct drm_exec *exec, struct xe_vm *vm,
+ 
+ 		err = vma_lock_and_validate(exec,
+ 					    gpuva_to_vma(op->base.unmap.va),
+-					    res_evict, false);
++					    res_evict, false, false);
+ 		break;
+ 	case DRM_GPUVA_OP_PREFETCH:
+ 	{
+@@ -3113,7 +3121,7 @@ static int op_lock_and_prep(struct drm_exec *exec, struct xe_vm *vm,
+ 
+ 		err = vma_lock_and_validate(exec,
+ 					    gpuva_to_vma(op->base.prefetch.va),
+-					    res_evict, false);
++					    res_evict, false, false);
+ 		if (!err && !xe_vma_has_no_bo(vma))
+ 			err = xe_bo_migrate(xe_vma_bo(vma),
+ 					    region_to_mem_type[region], NULL, exec);
+@@ -3432,7 +3440,8 @@ ALLOW_ERROR_INJECTION(vm_bind_ioctl_ops_execute, ERRNO);
+ 	 DRM_XE_VM_BIND_FLAG_NULL | \
+ 	 DRM_XE_VM_BIND_FLAG_DUMPABLE | \
+ 	 DRM_XE_VM_BIND_FLAG_CHECK_PXP | \
+-	 DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR)
++	 DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR | \
++	 DRM_XE_VM_BIND_FLAG_DECOMPRESS)
+ 
+ #ifdef TEST_VM_OPS_ERROR
+ #define SUPPORTED_FLAGS	(SUPPORTED_FLAGS_STUB | FORCE_OP_ERROR)
+@@ -3490,6 +3499,7 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
+ 		bool is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
+ 		bool is_cpu_addr_mirror = flags &
+ 			DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR;
++		bool is_decompress = flags & DRM_XE_VM_BIND_FLAG_DECOMPRESS;
+ 		u16 pat_index = (*bind_ops)[i].pat_index;
+ 		u16 coh_mode;
+ 
+@@ -3524,7 +3534,9 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
+ 		    XE_IOCTL_DBG(xe, obj_offset && (is_null ||
+ 						    is_cpu_addr_mirror)) ||
+ 		    XE_IOCTL_DBG(xe, op != DRM_XE_VM_BIND_OP_MAP &&
+-				 (is_null || is_cpu_addr_mirror)) ||
++				 (is_decompress || is_null || is_cpu_addr_mirror)) ||
++		    XE_IOCTL_DBG(xe, is_decompress &&
++				 xe_pat_index_get_comp_en(xe, pat_index)) ||
+ 		    XE_IOCTL_DBG(xe, !obj &&
+ 				 op == DRM_XE_VM_BIND_OP_MAP &&
+ 				 !is_null && !is_cpu_addr_mirror) ||
+@@ -3558,6 +3570,13 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
+ 			err = -EINVAL;
+ 			goto free_bind_ops;
+ 		}
++
++		if (is_decompress && (XE_IOCTL_DBG(xe, !xe_device_has_flat_ccs(xe)) ||
++				      XE_IOCTL_DBG(xe, GRAPHICS_VER(xe) < 20) ||
++				      XE_IOCTL_DBG(xe, !IS_DGFX(xe)))) {
++			err = -EOPNOTSUPP;
++			goto free_bind_ops;
++		}
+ 	}
+ 
+ 	return 0;
+diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
+index 3a4a15bce5ee0..cbac8fbaf93d2 100644
+--- a/drivers/gpu/drm/xe/xe_vm_types.h
++++ b/drivers/gpu/drm/xe/xe_vm_types.h
+@@ -363,6 +363,8 @@ struct xe_vma_op_map {
+ 	bool dumpable;
+ 	/** @invalidate: invalidate the VMA before bind */
+ 	bool invalidate_on_bind;
++	/** @request_decompress: schedule decompression for GPU map */
++	bool request_decompress;
+ 	/** @pat_index: The pat index to use for this operation. */
+ 	u16 pat_index;
+ };
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pat-Add-helper-to-query-compression-enable-st.patch
+++ b/backport/patches/base/0001-drm-xe-pat-Add-helper-to-query-compression-enable-st.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xin Wang <x.wang@intel.com>
+Date: Mon, 10 Nov 2025 22:14:58 +0000
+Subject: drm/xe/pat: Add helper to query compression enable status
+
+Add xe_pat_index_get_comp_en() helper function to check whether
+compression is enabled for a given PAT index by extracting the
+XE2_COMP_EN bit from the PAT table entry.
+
+There are no current users, however there are multiple in-flight series
+which will all use this helper.
+
+CC: Nitin Gote <nitin.r.gote@intel.com>
+CC: Sanjay Yadav <sanjay.kumar.yadav@intel.com>
+CC: Matt Roper <matthew.d.roper@intel.com>
+Suggested-by: Matthew Auld <matthew.auld@intel.com>
+Signed-off-by: Xin Wang <x.wang@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Reviewed-by: Nitin Gote <nitin.r.gote@intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Reviewed-by: Sanjay Yadav <sanjay.kumar.yadav@intel.com>
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://patch.msgid.link/20251110221458.1864507-2-x.wang@intel.com
+(cherry-picked from commit b2bce0e551e89af37cfcb1b1158d80f369eeea3f linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pat.c |  6 ++++++
+ drivers/gpu/drm/xe/xe_pat.h | 10 ++++++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_pat.c b/drivers/gpu/drm/xe/xe_pat.c
+index 6e48ff84ad0a0..a3a7f99f07aed 100644
+--- a/drivers/gpu/drm/xe/xe_pat.c
++++ b/drivers/gpu/drm/xe/xe_pat.c
+@@ -160,6 +160,12 @@ u16 xe_pat_index_get_coh_mode(struct xe_device *xe, u16 pat_index)
+ 	return xe->pat.table[pat_index].coh_mode;
+ }
+ 
++bool xe_pat_index_get_comp_en(struct xe_device *xe, u16 pat_index)
++{
++	WARN_ON(pat_index >= xe->pat.n_entries);
++	return !!(xe->pat.table[pat_index].value & XE2_COMP_EN);
++}
++
+ static void program_pat(struct xe_gt *gt, const struct xe_pat_table_entry table[],
+ 			int n_entries)
+ {
+diff --git a/drivers/gpu/drm/xe/xe_pat.h b/drivers/gpu/drm/xe/xe_pat.h
+index 268c9a899f56f..a04c58dfba85f 100644
+--- a/drivers/gpu/drm/xe/xe_pat.h
++++ b/drivers/gpu/drm/xe/xe_pat.h
+@@ -53,4 +53,14 @@ int xe_pat_dump(struct xe_gt *gt, struct drm_printer *p);
+  */
+ u16 xe_pat_index_get_coh_mode(struct xe_device *xe, u16 pat_index);
+ 
++/**
++ * xe_pat_index_get_comp_en - Extract the compression enable flag for
++ * the given pat_index.
++ * @xe: xe device
++ * @pat_index: The pat_index to query
++ *
++ * Return: true if compression is enabled for this pat_index, false otherwise.
++ */
++bool xe_pat_index_get_comp_en(struct xe_device *xe, u16 pat_index);
++
+ #endif
+-- 
+2.43.0
+

--- a/backport/patches/features/eu-debug/0001-drm-xe-Attach-debug-metadata-to-vma.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Attach-debug-metadata-to-vma.patch
@@ -25,7 +25,7 @@ Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
  5 files changed, 315 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.c b/drivers/gpu/drm/xe/xe_debug_metadata.c
-index 1dfed9aed285..b045bdd77235 100644
+index 1dfed9aed2853..b045bdd772353 100644
 --- a/drivers/gpu/drm/xe/xe_debug_metadata.c
 +++ b/drivers/gpu/drm/xe/xe_debug_metadata.c
 @@ -10,6 +10,113 @@
@@ -163,7 +163,7 @@ index 1dfed9aed285..b045bdd77235 100644
  				   void *data,
  				   struct drm_file *file)
 diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.h b/drivers/gpu/drm/xe/xe_debug_metadata.h
-index a02f02bb75da..c7624ac30ac0 100644
+index a02f02bb75dae..c7624ac30ac07 100644
 --- a/drivers/gpu/drm/xe/xe_debug_metadata.h
 +++ b/drivers/gpu/drm/xe/xe_debug_metadata.h
 @@ -6,13 +6,18 @@
@@ -252,7 +252,7 @@ index a02f02bb75da..c7624ac30ac0 100644
  
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index f5d2a9f32cbd..a85c42ad978d 100644
+index 7a29ea268ef70..fdcf5f65e3585 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
 @@ -24,6 +24,7 @@
@@ -263,7 +263,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  #include "xe_device.h"
  #include "xe_drm_client.h"
  #include "xe_eudebug.h"
-@@ -1207,6 +1208,9 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
+@@ -1254,6 +1255,9 @@ static struct xe_vma *xe_vma_create(struct xe_vm *vm,
  			vma->gpuva.gem.obj = &bo->ttm.base;
  	}
  
@@ -273,7 +273,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  	INIT_LIST_HEAD(&vma->combined_links.rebind);
  
  	INIT_LIST_HEAD(&vma->gpuva.gem.entry);
-@@ -1301,6 +1305,7 @@ static void xe_vma_destroy_late(struct xe_vma *vma)
+@@ -1348,6 +1352,7 @@ static void xe_vma_destroy_late(struct xe_vma *vma)
  		xe_bo_put(xe_vma_bo(vma));
  	}
  
@@ -281,7 +281,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  	xe_vma_free(vma);
  }
  
-@@ -2375,6 +2380,10 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -2483,6 +2488,10 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_vma_ops *vops,
  			op->map.pat_index = pat_index;
  			op->map.invalidate_on_bind =
  				__xe_vm_needs_clear_scratch_pages(vm, flags);
@@ -292,7 +292,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  		} else if (__op->op == DRM_GPUVA_OP_PREFETCH) {
  			struct xe_vma *vma = gpuva_to_vma(op->base.prefetch.va);
  			struct xe_svm_range *svm_range;
-@@ -2639,6 +2648,9 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+@@ -2758,6 +2767,9 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
  			if (IS_ERR(vma))
  				return PTR_ERR(vma);
  
@@ -302,7 +302,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  			op->map.vma = vma;
  			if (((op->map.immediate || !xe_vm_in_fault_mode(vm)) &&
  			     !op->map.is_cpu_addr_mirror) ||
-@@ -2686,6 +2698,9 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+@@ -2805,6 +2817,9 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
  				if (IS_ERR(vma))
  					return PTR_ERR(vma);
  
@@ -312,7 +312,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  				op->remap.prev = vma;
  
  				/*
-@@ -2716,6 +2731,16 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+@@ -2835,6 +2850,16 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
  				if (IS_ERR(vma))
  					return PTR_ERR(vma);
  
@@ -329,7 +329,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  				op->remap.next = vma;
  
  				/*
-@@ -2792,6 +2817,7 @@ static void xe_vma_op_unwind(struct xe_vm *vm, struct xe_vma_op *op,
+@@ -2911,6 +2936,7 @@ static void xe_vma_op_unwind(struct xe_vm *vm, struct xe_vma_op *op,
  	switch (op->base.op) {
  	case DRM_GPUVA_OP_MAP:
  		if (op->map.vma) {
@@ -337,7 +337,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  			prep_vma_destroy(vm, op->map.vma, post_commit);
  			xe_vma_destroy_unlocked(op->map.vma);
  		}
-@@ -3110,6 +3136,58 @@ static int vm_ops_setup_tile_args(struct xe_vm *vm, struct xe_vma_ops *vops)
+@@ -3248,6 +3274,58 @@ static int vm_ops_setup_tile_args(struct xe_vm *vm, struct xe_vma_ops *vops)
  	}
  
  	return number_tiles;
@@ -396,7 +396,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  }
  
  static struct dma_fence *ops_execute(struct xe_vm *vm,
-@@ -3312,7 +3390,9 @@ ALLOW_ERROR_INJECTION(vm_bind_ioctl_ops_execute, ERRNO);
+@@ -3466,7 +3544,9 @@ ALLOW_ERROR_INJECTION(vm_bind_ioctl_ops_execute, ERRNO);
  #define XE_64K_PAGE_MASK 0xffffull
  #define ALL_DRM_XE_SYNCS_FLAGS (DRM_XE_SYNCS_FLAG_WAIT_FOR_OP)
  
@@ -407,16 +407,16 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  				    struct drm_xe_vm_bind *args,
  				    struct drm_xe_vm_bind_op **bind_ops)
  {
-@@ -3359,6 +3439,7 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
- 		bool is_null = flags & DRM_XE_VM_BIND_FLAG_NULL;
+@@ -3517,6 +3597,7 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
  		bool is_cpu_addr_mirror = flags &
  			DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR;
+ 		bool is_decompress = flags & DRM_XE_VM_BIND_FLAG_DECOMPRESS;
 +		u64 extensions = (*bind_ops)[i].extensions;
  		u16 pat_index = (*bind_ops)[i].pat_index;
  		u16 coh_mode;
  
-@@ -3427,6 +3508,13 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
- 			err = -EINVAL;
+@@ -3594,6 +3675,13 @@ static int vm_bind_ioctl_check_args(struct xe_device *xe, struct xe_vm *vm,
+ 			err = -EOPNOTSUPP;
  			goto free_bind_ops;
  		}
 +
@@ -429,7 +429,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  	}
  
  	return 0;
-@@ -3551,7 +3639,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3718,7 +3806,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  	if (XE_IOCTL_DBG(xe, !vm))
  		return -EINVAL;
  
@@ -438,7 +438,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  	if (err)
  		goto put_vm;
  
-@@ -3680,11 +3768,17 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3858,11 +3946,17 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		u64 obj_offset = bind_ops[i].obj_offset;
  		u32 prefetch_region = bind_ops[i].prefetch_mem_region_instance;
  		u16 pat_index = bind_ops[i].pat_index;
@@ -458,7 +458,7 @@ index f5d2a9f32cbd..a85c42ad978d 100644
  			ops[i] = NULL;
  			goto unwind_ops;
 diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
-index cc53ea5de669..79bb9b0bf113 100644
+index b1b37d3f9a995..083782d99b3f4 100644
 --- a/drivers/gpu/drm/xe/xe_vm_types.h
 +++ b/drivers/gpu/drm/xe/xe_vm_types.h
 @@ -77,6 +77,15 @@ struct xe_userptr {
@@ -489,8 +489,8 @@ index cc53ea5de669..79bb9b0bf113 100644
  };
  
  /**
-@@ -362,6 +376,10 @@ struct xe_vma_op_map {
- 	bool invalidate_on_bind;
+@@ -380,6 +394,10 @@ struct xe_vma_op_map {
+ 	bool request_decompress;
  	/** @pat_index: The pat index to use for this operation. */
  	u16 pat_index;
 +	struct  {
@@ -500,7 +500,7 @@ index cc53ea5de669..79bb9b0bf113 100644
  };
  
  /** struct xe_vma_op_remap - VMA remap operation */
-@@ -482,4 +500,14 @@ struct xe_vma_ops {
+@@ -503,4 +521,14 @@ struct xe_vma_ops {
  #endif
  };
  
@@ -516,7 +516,7 @@ index cc53ea5de669..79bb9b0bf113 100644
 +
  #endif
 diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
-index e8a04073b2cc..5abba79e8056 100644
+index 3c0269180c0cd..c02ec368d4c5e 100644
 --- a/include/uapi/drm/xe_drm.h
 +++ b/include/uapi/drm/xe_drm.h
 @@ -976,6 +976,23 @@ struct drm_xe_vm_destroy {
@@ -543,11 +543,11 @@ index e8a04073b2cc..5abba79e8056 100644
  /**
   * struct drm_xe_vm_bind_op - run bind operations
   *
-@@ -1010,6 +1027,7 @@ struct drm_xe_vm_destroy {
-  *    handle MBZ, and the BO offset MBZ.
+@@ -1017,6 +1034,7 @@ struct drm_xe_vm_destroy {
+  *    support Flat CCS and the required HW generation XE2+.
   */
  struct drm_xe_vm_bind_op {
-+#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG 0
++#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG	0
  	/** @extensions: Pointer to the first extension struct, if any */
  	__u64 extensions;
  

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
@@ -52,10 +52,10 @@ Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
  delete mode 100644 include/uapi/drm/xe_drm_eudebug.h
 
 diff --git a/drivers/gpu/drm/xe/Kconfig b/drivers/gpu/drm/xe/Kconfig
-index fba32c51e..63c7b4db5 100644
+index 9cbf7518e8ae5..16a75c8f6a5a7 100644
 --- a/drivers/gpu/drm/xe/Kconfig
 +++ b/drivers/gpu/drm/xe/Kconfig
-@@ -129,7 +129,7 @@ config DRM_XE_FORCE_PROBE
+@@ -128,7 +128,7 @@ config DRM_XE_FORCE_PROBE
  
  	  Use "!*" to block the probe of the driver for all known devices.
  
@@ -65,7 +65,7 @@ index fba32c51e..63c7b4db5 100644
  	depends on DRM_XE
  	default y
 diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
-index 7c465cfc4..cc800c373 100644
+index 7c465cfc468c9..cc800c3738838 100644
 --- a/drivers/gpu/drm/xe/Makefile
 +++ b/drivers/gpu/drm/xe/Makefile
 @@ -57,7 +57,7 @@ xe-y += xe_bb.o \
@@ -92,7 +92,7 @@ diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.c b/drivers/gpu/drm/xe/prelim/
 similarity index 76%
 rename from drivers/gpu/drm/xe/xe_debug_metadata.c
 rename to drivers/gpu/drm/xe/prelim/xe_debug_metadata.c
-index c9a7596cb..d8e718b4a 100644
+index c9a7596cb005a..d8e718b4a62eb 100644
 --- a/drivers/gpu/drm/xe/xe_debug_metadata.c
 +++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata.c
 @@ -9,7 +9,7 @@
@@ -230,7 +230,7 @@ diff --git a/drivers/gpu/drm/xe/xe_debug_metadata.h b/drivers/gpu/drm/xe/prelim/
 similarity index 68%
 rename from drivers/gpu/drm/xe/xe_debug_metadata.h
 rename to drivers/gpu/drm/xe/prelim/xe_debug_metadata.h
-index c7624ac30..5cfc7d072 100644
+index c7624ac30ac07..5cfc7d072adab 100644
 --- a/drivers/gpu/drm/xe/xe_debug_metadata.h
 +++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata.h
 @@ -12,19 +12,19 @@ struct drm_device;
@@ -307,7 +307,7 @@ diff --git a/drivers/gpu/drm/xe/xe_debug_metadata_types.h b/drivers/gpu/drm/xe/p
 similarity index 92%
 rename from drivers/gpu/drm/xe/xe_debug_metadata_types.h
 rename to drivers/gpu/drm/xe/prelim/xe_debug_metadata_types.h
-index 624852920..7d3db6a00 100644
+index 624852920f588..7d3db6a004ff8 100644
 --- a/drivers/gpu/drm/xe/xe_debug_metadata_types.h
 +++ b/drivers/gpu/drm/xe/prelim/xe_debug_metadata_types.h
 @@ -8,7 +8,7 @@
@@ -323,7 +323,7 @@ diff --git a/drivers/gpu/drm/xe/xe_eudebug.c b/drivers/gpu/drm/xe/prelim/xe_eude
 similarity index 88%
 rename from drivers/gpu/drm/xe/xe_eudebug.c
 rename to drivers/gpu/drm/xe/prelim/xe_eudebug.c
-index 2f9df453e..b650f3215 100644
+index 2f9df453e14f3..b650f3215cde5 100644
 --- a/drivers/gpu/drm/xe/xe_eudebug.c
 +++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.c
 @@ -257,7 +257,7 @@ static void xe_eudebug_free(struct kref *ref)
@@ -1652,7 +1652,7 @@ index 2f9df453e..b650f3215 100644
  	if (!send_event) {
 diff --git a/drivers/gpu/drm/xe/prelim/xe_eudebug.h b/drivers/gpu/drm/xe/prelim/xe_eudebug.h
 new file mode 100644
-index 000000000..f9740a420
+index 0000000000000..f9740a420b322
 --- /dev/null
 +++ b/drivers/gpu/drm/xe/prelim/xe_eudebug.h
 @@ -0,0 +1,134 @@
@@ -1798,7 +1798,7 @@ diff --git a/drivers/gpu/drm/xe/xe_gt_debug.c b/drivers/gpu/drm/xe/prelim/xe_gt_
 similarity index 83%
 rename from drivers/gpu/drm/xe/xe_gt_debug.c
 rename to drivers/gpu/drm/xe/prelim/xe_gt_debug.c
-index 8386a527a..1c31b17ca 100644
+index 8386a527adf02..1c31b17cadeb9 100644
 --- a/drivers/gpu/drm/xe/xe_gt_debug.c
 +++ b/drivers/gpu/drm/xe/prelim/xe_gt_debug.c
 @@ -19,7 +19,7 @@ unsigned int xe_gt_eu_att_regs(struct xe_gt *gt)
@@ -1906,7 +1906,7 @@ diff --git a/drivers/gpu/drm/xe/xe_gt_debug.h b/drivers/gpu/drm/xe/prelim/xe_gt_
 similarity index 70%
 rename from drivers/gpu/drm/xe/xe_gt_debug.h
 rename to drivers/gpu/drm/xe/prelim/xe_gt_debug.h
-index aba36bc5f..53e2f5608 100644
+index aba36bc5f85d1..53e2f5608c3af 100644
 --- a/drivers/gpu/drm/xe/xe_gt_debug.h
 +++ b/drivers/gpu/drm/xe/prelim/xe_gt_debug.h
 @@ -11,7 +11,7 @@
@@ -1945,7 +1945,7 @@ index aba36bc5f..53e2f5608 100644
  			      const unsigned int settle_time_ms);
  
 diff --git a/drivers/gpu/drm/xe/tests/xe_live_test_mod.c b/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
-index 663ef0e9d..67804b13e 100644
+index 663ef0e9d13e3..67804b13e50e0 100644
 --- a/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
 +++ b/drivers/gpu/drm/xe/tests/xe_live_test_mod.c
 @@ -17,7 +17,7 @@ kunit_test_suite(xe_dma_buf_test_suite);
@@ -1958,7 +1958,7 @@ index 663ef0e9d..67804b13e 100644
  kunit_test_suite(xe_eudebug_test_suite);
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
-index 30a71f20e..6445a8c17 100644
+index d2375036e7cb6..8647cc82537e9 100644
 --- a/drivers/gpu/drm/xe/xe_device.c
 +++ b/drivers/gpu/drm/xe/xe_device.c
 @@ -27,11 +27,11 @@
@@ -2026,7 +2026,7 @@ index 30a71f20e..6445a8c17 100644
  	err = xe_pcode_probe_early(xe);
  	if (err || xe_survivability_mode_is_requested(xe)) {
 diff --git a/drivers/gpu/drm/xe/xe_device.h b/drivers/gpu/drm/xe/xe_device.h
-index 0c8e96b61..3b37f8781 100644
+index 0c8e96b61e9c7..3b37f878158b4 100644
 --- a/drivers/gpu/drm/xe/xe_device.h
 +++ b/drivers/gpu/drm/xe/xe_device.h
 @@ -210,7 +210,7 @@ int xe_is_injection_active(void);
@@ -2060,7 +2060,7 @@ index 0c8e96b61..3b37f8781 100644
  
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
-index 02c9c7fbc..78f607b3d 100644
+index a54777a6c3679..0c40905f6d9d4 100644
 --- a/drivers/gpu/drm/xe/xe_device_types.h
 +++ b/drivers/gpu/drm/xe/xe_device_types.h
 @@ -13,7 +13,7 @@
@@ -2072,7 +2072,7 @@ index 02c9c7fbc..78f607b3d 100644
  #include "xe_heci_gsc.h"
  #include "xe_late_bind_fw_types.h"
  #include "xe_lmtt_types.h"
-@@ -404,7 +404,7 @@ struct xe_device {
+@@ -420,7 +420,7 @@ struct xe_device {
  		struct workqueue_struct *wq;
  	} sriov;
  
@@ -2081,7 +2081,7 @@ index 02c9c7fbc..78f607b3d 100644
  	/** @clients: eudebug clients info */
  	struct {
  		/** @clients.lock: Protects client list */
-@@ -616,7 +616,7 @@ struct xe_device {
+@@ -634,7 +634,7 @@ struct xe_device {
  	atomic64_t global_total_pages;
  #endif
  
@@ -2090,7 +2090,7 @@ index 02c9c7fbc..78f607b3d 100644
  	/** @debugger connection list and globals for device */
  	struct {
  		/** @lock: protects the list of connections */
-@@ -743,7 +743,7 @@ struct xe_file {
+@@ -761,7 +761,7 @@ struct xe_file {
  	/** @refcount: ref count of this xe file */
  	struct kref refcount;
  
@@ -2100,7 +2100,7 @@ index 02c9c7fbc..78f607b3d 100644
  		/** @client_link: list entry in xe_device.clients.list */
  		struct list_head client_link;
 diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
-index d22fbb196..8b472ff65 100644
+index d087ed07b6680..bb03e2358f444 100644
 --- a/drivers/gpu/drm/xe/xe_exec_queue.c
 +++ b/drivers/gpu/drm/xe/xe_exec_queue.c
 @@ -29,7 +29,7 @@
@@ -2112,7 +2112,7 @@ index d22fbb196..8b472ff65 100644
  
  enum xe_exec_queue_sched_prop {
  	XE_EXEC_QUEUE_JOB_TIMEOUT = 0,
-@@ -559,7 +559,7 @@ exec_queue_set_pxp_type(struct xe_device *xe, struct xe_exec_queue *q, u64 value
+@@ -558,7 +558,7 @@ exec_queue_set_pxp_type(struct xe_device *xe, struct xe_exec_queue *q, u64 value
  static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
  				  u64 value)
  {
@@ -2121,7 +2121,7 @@ index d22fbb196..8b472ff65 100644
  
  	if (XE_IOCTL_DBG(xe, (q->class != XE_ENGINE_CLASS_RENDER &&
  			      q->class != XE_ENGINE_CLASS_COMPUTE)))
-@@ -568,7 +568,7 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
+@@ -567,7 +567,7 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
  	if (XE_IOCTL_DBG(xe, (value & ~known_flags)))
  		return -EINVAL;
  
@@ -2130,7 +2130,7 @@ index d22fbb196..8b472ff65 100644
  		return -EOPNOTSUPP;
  
  	if (XE_IOCTL_DBG(xe, !xe_exec_queue_is_lr(q)))
-@@ -578,10 +578,10 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
+@@ -577,10 +577,10 @@ static int exec_queue_set_eudebug(struct xe_device *xe, struct xe_exec_queue *q,
  	 * property is set.
  	 */
  	if (XE_IOCTL_DBG(xe,
@@ -2143,7 +2143,7 @@ index d22fbb196..8b472ff65 100644
  		return -EPERM;
  
  	q->eudebug_flags = EXEC_QUEUE_EUDEBUG_FLAG_ENABLE;
-@@ -603,7 +603,7 @@ static const xe_exec_queue_set_property_fn exec_queue_set_property_funcs[] = {
+@@ -602,7 +602,7 @@ static const xe_exec_queue_set_property_fn exec_queue_set_property_funcs[] = {
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY] = exec_queue_set_priority,
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE] = exec_queue_set_timeslice,
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_PXP_TYPE] = exec_queue_set_pxp_type,
@@ -2152,7 +2152,7 @@ index d22fbb196..8b472ff65 100644
  };
  
  static int exec_queue_user_ext_set_property(struct xe_device *xe,
-@@ -625,7 +625,7 @@ static int exec_queue_user_ext_set_property(struct xe_device *xe,
+@@ -624,7 +624,7 @@ static int exec_queue_user_ext_set_property(struct xe_device *xe,
  	    XE_IOCTL_DBG(xe, ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY &&
  			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE &&
  			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_PXP_TYPE &&
@@ -2161,7 +2161,7 @@ index d22fbb196..8b472ff65 100644
  		return -EINVAL;
  
  	idx = array_index_nospec(ext.property, ARRAY_SIZE(exec_queue_set_property_funcs));
-@@ -872,7 +872,7 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
+@@ -871,7 +871,7 @@ int xe_exec_queue_create_ioctl(struct drm_device *dev, void *data,
  
  	args->exec_queue_id = id;
  
@@ -2170,7 +2170,7 @@ index d22fbb196..8b472ff65 100644
  
  	return 0;
  
-@@ -1059,7 +1059,7 @@ int xe_exec_queue_destroy_ioctl(struct drm_device *dev, void *data,
+@@ -1058,7 +1058,7 @@ int xe_exec_queue_destroy_ioctl(struct drm_device *dev, void *data,
  	if (q->vm && q->hwe->hw_engine_group)
  		xe_hw_engine_group_del_exec_queue(q->hwe->hw_engine_group, q);
  
@@ -2180,7 +2180,7 @@ index d22fbb196..8b472ff65 100644
  	xe_exec_queue_kill(q);
  
 diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
-index bb4266593..694cce984 100644
+index 9ae98dece94e1..25e4be9b95682 100644
 --- a/drivers/gpu/drm/xe/xe_gt.c
 +++ b/drivers/gpu/drm/xe/xe_gt.c
 @@ -22,7 +22,7 @@
@@ -2192,7 +2192,7 @@ index bb4266593..694cce984 100644
  #include "xe_eu_stall.h"
  #include "xe_exec_queue.h"
  #include "xe_execlist.h"
-@@ -762,7 +762,7 @@ static int do_gt_reset(struct xe_gt *gt)
+@@ -804,7 +804,7 @@ static int do_gt_reset(struct xe_gt *gt)
  
  	xe_gsc_wa_14015076503(gt, true);
  
@@ -2202,7 +2202,7 @@ index bb4266593..694cce984 100644
  
  	xe_mmio_write32(&gt->mmio, GDRST, GRDOM_FULL);
 diff --git a/drivers/gpu/drm/xe/xe_gt_pagefault.c b/drivers/gpu/drm/xe/xe_gt_pagefault.c
-index ee8a598d3..327fe243d 100644
+index ee8a598d32282..327fe243d96d3 100644
 --- a/drivers/gpu/drm/xe/xe_gt_pagefault.c
 +++ b/drivers/gpu/drm/xe/xe_gt_pagefault.c
 @@ -13,7 +13,7 @@
@@ -2249,7 +2249,7 @@ index ee8a598d3..327fe243d 100644
  	xe_vm_put(vm);
  }
 diff --git a/drivers/gpu/drm/xe/xe_hw_engine.c b/drivers/gpu/drm/xe/xe_hw_engine.c
-index cb400c051..123a7000e 100644
+index cb400c051db6d..123a7000e8bfe 100644
 --- a/drivers/gpu/drm/xe/xe_hw_engine.c
 +++ b/drivers/gpu/drm/xe/xe_hw_engine.c
 @@ -19,7 +19,7 @@
@@ -2262,7 +2262,7 @@ index cb400c051..123a7000e 100644
  #include "xe_force_wake.h"
  #include "xe_gsc.h"
 diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
-index 04bd13be9..b58657cc7 100644
+index c8d6dbf95ed9d..c0ebf82088f8a 100644
 --- a/drivers/gpu/drm/xe/xe_sync.c
 +++ b/drivers/gpu/drm/xe/xe_sync.c
 @@ -15,7 +15,7 @@
@@ -2302,7 +2302,7 @@ index 04bd13be9..b58657cc7 100644
  		xe_sync_ufence_signal(ufence);
  
 diff --git a/drivers/gpu/drm/xe/xe_sync_types.h b/drivers/gpu/drm/xe/xe_sync_types.h
-index 33a93a0fa..be9fc77ad 100644
+index 33a93a0faa725..be9fc77add85f 100644
 --- a/drivers/gpu/drm/xe/xe_sync_types.h
 +++ b/drivers/gpu/drm/xe/xe_sync_types.h
 @@ -21,7 +21,7 @@ struct xe_user_fence {
@@ -2315,7 +2315,7 @@ index 33a93a0fa..be9fc77ad 100644
  		spinlock_t lock;
  		struct xe_eudebug *debugger;
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index 66c35c1ea..ea6916a67 100644
+index b271295c30026..7b40907d43d59 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
 @@ -24,10 +24,10 @@
@@ -2340,7 +2340,7 @@ index 66c35c1ea..ea6916a67 100644
  	INIT_LIST_HEAD(&vma->eudebug.metadata.list);
  #endif
  	INIT_LIST_HEAD(&vma->combined_links.rebind);
-@@ -1797,7 +1797,7 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
+@@ -1800,7 +1800,7 @@ struct xe_vm *xe_vm_create(struct xe_device *xe, u32 flags, struct xe_file *xef)
  	for_each_tile(tile, xe, id)
  		xe_range_fence_tree_init(&vm->rftree[id]);
  
@@ -2349,7 +2349,7 @@ index 66c35c1ea..ea6916a67 100644
  
  	vm->pt_ops = &xelp_pt_ops;
  
-@@ -2112,7 +2112,7 @@ static void vm_destroy_work_func(struct work_struct *w)
+@@ -2114,7 +2114,7 @@ static void vm_destroy_work_func(struct work_struct *w)
  	struct xe_tile *tile;
  	u8 id;
  
@@ -2358,7 +2358,7 @@ index 66c35c1ea..ea6916a67 100644
  
  	/* xe_vm_close_and_put was not called? */
  	xe_assert(xe, !vm->size);
-@@ -2248,7 +2248,7 @@ int xe_vm_create_ioctl(struct drm_device *dev, void *data,
+@@ -2250,7 +2250,7 @@ int xe_vm_create_ioctl(struct drm_device *dev, void *data,
  
  	args->vm_id = id;
  
@@ -2367,7 +2367,7 @@ index 66c35c1ea..ea6916a67 100644
  
  	return 0;
  
-@@ -2282,7 +2282,7 @@ int xe_vm_destroy_ioctl(struct drm_device *dev, void *data,
+@@ -2284,7 +2284,7 @@ int xe_vm_destroy_ioctl(struct drm_device *dev, void *data,
  	mutex_unlock(&xef->vm.lock);
  
  	if (!err) {
@@ -2376,7 +2376,7 @@ index 66c35c1ea..ea6916a67 100644
  		xe_vm_close_and_put(vm);
  	}
  
-@@ -2486,7 +2486,7 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -2489,7 +2489,7 @@ vm_bind_ioctl_ops_create(struct xe_vm *vm, struct xe_vma_ops *vops,
  			op->map.invalidate_on_bind =
  				__xe_vm_needs_clear_scratch_pages(vm, flags);
  
@@ -2385,7 +2385,7 @@ index 66c35c1ea..ea6916a67 100644
  			INIT_LIST_HEAD(&op->map.eudebug.metadata.list);
  #endif
  		} else if (__op->op == DRM_GPUVA_OP_PREFETCH) {
-@@ -3272,7 +3272,7 @@ typedef int (*xe_vm_bind_op_user_extension_fn)(struct xe_device *xe,
+@@ -3282,7 +3282,7 @@ typedef int (*xe_vm_bind_op_user_extension_fn)(struct xe_device *xe,
  					       u32 operation, u64 extension);
  
  static const xe_vm_bind_op_user_extension_fn vm_bind_op_extension_funcs[] = {
@@ -2394,7 +2394,7 @@ index 66c35c1ea..ea6916a67 100644
  };
  
  #define MAX_USER_EXTENSIONS	16
-@@ -3469,7 +3469,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
+@@ -3479,7 +3479,7 @@ static void vm_bind_ioctl_ops_fini(struct xe_vm *vm, struct xe_vma_ops *vops,
  				       fence);
  	}
  
@@ -2403,7 +2403,7 @@ index 66c35c1ea..ea6916a67 100644
  
  	if (ufence)
  		xe_sync_ufence_put(ufence);
-@@ -3880,7 +3880,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3904,7 +3904,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		}
  	}
  
@@ -2412,7 +2412,7 @@ index 66c35c1ea..ea6916a67 100644
  
  	syncs_user = u64_to_user_ptr(args->syncs);
  	for (num_syncs = 0; num_syncs < args->num_syncs; num_syncs++) {
-@@ -3942,7 +3942,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -3966,7 +3966,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  		if (err)
  			goto unwind_ops;
  
@@ -2421,7 +2421,7 @@ index 66c35c1ea..ea6916a67 100644
  
  #ifdef TEST_VM_OPS_ERROR
  		if (flags & FORCE_OP_ERROR) {
-@@ -3976,7 +3976,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
+@@ -4000,7 +4000,7 @@ int xe_vm_bind_ioctl(struct drm_device *dev, void *data, struct drm_file *file)
  
  unwind_ops:
  	if (err && err != -ENODATA) {
@@ -2431,7 +2431,7 @@ index 66c35c1ea..ea6916a67 100644
  	}
  
 diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
-index abceff3ff..6cb4ef66d 100644
+index 083782d99b3f4..8afe80a67694f 100644
 --- a/drivers/gpu/drm/xe/xe_vm_types.h
 +++ b/drivers/gpu/drm/xe/xe_vm_types.h
 @@ -78,7 +78,7 @@ struct xe_userptr {
@@ -2453,7 +2453,7 @@ index abceff3ff..6cb4ef66d 100644
  		/** @lock: Lock for eudebug_bind members */
  		spinlock_t lock;
 diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
-index a7b3a6d88..90465a40c 100644
+index e3a22217388a1..e6412856f34b8 100644
 --- a/include/uapi/drm/xe_drm.h
 +++ b/include/uapi/drm/xe_drm.h
 @@ -102,9 +102,6 @@ extern "C" {
@@ -2500,15 +2500,15 @@ index a7b3a6d88..90465a40c 100644
  /**
   * struct drm_xe_vm_bind_op - run bind operations
   *
-@@ -1027,7 +1004,6 @@ struct drm_xe_vm_bind_op_ext_attach_debug {
-  *    handle MBZ, and the BO offset MBZ.
+@@ -1034,7 +1011,6 @@ struct drm_xe_vm_bind_op_ext_attach_debug {
+  *    support Flat CCS and the required HW generation XE2+.
   */
  struct drm_xe_vm_bind_op {
--#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG 0
+-#define XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG	0
  	/** @extensions: Pointer to the first extension struct, if any */
  	__u64 extensions;
  
-@@ -1281,8 +1257,6 @@ struct drm_xe_exec_queue_create {
+@@ -1289,8 +1265,6 @@ struct drm_xe_exec_queue_create {
  #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY		0
  #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE		1
  #define   DRM_XE_EXEC_QUEUE_SET_PROPERTY_PXP_TYPE		2
@@ -2517,7 +2517,7 @@ index a7b3a6d88..90465a40c 100644
  	/** @extensions: Pointer to the first extension struct, if any */
  	__u64 extensions;
  
-@@ -1999,72 +1973,6 @@ struct drm_xe_query_eu_stall {
+@@ -2008,72 +1982,6 @@ struct drm_xe_query_eu_stall {
  	__u64 sampling_rates[];
  };
  
@@ -2592,7 +2592,7 @@ index a7b3a6d88..90465a40c 100644
  #if defined(__cplusplus)
 diff --git a/include/uapi/drm/xe_drm_eudebug.h b/include/uapi/drm/xe_drm_eudebug.h
 deleted file mode 100644
-index 3500b0a1c..000000000
+index 3500b0a1c8543..0000000000000
 --- a/include/uapi/drm/xe_drm_eudebug.h
 +++ /dev/null
 @@ -1,256 +0,0 @@
@@ -2853,7 +2853,7 @@ index 3500b0a1c..000000000
 -
 -#endif /* _UAPI_XE_DRM_EUDEBUG_H_ */
 diff --git a/include/uapi/drm/xe_drm_prelim.h b/include/uapi/drm/xe_drm_prelim.h
-index 9c86f5969..a085285bc 100644
+index 9c86f59695000..a085285bcc170 100644
 --- a/include/uapi/drm/xe_drm_prelim.h
 +++ b/include/uapi/drm/xe_drm_prelim.h
 @@ -70,4 +70,344 @@

--- a/series
+++ b/series
@@ -280,6 +280,11 @@ backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Skip-VRAM-auto-provis
 backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Add-documentation-for-vram_quota.patch
 backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-context-IDs-auto-pr.patch
 backport/patches/features/vf-vram-provision/0001-drm-xe-pf-Use-migration-friendly-doorbells-auto-prov.patch
+# base
+backport/patches/base/0001-drm-xe-pat-Add-helper-to-query-compression-enable-st.patch
+backport/patches/base/0001-drm-xe-add-VM_BIND-DECOMPRESS-uapi-flag.patch
+backport/patches/base/0001-drm-xe-add-xe_migrate_resolve-wrapper-and-is_vram_re.patch
+backport/patches/base/0001-drm-xe-implement-VM_BIND-decompression-in-vm_bind_io.patch
 # fixes
 backport/patches/fixes/base/0001-drm-me-gsc-mei-interrupt-top-half-should-be-in-irq-d.patch
 backport/patches/fixes/base/0001-drm-xe-Adjust-long-running-workload-timeslices-to-re.patch


### PR DESCRIPTION
Introduce DRM_XE_VM_BIND_FLAG_DECOMPRESS to allow userspace to request
on-device decompression of VRAM BOs during MAP operations. Validate
uAPI constraints and PAT requirements, and implement decompression via
xe_migrate_resolve() in the VM_BIND path, attaching the resulting fence
to BO reservation.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>