### PR TITLE
backport: Apply 1 fixes for main

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-oa-Allow-reading-after-disabling-OA-stream.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-oa-Allow-reading-after-disabling-OA-stream.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Date: Thu, 12 Mar 2026 22:36:30 -0700
+Subject: [PATCH] drm/xe/oa: Allow reading after disabling OA stream
+
+Some OA data might be present in the OA buffer when OA stream is
+disabled. Allow UMD's to retrieve this data, so that all data till the
+point when OA stream is disabled can be retrieved.
+
+v2: Update tail pointer after disable (Umesh)
+
+Fixes: efb315d0a013 ("drm/xe/oa/uapi: Read file_operation")
+Cc: stable@vger.kernel.org
+Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Reviewed-by: Umesh Nerlige Ramappa<umesh.nerlige.ramappa@intel.com>
+Link: https://patch.msgid.link/20260313053630.3176100-1-ashutosh.dixit@intel.com
+(cherry-picked from commit 4ff57c5e8dbba23b5457be12f9709d5c016da16e linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_oa.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_oa.c b/drivers/gpu/drm/xe/xe_oa.c
+index 8026bf658c10..1c70d0b39691 100644
+--- a/drivers/gpu/drm/xe/xe_oa.c
++++ b/drivers/gpu/drm/xe/xe_oa.c
+@@ -543,8 +543,7 @@ static ssize_t xe_oa_read(struct file *file, char __user *buf,
+ 	size_t offset = 0;
+ 	int ret;
+ 
+-	/* Can't read from disabled streams */
+-	if (!stream->enabled || !stream->sample)
++	if (!stream->sample)
+ 		return -EINVAL;
+ 
+ 	if (!(file->f_flags & O_NONBLOCK)) {
+@@ -1460,6 +1459,10 @@ static void xe_oa_stream_disable(struct xe_oa_stream *stream)
+ 
+ 	if (stream->sample)
+ 		hrtimer_cancel(&stream->poll_check_timer);
++
++	/* Update stream->oa_buffer.tail to allow any final reports to be read */
++	if (xe_oa_buffer_check_unlocked(stream))
++		wake_up(&stream->poll_wq);
+ }
+ 
+ static int xe_oa_enable_preempt_timeslice(struct xe_oa_stream *stream)
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -343,6 +343,7 @@ backport/patches/fixes/base/0001-drm-xe-Forcefully-tear-down-exec-queues-in-GuC-
 backport/patches/fixes/base/0001-drm-xe-Trigger-queue-cleanup-if-not-in-wedged-mode-2.patch
 backport/patches/fixes/base/0001-drm-xe-Open-code-GGTT-MMIO-access-protection.patch
 backport/patches/fixes/base/0001-drm-xe-wa-Steer-RMW-of-MCR-registers-while-building-.patch
+backport/patches/fixes/base/0001-drm-xe-oa-Allow-reading-after-disabling-OA-stream.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Automatically backported kernel fixes:
- Applied 1 patches
- Build verification: passed
- Generated by backport-kernel-fixes automation