### PR TITLE
drm/xe/vf: Fix LRC races during post-migration recovery

### DIFF
--- a/backport/patches/features/eu-debug/0001-drm-xe-Add-EUDEBUG_ENABLE-exec-queue-property.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-Add-EUDEBUG_ENABLE-exec-queue-property.patch
@@ -56,10 +56,10 @@ index 5378432f9..b921ca8bd 100644
  
  	h_c = find_handle(d->res, XE_EUDEBUG_RES_TYPE_CLIENT, xef);
 diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
-index 2614ce94c..7caf44018 100644
+index e1bb2f39f..ff2daddbd 100644
 --- a/drivers/gpu/drm/xe/xe_exec_queue.c
 +++ b/drivers/gpu/drm/xe/xe_exec_queue.c
-@@ -181,6 +181,9 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
+@@ -242,6 +242,9 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
  			flags |= XE_LRC_CREATE_RUNALONE;
  	}
  
@@ -69,7 +69,7 @@ index 2614ce94c..7caf44018 100644
  	if (!(exec_queue_flags & EXEC_QUEUE_FLAG_KERNEL))
  		flags |= XE_LRC_CREATE_USER_CTX;
  
-@@ -525,6 +528,42 @@ exec_queue_set_pxp_type(struct xe_device *xe, struct xe_exec_queue *q, u64 value
+@@ -611,6 +614,42 @@ exec_queue_set_pxp_type(struct xe_device *xe, struct xe_exec_queue *q, u64 value
  	return xe_pxp_exec_queue_set_type(xe->pxp, q, DRM_XE_PXP_TYPE_HWDRM);
  }
  
@@ -112,7 +112,7 @@ index 2614ce94c..7caf44018 100644
  typedef int (*xe_exec_queue_set_property_fn)(struct xe_device *xe,
  					     struct xe_exec_queue *q,
  					     u64 value);
-@@ -533,6 +572,7 @@ static const xe_exec_queue_set_property_fn exec_queue_set_property_funcs[] = {
+@@ -619,6 +658,7 @@ static const xe_exec_queue_set_property_fn exec_queue_set_property_funcs[] = {
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY] = exec_queue_set_priority,
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE] = exec_queue_set_timeslice,
  	[DRM_XE_EXEC_QUEUE_SET_PROPERTY_PXP_TYPE] = exec_queue_set_pxp_type,
@@ -120,7 +120,7 @@ index 2614ce94c..7caf44018 100644
  };
  
  static int exec_queue_user_ext_set_property(struct xe_device *xe,
-@@ -553,7 +593,8 @@ static int exec_queue_user_ext_set_property(struct xe_device *xe,
+@@ -639,7 +679,8 @@ static int exec_queue_user_ext_set_property(struct xe_device *xe,
  	    XE_IOCTL_DBG(xe, ext.pad) ||
  	    XE_IOCTL_DBG(xe, ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_PRIORITY &&
  			 ext.property != DRM_XE_EXEC_QUEUE_SET_PROPERTY_TIMESLICE &&
@@ -131,21 +131,21 @@ index 2614ce94c..7caf44018 100644
  
  	idx = array_index_nospec(ext.property, ARRAY_SIZE(exec_queue_set_property_funcs));
 diff --git a/drivers/gpu/drm/xe/xe_exec_queue.h b/drivers/gpu/drm/xe/xe_exec_queue.h
-index a4dfbe858..9aa6a9e80 100644
+index 3c472c827..b02e2d8c3 100644
 --- a/drivers/gpu/drm/xe/xe_exec_queue.h
 +++ b/drivers/gpu/drm/xe/xe_exec_queue.h
-@@ -92,4 +92,6 @@ int xe_exec_queue_contexts_hwsp_rebase(struct xe_exec_queue *q, void *scratch);
- 
+@@ -113,4 +113,6 @@ int xe_exec_queue_contexts_hwsp_rebase(struct xe_exec_queue *q, void *scratch);
  struct xe_lrc *xe_exec_queue_lrc(struct xe_exec_queue *q);
+ struct xe_lrc *xe_exec_queue_get_lrc(struct xe_exec_queue *q, u16 idx);
  
 +int xe_exec_queue_is_debuggable(struct xe_exec_queue *q);
 +
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_exec_queue_types.h b/drivers/gpu/drm/xe/xe_exec_queue_types.h
-index 282505fa1..a509520c6 100644
+index 67c19eacc..79bd58aba 100644
 --- a/drivers/gpu/drm/xe/xe_exec_queue_types.h
 +++ b/drivers/gpu/drm/xe/xe_exec_queue_types.h
-@@ -96,6 +96,13 @@ struct xe_exec_queue {
+@@ -103,6 +103,13 @@ struct xe_exec_queue {
  	 */
  	unsigned long flags;
  
@@ -160,10 +160,10 @@ index 282505fa1..a509520c6 100644
  		/** @multi_gt_list: list head for VM bind engines if multi-GT */
  		struct list_head multi_gt_list;
 diff --git a/drivers/gpu/drm/xe/xe_lrc.c b/drivers/gpu/drm/xe/xe_lrc.c
-index b7a6be5b4..6c7ca5875 100644
+index bdfec1c9b..cf59a50a7 100644
 --- a/drivers/gpu/drm/xe/xe_lrc.c
 +++ b/drivers/gpu/drm/xe/xe_lrc.c
-@@ -1464,6 +1464,16 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
+@@ -1467,6 +1467,16 @@ static int xe_lrc_init(struct xe_lrc *lrc, struct xe_hw_engine *hwe,
  	if (err)
  		goto err_lrc_finish;
  
@@ -181,7 +181,7 @@ index b7a6be5b4..6c7ca5875 100644
  
  err_lrc_finish:
 diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
-index a7fa437fd..250f9e4a0 100644
+index 69b71b17e..e92683f70 100644
 --- a/include/uapi/drm/xe_drm.h
 +++ b/include/uapi/drm/xe_drm.h
 @@ -1260,6 +1260,8 @@ struct drm_xe_exec_queue_create {

--- a/backport/patches/features/sriov/0001-drm-xe-Wrappers-for-setting-and-getting-LRC-referenc.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Wrappers-for-setting-and-getting-LRC-referenc.patch
@@ -1,0 +1,181 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tomasz Lis <tomasz.lis@intel.com>
+Date: Thu, 26 Feb 2026 22:26:59 +0100
+Subject: drm/xe: Wrappers for setting and getting LRC references
+
+There is a small but non-zero chance that VF post migration fixups
+are running on an exec queue during teardown. The chances are
+decreased by starting the teardown by releasing guc_id, but remain
+non-zero. On the other hand the sync between fixups and EQ creation
+(wait_valid_ggtt) drastically increases the chance for such parallel
+teardown if queue creation error path is entered (err_lrc label).
+
+The exec queue itself is not going to cause an issue, but LRCs have
+a small chance of getting freed during the fixups.
+
+Creating a setter and a getter makes it easier to protect the fixup
+operations with a lock. For other driver activities, the original
+access method (without any protection) can still be used.
+
+v2: Separate lock, only for LRCs. Kerneldoc fixes. Subject tag fix.
+
+Signed-off-by: Tomasz Lis <tomasz.lis@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://patch.msgid.link/20260226212701.2937065-3-tomasz.lis@intel.com
+(backported from commit ec172c7befc4a48ea7d6afe6f0fa23c533222233 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_exec_queue.c       | 73 ++++++++++++++++++------
+ drivers/gpu/drm/xe/xe_exec_queue.h       |  1 +
+ drivers/gpu/drm/xe/xe_exec_queue_types.h |  5 ++
+ 3 files changed, 60 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index 137d6db5c..fdbeb8dae 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -124,6 +124,7 @@ static struct xe_exec_queue *__xe_exec_queue_alloc(struct xe_device *xe,
+ 	INIT_LIST_HEAD(&q->multi_gt_link);
+ 	INIT_LIST_HEAD(&q->hw_engine_group_link);
+ 	INIT_LIST_HEAD(&q->pxp.link);
++	spin_lock_init(&q->lrc_lookup_lock);
+ 
+ 	q->sched_props.timeslice_us = hwe->eclass->sched_props.timeslice_us;
+ 	q->sched_props.preempt_timeout_us =
+@@ -162,6 +163,56 @@ static struct xe_exec_queue *__xe_exec_queue_alloc(struct xe_device *xe,
+ 	return q;
+ }
+ 
++static void xe_exec_queue_set_lrc(struct xe_exec_queue *q, struct xe_lrc *lrc, u16 idx)
++{
++	xe_assert(gt_to_xe(q->gt), idx < q->width);
++
++	scoped_guard(spinlock, &q->lrc_lookup_lock)
++		q->lrc[idx] = lrc;
++}
++
++/**
++ * xe_exec_queue_get_lrc() - Get the LRC from exec queue.
++ * @q: The exec queue instance.
++ * @idx: Index within multi-LRC array.
++ *
++ * Retrieves LRC of given index for the exec queue under lock
++ * and takes reference.
++ *
++ * Return: Pointer to LRC on success, error on failure, NULL on
++ * lookup failure.
++ */
++struct xe_lrc *xe_exec_queue_get_lrc(struct xe_exec_queue *q, u16 idx)
++{
++	struct xe_lrc *lrc;
++
++	xe_assert(gt_to_xe(q->gt), idx < q->width);
++
++	scoped_guard(spinlock, &q->lrc_lookup_lock) {
++		lrc = q->lrc[idx];
++		if (lrc)
++			xe_lrc_get(lrc);
++	}
++
++	return lrc;
++}
++
++/**
++ * xe_exec_queue_lrc() - Get the LRC from exec queue.
++ * @q: The exec queue instance.
++ *
++ * Retrieves the primary LRC for the exec queue. Note that this function
++ * returns only the first LRC instance, even when multiple parallel LRCs
++ * are configured. This function does not increment reference count,
++ * so the reference can be just forgotten after use.
++ *
++ * Return: Pointer to LRC on success, error on failure
++ */
++struct xe_lrc *xe_exec_queue_lrc(struct xe_exec_queue *q)
++{
++	return q->lrc[0];
++}
++
+ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
+ {
+ 	int i, err;
+@@ -209,8 +260,7 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
+ 			goto err_lrc;
+ 		}
+ 
+-		/* Pairs with READ_ONCE to xe_exec_queue_contexts_hwsp_rebase */
+-		WRITE_ONCE(q->lrc[i], lrc);
++		xe_exec_queue_set_lrc(q, lrc, i);
+ 	}
+ 
+ 	return 0;
+@@ -866,21 +916,6 @@ int xe_exec_queue_get_property_ioctl(struct drm_device *dev, void *data,
+ 	return ret;
+ }
+ 
+-/**
+- * xe_exec_queue_lrc() - Get the LRC from exec queue.
+- * @q: The exec_queue.
+- *
+- * Retrieves the primary LRC for the exec queue. Note that this function
+- * returns only the first LRC instance, even when multiple parallel LRCs
+- * are configured.
+- *
+- * Return: Pointer to LRC on success, error on failure
+- */
+-struct xe_lrc *xe_exec_queue_lrc(struct xe_exec_queue *q)
+-{
+-	return q->lrc[0];
+-}
+-
+ /**
+  * xe_exec_queue_is_lr() - Whether an exec_queue is long-running
+  * @q: The exec_queue
+@@ -1240,14 +1275,14 @@ int xe_exec_queue_contexts_hwsp_rebase(struct xe_exec_queue *q, void *scratch)
+ 	for (i = 0; i < q->width; ++i) {
+ 		struct xe_lrc *lrc;
+ 
+-		/* Pairs with WRITE_ONCE in __xe_exec_queue_init  */
+-		lrc = READ_ONCE(q->lrc[i]);
++		lrc = xe_exec_queue_get_lrc(q, i);
+ 		if (!lrc)
+ 			continue;
+ 
+ 		xe_lrc_update_memirq_regs_with_address(lrc, q->hwe, scratch);
+ 		xe_lrc_update_hwctx_regs_with_address(lrc);
+ 		err = xe_lrc_setup_wa_bb_with_scratch(lrc, q->hwe, scratch);
++		xe_lrc_put(lrc);
+ 		if (err)
+ 			break;
+ 	}
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.h b/drivers/gpu/drm/xe/xe_exec_queue.h
+index 37a9da22f..3c472c827 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue.h
+@@ -111,5 +111,6 @@ void xe_exec_queue_update_run_ticks(struct xe_exec_queue *q);
+ int xe_exec_queue_contexts_hwsp_rebase(struct xe_exec_queue *q, void *scratch);
+ 
+ struct xe_lrc *xe_exec_queue_lrc(struct xe_exec_queue *q);
++struct xe_lrc *xe_exec_queue_get_lrc(struct xe_exec_queue *q, u16 idx);
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue_types.h b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+index 5278ba30d..67c19eacc 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue_types.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+@@ -187,6 +187,11 @@ struct xe_exec_queue {
+ 	u64 tlb_flush_seqno;
+ 	/** @hw_engine_group_link: link into exec queues in the same hw engine group */
+ 	struct list_head hw_engine_group_link;
++	/**
++	 * @lrc_lookup_lock: Lock for protecting lrc array access. Only used when
++	 * running in parallel to queue creation is possible.
++	 */
++	spinlock_t lrc_lookup_lock;
+ 	/** @lrc: logical ring context for this exec queue */
+ 	struct xe_lrc *lrc[] __counted_by(width);
+ };
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-vf-Redo-LRC-creation-while-in-VF-fixups.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-vf-Redo-LRC-creation-while-in-VF-fixups.patch
@@ -1,0 +1,190 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tomasz Lis <tomasz.lis@intel.com>
+Date: Thu, 26 Feb 2026 22:27:01 +0100
+Subject: drm/xe/vf: Redo LRC creation while in VF fixups
+
+If the xe module within a VM was creating a new LRC during save/
+restore, this LRC will be invalid. The fixups procedure may not
+be able to reach it, as there will be a race to add the new LRC
+reference to an exec queue.
+
+Even if the new LRC which was being created during VM migration is
+added to EQ in time for fixups, said LRC may still remain damaged.
+In a small percentage of specially crafted test cases, the resulting
+LRC was still damaged and caused GPU hang.
+
+Any LRC which could be created in such a situation, have to be
+re-created.
+
+Due to VM having arbitrarily set amount of CPU cores, it is possible
+to limit the amount to 1. In such case, there is a possibility that
+kernel will switch CPU contexts in a way which allows to miss
+VF migration recovery running in parallel (by simply not switching
+to the LRC creation thread during recovery). Therefore checking
+if the migration is in progress just after LRC creation, is not
+enough to ensure detection.
+
+Free the incorrectly created LRC, and trigger a re-run of the
+creation, but only after waiting for default LRC to get fixups.
+Use additional atomic value increased after fixups, to ensure any VF
+migration that avoided detection by just checking for recovery in
+progress, will be caught.
+
+v2: Merge marker and wait for default LRC, reducing amount of calls
+  within xe_init_eq(). Alter the LRC creation loop to remove a race
+  with post-migration fixups worker.
+v3: Kerneldoc fixes. Rename fixups_complete_count.
+
+Signed-off-by: Tomasz Lis <tomasz.lis@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://patch.msgid.link/20260226212701.2937065-5-tomasz.lis@intel.com
+(backported from commit c692ae39e9fd33d0e58ac24bf3d98b352b5064da linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_exec_queue.c        | 30 ++++++++++++------
+ drivers/gpu/drm/xe/xe_gt_sriov_vf.c       | 38 +++++++++++++++++++++--
+ drivers/gpu/drm/xe/xe_gt_sriov_vf.h       |  3 +-
+ drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h |  2 ++
+ 4 files changed, 59 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index fdbeb8dae..6024485c3 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -250,19 +250,29 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
+ 	 * from the moment vCPU resumes execution.
+ 	 */
+ 	for (i = 0; i < q->width; ++i) {
+-		struct xe_lrc *lrc;
++                struct xe_lrc *__lrc = NULL;
++                int marker;
+ 
+-		xe_gt_sriov_vf_wait_valid_ggtt(q->gt);
+-		lrc = xe_lrc_create(q->hwe, q->vm, xe_lrc_ring_size(),
+-				    q->msix_vec, flags);
+-		if (IS_ERR(lrc)) {
+-			err = PTR_ERR(lrc);
+-			goto err_lrc;
+-		}
++                do {
++                        struct xe_lrc *lrc;
+ 
+-		xe_exec_queue_set_lrc(q, lrc, i);
+-	}
++                        marker = xe_gt_sriov_vf_wait_valid_ggtt(q->gt);
++
++                        lrc = xe_lrc_create(q->hwe, q->vm, xe_lrc_ring_size(),
++                                            q->msix_vec, flags);
++                        if (IS_ERR(lrc)) {
++                                err = PTR_ERR(lrc);
++                                goto err_lrc;
++                        }
+ 
++                        xe_exec_queue_set_lrc(q, lrc, i);
++
++                        if (__lrc)
++                                xe_lrc_put(__lrc);
++                        __lrc = lrc;
++
++                } while (marker != xe_vf_migration_fixups_complete_count(q->gt));
++        }
+ 	return 0;
+ 
+ err_lrc:
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
+index bbdd672ff..47394118e 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
+@@ -1159,6 +1159,8 @@ static int vf_post_migration_fixups(struct xe_gt *gt)
+ 	if (err)
+ 		return err;
+ 
++	atomic_inc(&gt->sriov.vf.migration.fixups_complete_count);
++
+ 	return 0;
+ }
+ 
+@@ -1365,20 +1367,50 @@ static bool vf_valid_ggtt(struct xe_gt *gt)
+ 	return true;
+ }
+ 
++/**
++ * xe_vf_migration_fixups_complete_count() - Get count of VF fixups completions.
++ * @gt: the &xe_gt instance which contains affected Global GTT
++ *
++ * Return: number of times VF fixups were completed since driver
++ * probe, or 0 if migration is not available, or -1 if fixups are
++ * pending or being applied right now.
++ */
++int xe_vf_migration_fixups_complete_count(struct xe_gt *gt)
++{
++	if (!IS_SRIOV_VF(gt_to_xe(gt)) ||
++	    !xe_sriov_vf_migration_supported(gt_to_xe(gt)))
++		return 0;
++
++	/* should never match fixups_complete_count value */
++	if (!vf_valid_ggtt(gt))
++		return -1;
++
++	return atomic_read(&gt->sriov.vf.migration.fixups_complete_count);
++}
++
+ /**
+  * xe_gt_sriov_vf_wait_valid_ggtt() - wait for valid GGTT nodes and address refs
+- * @gt: the &xe_gt
++ * @gt: the &xe_gt instance which contains affected Global GTT
++ *
++ * Return: number of times VF fixups were completed since driver
++ * probe, or 0 if migration is not available.
+  */
+-void xe_gt_sriov_vf_wait_valid_ggtt(struct xe_gt *gt)
++int xe_gt_sriov_vf_wait_valid_ggtt(struct xe_gt *gt)
+ {
+ 	int ret;
+ 
++	/*
++	 * this condition needs to be identical to one in
++	 * xe_vf_migration_fixups_complete_count()
++	 */
+ 	if (!IS_SRIOV_VF(gt_to_xe(gt)) ||
+ 	    !xe_sriov_vf_migration_supported(gt_to_xe(gt)))
+-		return;
++		return 0;
+ 
+ 	ret = wait_event_interruptible_timeout(gt->sriov.vf.migration.wq,
+ 					       vf_valid_ggtt(gt),
+ 					       HZ * 5);
+ 	xe_gt_WARN_ON(gt, !ret);
++
++	return atomic_read(&gt->sriov.vf.migration.fixups_complete_count);
+ }
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf.h b/drivers/gpu/drm/xe/xe_gt_sriov_vf.h
+index af4027679..bf569c587 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_vf.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf.h
+@@ -38,6 +38,7 @@ void xe_gt_sriov_vf_print_config(struct xe_gt *gt, struct drm_printer *p);
+ void xe_gt_sriov_vf_print_runtime(struct xe_gt *gt, struct drm_printer *p);
+ void xe_gt_sriov_vf_print_version(struct xe_gt *gt, struct drm_printer *p);
+ 
+-void xe_gt_sriov_vf_wait_valid_ggtt(struct xe_gt *gt);
++int xe_gt_sriov_vf_wait_valid_ggtt(struct xe_gt *gt);
++int xe_vf_migration_fixups_complete_count(struct xe_gt *gt);
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
+index 6b9e10862..f72f2edd2 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
+@@ -52,6 +52,8 @@ struct xe_gt_sriov_vf_migration {
+ 	wait_queue_head_t wq;
+ 	/** @scratch: Scratch memory for VF recovery */
+ 	void *scratch;
++	/** @fixups_complete_count: Counts completed fixups stages */
++	atomic_t fixups_complete_count;
+ 	/** @recovery_teardown: VF post migration recovery is being torn down */
+ 	bool recovery_teardown;
+ 	/** @recovery_queued: VF post migration recovery in queued */
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-vf-Wait-for-all-fixups-before-using-default-L.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-vf-Wait-for-all-fixups-before-using-default-L.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tomasz Lis <tomasz.lis@intel.com>
+Date: Thu, 26 Feb 2026 22:27:00 +0100
+Subject: drm/xe/vf: Wait for all fixups before using default LRCs
+
+When a context is being created during save/restore, the LRC creation
+needs to wait for GGTT address space to be shifted. But it also needs
+to have fixed default LRCs. This is mandatory to avoid the situation
+where LRC will be created based on data from before the fixups, but
+reference within exec queue will be set too late for fixups.
+
+This fixes an issue where contexts created during save/restore have
+a large chance of having one unfixed LRC, due to the xe_lrc_create()
+being synced for equal start to race with default LRC fixups.
+
+v2: Move the fixups confirmation further, behind all fixups.
+  Revert some renames.
+
+Signed-off-by: Tomasz Lis <tomasz.lis@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://patch.msgid.link/20260226212701.2937065-4-tomasz.lis@intel.com
+(backported from commit f3fb5f1ebbf39e685dd2885c9dbc8bb0a80be7c6 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_vf.c       | 16 +++++++++-------
+ drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h |  2 +-
+ 2 files changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
+index 46518e629..bbdd672ff 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
+@@ -483,12 +483,6 @@ static int vf_get_ggtt_info(struct xe_gt *gt)
+ 		xe_tile_sriov_vf_fixup_ggtt_nodes_locked(gt_to_tile(gt), shift);
+ 	}
+ 
+-	if (xe_sriov_vf_migration_supported(gt_to_xe(gt))) {
+-		WRITE_ONCE(gt->sriov.vf.migration.ggtt_need_fixes, false);
+-		smp_wmb();	/* Ensure above write visible before wake */
+-		wake_up_all(&gt->sriov.vf.migration.wq);
+-	}
+-
+ 	return 0;
+ }
+ 
+@@ -726,6 +720,13 @@ static void xe_gt_sriov_vf_default_lrcs_hwsp_rebase(struct xe_gt *gt)
+ 		xe_default_lrc_update_memirq_regs_with_address(hwe);
+ }
+ 
++static void vf_post_migration_mark_fixups_done(struct xe_gt *gt)
++{
++	WRITE_ONCE(gt->sriov.vf.migration.ggtt_need_fixes, false);
++	smp_wmb();	/* Ensure above write visible before wake */
++	wake_up_all(&gt->sriov.vf.migration.wq);
++}
++
+ static void vf_start_migration_recovery(struct xe_gt *gt)
+ {
+ 	bool started;
+@@ -1233,6 +1234,7 @@ static void vf_post_migration_recovery(struct xe_gt *gt)
+ 	if (err)
+ 		goto fail;
+ 
++	vf_post_migration_mark_fixups_done(gt);
+ 	vf_post_migration_rearm(gt);
+ 
+ 	err = vf_post_migration_notify_resfix_done(gt);
+@@ -1364,7 +1366,7 @@ static bool vf_valid_ggtt(struct xe_gt *gt)
+ }
+ 
+ /**
+- * xe_gt_sriov_vf_wait_valid_ggtt() - VF wait for valid GGTT addresses
++ * xe_gt_sriov_vf_wait_valid_ggtt() - wait for valid GGTT nodes and address refs
+  * @gt: the &xe_gt
+  */
+ void xe_gt_sriov_vf_wait_valid_ggtt(struct xe_gt *gt)
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
+index 420b0e608..6b9e10862 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
+@@ -58,7 +58,7 @@ struct xe_gt_sriov_vf_migration {
+ 	bool recovery_queued;
+ 	/** @recovery_inprogress: VF post migration recovery in progress */
+ 	bool recovery_inprogress;
+-	/** @ggtt_need_fixes: VF GGTT needs fixes */
++	/** @ggtt_need_fixes: VF GGTT and references to it need fixes */
+ 	bool ggtt_need_fixes;
+ };
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/vf-double-migration/0001-drm-xe-vf-Add-debugfs-entries-to-test-VF-double-migr.patch
+++ b/backport/patches/features/vf-double-migration/0001-drm-xe-vf-Add-debugfs-entries-to-test-VF-double-migr.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
 Date: Mon, 1 Dec 2025 15:20:16 +0530
-Subject: drm/xe/vf: Add debugfs entries to test VF double
- migration
+Subject: drm/xe/vf: Add debugfs entries to test VF double migration
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -43,7 +42,7 @@ Acked-by: Adam Miszczak <adam.miszczak@linux.intel.com>
 Reviewed-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
 Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
 Link: https://patch.msgid.link/20251201095011.21453-10-satyanarayana.k.v.p@intel.com
-(cherry-picked from commit 4c2768704710a5d4585941288e6a8159dd6dd33d linux-next )
+(backported from commit 4c2768704710a5d4585941288e6a8159dd6dd33d linux-next )
 Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
 ---
  drivers/gpu/drm/xe/xe_gt_sriov_vf.c         | 40 +++++++++++++++++++++
@@ -52,7 +51,7 @@ Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
  3 files changed, 60 insertions(+)
 
 diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
-index 0b3ecb000ff7..3c806c8e5f3e 100644
+index c4e88aa35..007a624a5 100644
 --- a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
 +++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
 @@ -5,6 +5,7 @@
@@ -63,7 +62,7 @@ index 0b3ecb000ff7..3c806c8e5f3e 100644
  
  #include <drm/drm_managed.h>
  #include <drm/drm_print.h>
-@@ -41,6 +42,37 @@
+@@ -42,6 +43,37 @@
  
  #define make_u64_from_u32(hi, lo) ((u64)((u64)(u32)(hi) << 32 | (u32)(lo)))
  
@@ -101,7 +100,7 @@ index 0b3ecb000ff7..3c806c8e5f3e 100644
  static int guc_action_vf_reset(struct xe_guc *guc)
  {
  	u32 request[GUC_HXG_REQUEST_MSG_MIN_LEN] = {
-@@ -320,6 +352,8 @@ static int vf_resfix_start(struct xe_gt *gt, u16 marker)
+@@ -321,6 +353,8 @@ static int vf_resfix_start(struct xe_gt *gt, u16 marker)
  
  	xe_gt_assert(gt, IS_SRIOV_VF(gt_to_xe(gt)));
  
@@ -110,7 +109,7 @@ index 0b3ecb000ff7..3c806c8e5f3e 100644
  	xe_gt_sriov_dbg_verbose(gt, "Sending resfix start marker %u\n", marker);
  
  	return guc_action_vf_resfix_start(guc, marker);
-@@ -1158,6 +1192,8 @@ static int vf_post_migration_fixups(struct xe_gt *gt)
+@@ -1160,6 +1194,8 @@ static int vf_post_migration_fixups(struct xe_gt *gt)
  	void *buf = gt->sriov.vf.migration.scratch;
  	int err;
  
@@ -119,7 +118,7 @@ index 0b3ecb000ff7..3c806c8e5f3e 100644
  	/* xe_gt_sriov_vf_query_config will fixup the GGTT addresses */
  	err = xe_gt_sriov_vf_query_config(gt);
  	if (err)
-@@ -1176,6 +1212,8 @@ static int vf_post_migration_fixups(struct xe_gt *gt)
+@@ -1180,6 +1216,8 @@ static int vf_post_migration_fixups(struct xe_gt *gt)
  
  static void vf_post_migration_rearm(struct xe_gt *gt)
  {
@@ -128,7 +127,7 @@ index 0b3ecb000ff7..3c806c8e5f3e 100644
  	/*
  	 * Make sure interrupts on the new HW are properly set. The GuC IRQ
  	 * must be working at this point, since the recovery did started,
-@@ -1206,6 +1244,8 @@ static void vf_post_migration_abort(struct xe_gt *gt)
+@@ -1210,6 +1248,8 @@ static void vf_post_migration_abort(struct xe_gt *gt)
  
  static int vf_post_migration_resfix_done(struct xe_gt *gt, u16 marker)
  {
@@ -138,7 +137,7 @@ index 0b3ecb000ff7..3c806c8e5f3e 100644
  	if (gt->sriov.vf.migration.recovery_queued)
  		xe_gt_sriov_dbg(gt, "another recovery imminent\n");
 diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf_debugfs.c b/drivers/gpu/drm/xe/xe_gt_sriov_vf_debugfs.c
-index 2ed5b6780d30..507718326e1f 100644
+index 2ed5b6780..507718326 100644
 --- a/drivers/gpu/drm/xe/xe_gt_sriov_vf_debugfs.c
 +++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf_debugfs.c
 @@ -69,4 +69,16 @@ void xe_gt_sriov_vf_debugfs_register(struct xe_gt *gt, struct dentry *root)
@@ -159,7 +158,7 @@ index 2ed5b6780d30..507718326e1f 100644
 +	}
  }
 diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
-index db2f8b3ed3e9..510c33116fbd 100644
+index 931012676..bfa54f0f9 100644
 --- a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
 +++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
 @@ -52,6 +52,14 @@ struct xe_gt_sriov_vf_migration {
@@ -174,9 +173,9 @@ index db2f8b3ed3e9..510c33116fbd 100644
 +		 */
 +		u8 resfix_stoppers;
 +	} debug;
+ 	/** @fixups_complete_count: Counts completed fixups stages */
+ 	atomic_t fixups_complete_count;
  	/**
- 	 * @resfix_marker: Marker sent on start and on end of post-migration
- 	 * steps.
 -- 
-2.34.1
+2.43.0
 

--- a/backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch
+++ b/backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch
@@ -141,7 +141,7 @@ index 0b28659d9..d9f21202e 100644
 +
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
-index 46518e629..7db1aeddc 100644
+index 47394118e..9914e6f8d 100644
 --- a/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
 +++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf.c
 @@ -300,12 +300,13 @@ void xe_gt_sriov_vf_guc_versions(struct xe_gt *gt,
@@ -218,7 +218,7 @@ index 46518e629..7db1aeddc 100644
  }
  
  static int guc_action_query_single_klv(struct xe_guc *guc, u32 key,
-@@ -1163,6 +1177,13 @@ static int vf_post_migration_fixups(struct xe_gt *gt)
+@@ -1166,6 +1180,13 @@ static int vf_post_migration_fixups(struct xe_gt *gt)
  
  static void vf_post_migration_rearm(struct xe_gt *gt)
  {
@@ -232,7 +232,7 @@ index 46518e629..7db1aeddc 100644
  	xe_guc_ct_restart(&gt->uc.guc.ct);
  	xe_guc_submit_unpause_prepare(&gt->uc.guc);
  }
-@@ -1184,37 +1205,40 @@ static void vf_post_migration_abort(struct xe_gt *gt)
+@@ -1187,37 +1208,40 @@ static void vf_post_migration_abort(struct xe_gt *gt)
  	xe_guc_submit_pause_abort(&gt->uc.guc);
  }
  
@@ -291,7 +291,7 @@ index 46518e629..7db1aeddc 100644
  
  	xe_gt_sriov_dbg(gt, "migration recovery in progress\n");
  
-@@ -1229,15 +1253,27 @@ static void vf_post_migration_recovery(struct xe_gt *gt)
+@@ -1232,6 +1256,15 @@ static void vf_post_migration_recovery(struct xe_gt *gt)
  		goto fail;
  	}
  
@@ -307,7 +307,8 @@ index 46518e629..7db1aeddc 100644
  	err = vf_post_migration_fixups(gt);
  	if (err)
  		goto fail;
- 
+@@ -1239,9 +1272,12 @@ static void vf_post_migration_recovery(struct xe_gt *gt)
+ 	vf_post_migration_mark_fixups_done(gt);
  	vf_post_migration_rearm(gt);
  
 -	err = vf_post_migration_notify_resfix_done(gt);
@@ -322,13 +323,13 @@ index 46518e629..7db1aeddc 100644
  	vf_post_migration_kickstart(gt);
  
 diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
-index fcb5de72e..b2e324b41 100644
+index f72f2edd2..931012676 100644
 --- a/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
 +++ b/drivers/gpu/drm/xe/xe_gt_sriov_vf_types.h
-@@ -51,6 +51,11 @@ struct xe_gt_sriov_vf_migration {
- 	wait_queue_head_t wq;
- 	/** @scratch: Scratch memory for VF recovery */
+@@ -54,6 +54,11 @@ struct xe_gt_sriov_vf_migration {
  	void *scratch;
+ 	/** @fixups_complete_count: Counts completed fixups stages */
+ 	atomic_t fixups_complete_count;
 +	/**
 +	 * @resfix_marker: Marker sent on start and on end of post-migration
 +	 * steps.
@@ -433,5 +434,5 @@ index d56b8cfea..86423a799 100644
  
  /**
 -- 
-2.34.1
+2.43.0
 

--- a/backport/patches/fixes/sriov/0001-drm-xe-queue-Call-fini-on-exec-queue-creation-fail.patch
+++ b/backport/patches/fixes/sriov/0001-drm-xe-queue-Call-fini-on-exec-queue-creation-fail.patch
@@ -24,19 +24,19 @@ Signed-off-by: Tomasz Lis <tomasz.lis@intel.com>
 Reviewed-by: Matthew Brost <matthew.brost@intel.com> (v1)
 Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
 Link: https://patch.msgid.link/20260226212701.2937065-2-tomasz.lis@intel.com
-(cherry-picked from commit 393e5fea6f7d7054abc2c3d97a4cfe8306cd6079 linux-next)
+(backported from commit 393e5fea6f7d7054abc2c3d97a4cfe8306cd6079 linux-next)
 Signed-off-by: Bommu Krishnaiah <bommu.krishnaiah@intel.com>
 ---
- drivers/gpu/drm/xe/xe_exec_queue.c | 23 +++++++++++------------
+ drivers/gpu/drm/xe/xe_exec_queue.c | 22 ++++++++++------------
  drivers/gpu/drm/xe/xe_lrc.h        |  3 ++-
- 2 files changed, 13 insertions(+), 13 deletions(-)
+ 2 files changed, 12 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
-index 8b472ff65833..bb03e2358f44 100644
+index 6024485c3..9cd87d860 100644
 --- a/drivers/gpu/drm/xe/xe_exec_queue.c
 +++ b/drivers/gpu/drm/xe/xe_exec_queue.c
-@@ -163,6 +163,16 @@ static struct xe_exec_queue *__xe_exec_queue_alloc(struct xe_device *xe,
- 	return q;
+@@ -213,6 +213,15 @@ struct xe_lrc *xe_exec_queue_lrc(struct xe_exec_queue *q)
+ 	return q->lrc[0];
  }
  
 +static void __xe_exec_queue_fini(struct xe_exec_queue *q)
@@ -44,7 +44,6 @@ index 8b472ff65833..bb03e2358f44 100644
 +	int i;
 +
 +	q->ops->fini(q);
-+
 +	for (i = 0; i < q->width; ++i)
 +		xe_lrc_put(q->lrc[i]);
 +}
@@ -52,7 +51,7 @@ index 8b472ff65833..bb03e2358f44 100644
  static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
  {
  	int i, err;
-@@ -220,21 +230,10 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
+@@ -276,21 +285,10 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
  	return 0;
  
  err_lrc:
@@ -76,7 +75,7 @@ index 8b472ff65833..bb03e2358f44 100644
  					   u32 logical_mask, u16 width,
  					   struct xe_hw_engine *hwe, u32 flags,
 diff --git a/drivers/gpu/drm/xe/xe_lrc.h b/drivers/gpu/drm/xe/xe_lrc.h
-index 2fb628da5c43..96ae31df3359 100644
+index 2fb628da5..96ae31df3 100644
 --- a/drivers/gpu/drm/xe/xe_lrc.h
 +++ b/drivers/gpu/drm/xe/xe_lrc.h
 @@ -73,7 +73,8 @@ static inline struct xe_lrc *xe_lrc_get(struct xe_lrc *lrc)

--- a/series
+++ b/series
@@ -262,6 +262,9 @@ backport/patches/features/sriov/0001-drm-xe-Disallow-input-fences-on-zero-batch-
 backport/patches/features/sriov/0001-drm-xe-Remove-last-fence-dependency-check-from-binds.patch
 backport/patches/features/sriov/0001-drm-xe-debugfs-Add-back-missing-GT-stats-entry.patch
 backport/patches/features/sriov/0001-drm-xe-vf-Allow-VF-to-initialize-MCR-tables.patch
+backport/patches/features/sriov/0001-drm-xe-Wrappers-for-setting-and-getting-LRC-referenc.patch
+backport/patches/features/sriov/0001-drm-xe-vf-Wait-for-all-fixups-before-using-default-L.patch
+backport/patches/features/sriov/0001-drm-xe-vf-Redo-LRC-creation-while-in-VF-fixups.patch
 # features/vf-double-migration
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Enable-VF-migration-only-on-supported-GuC-.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch


### PR DESCRIPTION
Fix races between LRC creation, teardown, and VF post-migration
fixups that can lead to invalid or partially updated LRCs.

Ensure fixups complete before LRCs are used, protect LRC access
during fixups, and recreate any LRCs created while fixups are
in progress.

This prevents inconsistent state and potential GPU hangs.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>