### PR TITLE
series: drm/xe/eudebug: Add missing entry for lockdown error fix patch in series

### DIFF
--- a/series
+++ b/series
@@ -379,3 +379,4 @@ backport/patches/features/eu-debug/0001-drm-xe-eudebug-add-eudebug-drm-managed-f
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Check-attention-bits-only-once-in-att.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-xe_eudebug_init-fixup.patch
 backport/patches/features/eu-debug/0001-drm-xe-oa-Fix-NULL-pointer-dereference-in-sync-parsi.patch
+backport/patches/features/eu-debug/0001-drm-xe-eudebug-return-lockdown-error-when-enable-fai.patch


### PR DESCRIPTION
The patch fixing the lockdown error handling in eudebug was
accidentally omitted from the series file. Add the missing entry
to ensure the patch is applied as part of the series.

Patch: 0001-drm-xe-eudebug-return-lockdown-error-when-enable-fai.patch

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>