### PR TITLE
drm/xe: Fix remap unwind overlap by tracking prev/next

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-always-keep-track-of-remap-prev-next.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-always-keep-track-of-remap-prev-next.patch
@@ -1,0 +1,201 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Auld <matthew.auld@intel.com>
+Date: Wed, 18 Mar 2026 10:02:09 +0000
+Subject: drm/xe: always keep track of remap prev/next
+
+During 3D workload, user is reporting hitting:
+
+[  413.361679] WARNING: drivers/gpu/drm/xe/xe_vm.c:1217 at vm_bind_ioctl_ops_unwind+0x1e2/0x2e0 [xe], CPU#7: vkd3d_queue/9925
+[  413.361944] CPU: 7 UID: 1000 PID: 9925 Comm: vkd3d_queue Kdump: loaded Not tainted 7.0.0-070000rc3-generic #202603090038 PREEMPT(lazy)
+[  413.361949] RIP: 0010:vm_bind_ioctl_ops_unwind+0x1e2/0x2e0 [xe]
+[  413.362074] RSP: 0018:ffffd4c25c3df930 EFLAGS: 00010282
+[  413.362077] RAX: 0000000000000000 RBX: ffff8f3ee817ed10 RCX: 0000000000000000
+[  413.362078] RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000000
+[  413.362079] RBP: ffffd4c25c3df980 R08: 0000000000000000 R09: 0000000000000000
+[  413.362081] R10: 0000000000000000 R11: 0000000000000000 R12: ffff8f41fbf99380
+[  413.362082] R13: ffff8f3ee817e968 R14: 00000000ffffffef R15: ffff8f43d00bd380
+[  413.362083] FS:  00000001040ff6c0(0000) GS:ffff8f4696d89000(0000) knlGS:00000000330b0000
+[  413.362085] CS:  0010 DS: 002b ES: 002b CR0: 0000000080050033
+[  413.362086] CR2: 00007ddfc4747000 CR3: 00000002e6262005 CR4: 0000000000f72ef0
+[  413.362088] PKRU: 55555554
+[  413.362089] Call Trace:
+[  413.362092]  <TASK>
+[  413.362096]  xe_vm_bind_ioctl+0xa9a/0xc60 [xe]
+
+Which seems to hint that the vma we are re-inserting for the ops unwind
+is either invalid or overlapping with something already inserted in the
+vm. It shouldn't be invalid since this is a re-insertion, so must have
+worked before. Leaving the likely culprit as something already placed
+where we want to insert the vma.
+
+Following from that, for the case where we do something like a rebind in
+the middle of a vma, and one or both mapped ends are already compatible,
+we skip doing the rebind of those vma and set next/prev to NULL. As well
+as then adjust the original unmap va range, to avoid unmapping the ends.
+However, if we trigger the unwind path, we end up with three va, with
+the two ends never being removed and the original va range in the middle
+still being the shrunken size.
+
+If this occurs, one failure mode is when another unwind op needs to
+interact with that range, which can happen with a vector of binds. For
+example, if we need to re-insert something in place of the original va.
+In this case the va is still the shrunken version, so when removing it
+and then doing a re-insert it can overlap with the ends, which were
+never removed, triggering a warning like above, plus leaving the vm in a
+bad state.
+
+With that, we need two things here:
+
+ 1) Stop nuking the prev/next tracking for the skip cases. Instead
+    relying on checking for skip prev/next, where needed. That way on the
+    unwind path, we now correctly remove both ends.
+
+ 2) Undo the unmap va shrinkage, on the unwind path. With the two ends
+    now removed the unmap va should expand back to the original size again,
+    before re-insertion.
+
+v2:
+  - Update the explanation in the commit message, based on an actual IGT of
+    triggering this issue, rather than conjecture.
+  - Also undo the unmap shrinkage, for the skip case. With the two ends
+    now removed, the original unmap va range should expand back to the
+    original range.
+v3:
+  - Track the old start/range separately. vma_size/start() uses the va
+    info directly.
+
+Link: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues/7602
+Fixes: 8f33b4f054fc ("drm/xe: Avoid doing rebinds")
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: <stable@vger.kernel.org> # v6.8+
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Link: https://patch.msgid.link/20260318100208.78097-2-matthew.auld@intel.com
+(backported from commit aec6969f75afbf4e01fd5fb5850ed3e9c27043ac linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pt.c       | 12 ++++++------
+ drivers/gpu/drm/xe/xe_vm.c       | 22 ++++++++++++++++++----
+ drivers/gpu/drm/xe/xe_vm_types.h |  4 ++++
+ 3 files changed, 28 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pt.c b/drivers/gpu/drm/xe/xe_pt.c
+index 8376b4b7d9b27..26f485e975625 100644
+--- a/drivers/gpu/drm/xe/xe_pt.c
++++ b/drivers/gpu/drm/xe/xe_pt.c
+@@ -1426,9 +1426,9 @@ static int op_check_userptr(struct xe_vm *vm, struct xe_vma_op *op,
+ 		err = vma_check_userptr(vm, op->map.vma, pt_update);
+ 		break;
+ 	case DRM_GPUVA_OP_REMAP:
+-		if (op->remap.prev)
++		if (op->remap.prev && !op->remap.skip_prev)
+ 			err = vma_check_userptr(vm, op->remap.prev, pt_update);
+-		if (!err && op->remap.next)
++		if (!err && op->remap.next && !op->remap.skip_next)
+ 			err = vma_check_userptr(vm, op->remap.next, pt_update);
+ 		break;
+ 	case DRM_GPUVA_OP_UNMAP:
+@@ -2033,12 +2033,12 @@ static int op_prepare(struct xe_vm *vm,
+ 
+ 		err = unbind_op_prepare(tile, pt_update_ops, old);
+ 
+-		if (!err && op->remap.prev) {
++		if (!err && op->remap.prev && !op->remap.skip_prev) {
+ 			err = bind_op_prepare(vm, tile, pt_update_ops,
+ 					      op->remap.prev, false);
+ 			pt_update_ops->wait_vm_bookkeep = true;
+ 		}
+-		if (!err && op->remap.next) {
++		if (!err && op->remap.next && !op->remap.skip_next) {
+ 			err = bind_op_prepare(vm, tile, pt_update_ops,
+ 					      op->remap.next, false);
+ 			pt_update_ops->wait_vm_bookkeep = true;
+@@ -2262,10 +2262,10 @@ static void op_commit(struct xe_vm *vm,
+ 
+ 		unbind_op_commit(vm, tile, pt_update_ops, old, fence, fence2);
+ 
+-		if (op->remap.prev)
++		if (op->remap.prev && !op->remap.skip_prev)
+ 			bind_op_commit(vm, tile, pt_update_ops, op->remap.prev,
+ 				       fence, fence2, false);
+-		if (op->remap.next)
++		if (op->remap.next && !op->remap.skip_next)
+ 			bind_op_commit(vm, tile, pt_update_ops, op->remap.next,
+ 				       fence, fence2, false);
+ 		break;
+diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
+index 706549def9630..be2f300348c3c 100644
+--- a/drivers/gpu/drm/xe/xe_vm.c
++++ b/drivers/gpu/drm/xe/xe_vm.c
+@@ -2674,7 +2674,6 @@ static int xe_vma_op_commit(struct xe_vm *vm, struct xe_vma_op *op)
+ 			if (!err && op->remap.skip_prev) {
+ 				op->remap.prev->tile_present =
+ 					tile_present;
+-				op->remap.prev = NULL;
+ 			}
+ 		}
+ 		if (op->remap.next) {
+@@ -2684,11 +2683,13 @@ static int xe_vma_op_commit(struct xe_vm *vm, struct xe_vma_op *op)
+ 			if (!err && op->remap.skip_next) {
+ 				op->remap.next->tile_present =
+ 					tile_present;
+-				op->remap.next = NULL;
+ 			}
+ 		}
+ 
+-		/* Adjust for partial unbind after removing VMA from VM */
++		/*
++		 * Adjust for partial unbind after removing VMA from VM. In case
++		 * of unwind we might need to undo this later.
++		 */
+ 		if (!err) {
+ 			op->base.remap.unmap->va->va.addr = op->remap.start;
+ 			op->base.remap.unmap->va->va.range = op->remap.range;
+@@ -2777,6 +2778,8 @@ static int vm_bind_ioctl_ops_parse(struct xe_vm *vm, struct drm_gpuva_ops *ops,
+ 
+ 			op->remap.start = xe_vma_start(old);
+ 			op->remap.range = xe_vma_size(old);
++			op->remap.old_start = op->remap.start;
++			op->remap.old_range = op->remap.range;
+ 
+ 			flags |= op->base.remap.unmap->va->flags &
+ 				XE_VMA_READ_ONLY ?
+@@ -2935,8 +2938,19 @@ static void xe_vma_op_unwind(struct xe_vm *vm, struct xe_vma_op *op,
+ 			down_read(&vm->userptr.notifier_lock);
+ 			vma->gpuva.flags &= ~XE_VMA_DESTROYED;
+ 			up_read(&vm->userptr.notifier_lock);
+-			if (post_commit)
++			if (post_commit) {
++				/*
++				 * Restore the old va range, in case of the
++				 * prev/next skip optimisation. Otherwise what
++				 * we re-insert here could be smaller than the
++				 * original range.
++				 */
++				op->base.remap.unmap->va->va.addr =
++					op->remap.old_start;
++				op->base.remap.unmap->va->va.range =
++					op->remap.old_range;
+ 				xe_vm_insert_vma(vm, vma);
++			}
+ 		}
+ 		break;
+ 	}
+diff --git a/drivers/gpu/drm/xe/xe_vm_types.h b/drivers/gpu/drm/xe/xe_vm_types.h
+index 3702cd5ae416e..4a7b34f8206d5 100644
+--- a/drivers/gpu/drm/xe/xe_vm_types.h
++++ b/drivers/gpu/drm/xe/xe_vm_types.h
+@@ -379,6 +379,10 @@ struct xe_vma_op_remap {
+ 	u64 start;
+ 	/** @range: range of the VMA unmap */
+ 	u64 range;
++	/** @old_start: Original start of the VMA we unmap */
++	u64 old_start;
++	/** @old_range: Original range of the VMA we unmap */
++	u64 old_range;
+ 	/** @skip_prev: skip prev rebind */
+ 	bool skip_prev;
+ 	/** @skip_next: skip next rebind */
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -356,6 +356,7 @@ backport/patches/fixes/base/0001-drm-xe-pxp-Remove-incorrect-handling-of-impossi
 backport/patches/fixes/base/0001-drm-xe-pxp-Clear-restart-flag-in-pxp_start-after-jum.patch
 backport/patches/fixes/base/0001-drm-xe-Disable-garbage-collector-work-item-on-SVM-cl.patch
 backport/patches/fixes/base/0001-drm-xe-Avoid-memory-allocations-in-xe_device_declare.patch
+backport/patches/fixes/base/0001-drm-xe-always-keep-track-of-remap-prev-next.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
During 3D workloads, a warning is triggered in the unwind
path due to VMA overlap.

This happens when rebind skips compatible ends, clears prev/next,
and shrinks the unmap range. On unwind, the ends remain while
the middle VMA is re-inserted, causing overlap.

Fix by keeping prev/next tracking and restoring the original
unmap range during unwind.

v2: Update message and restore unmap range for skip case.
v3: Track original start/range separately.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>