### PR TITLE
drm/xe: Update Wa_16025250150 per latest spec guidance

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-Implement-recent-spec-updates-to-Wa_160252501.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-Implement-recent-spec-updates-to-Wa_160252501.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Roper <matthew.d.roper@intel.com>
+Date: Thu, 19 Mar 2026 15:30:34 -0700
+Subject: drm/xe: Implement recent spec updates to Wa_16025250150
+
+The hardware teams noticed that the originally documented workaround
+steps for Wa_16025250150 may not be sufficient to fully avoid a hardware
+issue.  The workaround documentation has been augmented to suggest
+programming one additional register; make the corresponding change in
+the driver.
+
+Fixes: 7654d51f1fd8 ("drm/xe/xe2hpg: Add Wa_16025250150")
+Reviewed-by: Matt Atwood <matthew.s.atwood@intel.com>
+Link: https://patch.msgid.link/20260319-wa_16025250150_part2-v1-1-46b1de1a31b2@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(backported from commit a31566762d4075646a8a2214586158b681e94305 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h | 1 +
+ drivers/gpu/drm/xe/xe_wa.c           | 3 ++-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index d71f427410f1e..239f0f8609a9a 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -540,6 +540,7 @@
+ #define   ENABLE_SMP_LD_RENDER_SURFACE_CONTROL	REG_BIT(44 - 32)
+ #define   FORCE_SLM_FENCE_SCOPE_TO_TILE		REG_BIT(42 - 32)
+ #define   FORCE_UGM_FENCE_SCOPE_TO_TILE		REG_BIT(41 - 32)
++#define   L3_128B_256B_WRT_DIS			REG_BIT(40 - 32)
+ #define   MAXREQS_PER_BANK			REG_GENMASK(39 - 32, 37 - 32)
+ #define   DISABLE_128B_EVICTION_COMMAND_UDW	REG_BIT(36 - 32)
+ 
+diff --git a/drivers/gpu/drm/xe/xe_wa.c b/drivers/gpu/drm/xe/xe_wa.c
+index d550b83d0c3cb..f9b769807cdea 100644
+--- a/drivers/gpu/drm/xe/xe_wa.c
++++ b/drivers/gpu/drm/xe/xe_wa.c
+@@ -241,7 +241,8 @@ static const struct xe_rtp_entry_sr gt_was[] = {
+ 				   LSN_DIM_Z_WGT_MASK,
+ 				   LSN_LNI_WGT(1) | LSN_LNE_WGT(1) |
+ 				   LSN_DIM_X_WGT(1) | LSN_DIM_Y_WGT(1) |
+-				   LSN_DIM_Z_WGT(1)))
++				   LSN_DIM_Z_WGT(1)),
++			  SET(LSC_CHICKEN_BIT_0_UDW, L3_128B_256B_WRT_DIS))
+ 	},
+ 
+ 	/* Xe2_HPM */
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -344,6 +344,7 @@ backport/patches/fixes/base/0001-drm-xe-Trigger-queue-cleanup-if-not-in-wedged-m
 backport/patches/fixes/base/0001-drm-xe-Open-code-GGTT-MMIO-access-protection.patch
 backport/patches/fixes/base/0001-drm-xe-wa-Steer-RMW-of-MCR-registers-while-building-.patch
 backport/patches/fixes/base/0001-drm-xe-oa-Allow-reading-after-disabling-OA-stream.patch
+backport/patches/fixes/base/0001-drm-xe-Implement-recent-spec-updates-to-Wa_160252501.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
The hardware team identified that the previously documented workaround
for Wa_16025250150 may not fully mitigate the issue. The specification
has been updated to include programming an additional register.

Update the driver implementation accordingly to reflect the revised
workaround steps.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>