### PR TITLE
mtd: intel-dg: Fix regions access before setting nregions

### DIFF
--- a/backport/patches/base/0001-mtd-intel-dg-Fix-accessing-regions-before-setting-nr.patch
+++ b/backport/patches/base/0001-mtd-intel-dg-Fix-accessing-regions-before-setting-nr.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Usyskin <alexander.usyskin@intel.com>
+Date: Thu, 15 Jan 2026 07:22:37 +0200
+Subject: mtd: intel-dg: Fix accessing regions before setting nregions
+
+The regions array is counted by nregions, but it's set only after
+accessing it:
+
+[] UBSAN: array-index-out-of-bounds in drivers/mtd/devices/mtd_intel_dg.c:750:15
+[] index 0 is out of range for type '<unknown> [*]'
+
+Fix it by also fixing an undesired behavior: the loop silently ignores
+ENOMEM and continues setting the other entries.
+
+CC: Gustavo A. R. Silva <gustavoars@kernel.org>
+CC: Raag Jadav <raag.jadav@intel.com>
+Reported-by: Jani Partanen <jiipee@sotapeli.fi>
+Closes: https://lore.kernel.org/all/caca6c67-4f1d-49f1-948f-e63b6b937b29@sotapeli.fi
+Fixes: ceb5ab3cb646 ("mtd: add driver for intel graphics non-volatile memory device")
+Signed-off-by: Lucas De Marchi <demarchi@kernel.org>
+Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
+Reviewed-by: Raag Jadav <raag.jadav@intel.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+(cherry-picked from commit 779c59274d03cc5c07237a2c845dfb71cff77705 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/mtd/devices/mtd_intel_dg.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/mtd/devices/mtd_intel_dg.c b/drivers/mtd/devices/mtd_intel_dg.c
+index b438ee5aacc34..114e69135b8d9 100644
+--- a/drivers/mtd/devices/mtd_intel_dg.c
++++ b/drivers/mtd/devices/mtd_intel_dg.c
+@@ -738,6 +738,7 @@ static int intel_dg_mtd_probe(struct auxiliary_device *aux_dev,
+ 
+ 	kref_init(&nvm->refcnt);
+ 	mutex_init(&nvm->lock);
++	nvm->nregions = nregions;
+ 
+ 	for (n = 0, i = 0; i < INTEL_DG_NVM_REGIONS; i++) {
+ 		if (!invm->regions[i].name)
+@@ -745,13 +746,15 @@ static int intel_dg_mtd_probe(struct auxiliary_device *aux_dev,
+ 
+ 		char *name = kasprintf(GFP_KERNEL, "%s.%s",
+ 				       dev_name(&aux_dev->dev), invm->regions[i].name);
+-		if (!name)
+-			continue;
++		if (!name) {
++			ret = -ENOMEM;
++			goto err;
++		}
++
+ 		nvm->regions[n].name = name;
+ 		nvm->regions[n].id = i;
+ 		n++;
+ 	}
+-	nvm->nregions = n; /* in case where kasprintf fail */
+ 
+ 	nvm->base = devm_ioremap_resource(device, &invm->bar);
+ 	if (IS_ERR(nvm->base)) {
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -20,6 +20,7 @@ backport/patches/base/0001-drm-xe-dma-buf-Allow-pinning-of-p2p-dma-buf.patch
 backport/patches/base/0001-drm-xe-Drop-preempt-fences-when-destroying-imported-.patch
 backport/patches/base/0001-drm-xe-migrate-fix-batch-buffer-sizing.patch
 backport/patches/base/0001-drm-xe-make-xe_gt_idle_disable_c6-handle-the-forcewa.patch
+backport/patches/base/0001-mtd-intel-dg-Fix-accessing-regions-before-setting-nr.patch
 # features/xe-late-bind-fw
 backport/patches/features/xe-late-bind-fw/0001-mei-bus-add-mei_cldev_mtu-interface.patch
 backport/patches/features/xe-late-bind-fw/0001-mei-late_bind-add-late-binding-component-driver.patch


### PR DESCRIPTION
nregions is set after accessing the regions array, which can cause
out-of-bounds access.

Fix by initializing nregions earlier and handle -ENOMEM properly
instead of continuing the loop.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>