### PR TITLE
backport/base: Add stepping info and NVL-P workaround patches

### DIFF
--- a/backport/patches/base/0001-drm-xe-Drop-unused-IS_PLATFORM_STEP-and-IS_SUBPLATFO.patch
+++ b/backport/patches/base/0001-drm-xe-Drop-unused-IS_PLATFORM_STEP-and-IS_SUBPLATFO.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gustavo Sousa <gustavo.sousa@intel.com>
+Date: Mon, 9 Mar 2026 21:42:07 -0300
+Subject: drm/xe: Drop unused IS_PLATFORM_STEP() and
+ IS_SUBPLATFORM_STEP()
+
+The macros IS_PLATFORM_STEP() and IS_SUBPLATFORM_STEP() are unused since
+commit 87c299fa3a97 ("drm/xe/guc: Port Wa_14014475959 to xe_wa and fix
+it") and commit 63bbd800ff01 ("drm/xe/guc: Port
+Wa_22012727170/Wa_22012727685 to xe_wa"), respectively, and we can drop
+them now.  Furthermore, in upcoming changes we will add logic to read
+platform-level step information from PCI RevID and keeping those macros
+around would potentially cause confusion.
+
+v2:
+  - Cite commits that made the macros unused. (Matt)
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patch.msgid.link/20260309-extra-nvl-p-enabling-patches-v5-2-be9c902ee34e@intel.com
+Signed-off-by: Gustavo Sousa <gustavo.sousa@intel.com>
+(backported from commit ce517adff59c50a54a33ae90e2947eff9698dc86 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device_types.h | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index e8e8d54d19ea8..123d5489608f5 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -81,16 +81,6 @@ enum xe_wedged_mode {
+ 
+ #define XE_MAX_ASID	(BIT(20))
+ 
+-#define IS_PLATFORM_STEP(_xe, _platform, min_step, max_step)	\
+-	((_xe)->info.platform == (_platform) &&			\
+-	 (_xe)->info.step.graphics >= (min_step) &&		\
+-	 (_xe)->info.step.graphics < (max_step))
+-#define IS_SUBPLATFORM_STEP(_xe, _platform, sub, min_step, max_step)	\
+-	((_xe)->info.platform == (_platform) &&				\
+-	 (_xe)->info.subplatform == (sub) &&				\
+-	 (_xe)->info.step.graphics >= (min_step) &&			\
+-	 (_xe)->info.step.graphics < (max_step))
+-
+ #define tile_to_xe(tile__)								\
+ 	_Generic(tile__,								\
+ 		 const struct xe_tile * : (const struct xe_device *)((tile__)->xe),	\
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Modify-stepping-info-directly-in-xe_step_-_ge.patch
+++ b/backport/patches/base/0001-drm-xe-Modify-stepping-info-directly-in-xe_step_-_ge.patch
@@ -1,0 +1,186 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gustavo Sousa <gustavo.sousa@intel.com>
+Date: Mon, 9 Mar 2026 21:42:06 -0300
+Subject: drm/xe: Modify stepping info directly in xe_step_*_get()
+
+In an upcoming change, we will add a member to struct xe_step_info to
+represent the platform-level stepping.  As such, we should stop assigning
+the value returned by functions xe_step_pre_gmdid_get() and
+xe_step_gmdid_get() directly to xe->info.step.
+
+Since there are no other users for those functions, let's simply update
+them to modify xe->info.step directly.
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patch.msgid.link/20260309-extra-nvl-p-enabling-patches-v5-1-be9c902ee34e@intel.com
+Signed-off-by: Gustavo Sousa <gustavo.sousa@intel.com>
+(cherry-picked from commit 7e9de44e2c0f7d4cae734af59593054b127c8f69 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci.c  |  6 ++---
+ drivers/gpu/drm/xe/xe_step.c | 52 +++++++++++++++++++++---------------
+ drivers/gpu/drm/xe/xe_step.h |  8 +++---
+ 3 files changed, 36 insertions(+), 30 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index c0c371e58cb27..4882c0fea86b8 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -886,7 +886,7 @@ static int xe_info_init(struct xe_device *xe,
+ 	if (desc->pre_gmdid_graphics_ip) {
+ 		graphics_ip = desc->pre_gmdid_graphics_ip;
+ 		media_ip = desc->pre_gmdid_media_ip;
+-		xe->info.step = xe_step_pre_gmdid_get(xe);
++		xe_step_pre_gmdid_get(xe);
+ 	} else {
+ 		xe_assert(xe, !desc->pre_gmdid_media_ip);
+ 		ret = handle_gmdid(xe, &graphics_ip, &media_ip,
+@@ -894,9 +894,7 @@ static int xe_info_init(struct xe_device *xe,
+ 		if (ret)
+ 			return ret;
+ 
+-		xe->info.step = xe_step_gmdid_get(xe,
+-						  graphics_gmdid_revid,
+-						  media_gmdid_revid);
++		xe_step_gmdid_get(xe, graphics_gmdid_revid, media_gmdid_revid);
+ 	}
+ 
+ 	/*
+diff --git a/drivers/gpu/drm/xe/xe_step.c b/drivers/gpu/drm/xe/xe_step.c
+index 2860986f82f78..064b604b5b942 100644
+--- a/drivers/gpu/drm/xe/xe_step.c
++++ b/drivers/gpu/drm/xe/xe_step.c
+@@ -115,15 +115,17 @@ __diag_pop();
+  * Convert the PCI revid into proper IP steppings.  This should only be
+  * used on platforms that do not have GMD_ID support.
+  */
+-struct xe_step_info xe_step_pre_gmdid_get(struct xe_device *xe)
++void xe_step_pre_gmdid_get(struct xe_device *xe)
+ {
+ 	const struct xe_step_info *revids = NULL;
+-	struct xe_step_info step = {};
+ 	u16 revid = xe->info.revid;
+ 	int size = 0;
+ 	const int *basedie_info = NULL;
+ 	int basedie_size = 0;
+ 	int baseid = 0;
++	u8 graphics = STEP_NONE;
++	u8 media = STEP_NONE;
++	u8 basedie = STEP_NONE;
+ 
+ 	if (xe->info.platform == XE_PVC) {
+ 		baseid = FIELD_GET(GENMASK(5, 3), xe->info.revid);
+@@ -166,10 +168,12 @@ struct xe_step_info xe_step_pre_gmdid_get(struct xe_device *xe)
+ 
+ 	/* Not using the stepping scheme for the platform yet. */
+ 	if (!revids)
+-		return step;
++		goto done;
+ 
+ 	if (revid < size && revids[revid].graphics != STEP_NONE) {
+-		step = revids[revid];
++		graphics = revids[revid].graphics;
++		media = revids[revid].media;
++		basedie = revids[revid].basedie;
+ 	} else {
+ 		drm_warn(&xe->drm, "Unknown revid 0x%02x\n", revid);
+ 
+@@ -187,25 +191,30 @@ struct xe_step_info xe_step_pre_gmdid_get(struct xe_device *xe)
+ 		if (revid < size) {
+ 			drm_dbg(&xe->drm, "Using steppings for revid 0x%02x\n",
+ 				revid);
+-			step = revids[revid];
++			graphics = revids[revid].graphics;
++			media = revids[revid].media;
++			basedie = revids[revid].basedie;
+ 		} else {
+ 			drm_dbg(&xe->drm, "Using future steppings\n");
+-			step.graphics = STEP_FUTURE;
++			graphics = STEP_FUTURE;
+ 		}
+ 	}
+ 
+-	drm_WARN_ON(&xe->drm, step.graphics == STEP_NONE);
++	drm_WARN_ON(&xe->drm, graphics == STEP_NONE);
+ 
+ 	if (basedie_info && basedie_size) {
+ 		if (baseid < basedie_size && basedie_info[baseid] != STEP_NONE) {
+-			step.basedie = basedie_info[baseid];
++			basedie = basedie_info[baseid];
+ 		} else {
+ 			drm_warn(&xe->drm, "Unknown baseid 0x%02x\n", baseid);
+-			step.basedie = STEP_FUTURE;
++			basedie = STEP_FUTURE;
+ 		}
+ 	}
+ 
+-	return step;
++done:
++	xe->info.step.graphics = graphics;
++	xe->info.step.media = media;
++	xe->info.step.basedie = basedie;
+ }
+ 
+ /**
+@@ -220,28 +229,27 @@ struct xe_step_info xe_step_pre_gmdid_get(struct xe_device *xe)
+  * all platforms:  major steppings (A0, B0, etc.) are 4 apart, with minor
+  * steppings (A1, A2, etc.) taking the values in between.
+  */
+-struct xe_step_info xe_step_gmdid_get(struct xe_device *xe,
+-				      u32 graphics_gmdid_revid,
+-				      u32 media_gmdid_revid)
++void xe_step_gmdid_get(struct xe_device *xe,
++		       u32 graphics_gmdid_revid,
++		       u32 media_gmdid_revid)
+ {
+-	struct xe_step_info step = {
+-		.graphics = STEP_A0 + graphics_gmdid_revid,
+-		.media = STEP_A0 + media_gmdid_revid,
+-	};
++	u8 graphics = STEP_A0 + graphics_gmdid_revid;
++	u8 media = STEP_A0 + media_gmdid_revid;
+ 
+-	if (step.graphics >= STEP_FUTURE) {
+-		step.graphics = STEP_FUTURE;
++	if (graphics >= STEP_FUTURE) {
++		graphics = STEP_FUTURE;
+ 		drm_dbg(&xe->drm, "Graphics GMD_ID revid value %d treated as future stepping\n",
+ 			graphics_gmdid_revid);
+ 	}
+ 
+-	if (step.media >= STEP_FUTURE) {
+-		step.media = STEP_FUTURE;
++	if (media >= STEP_FUTURE) {
++		media = STEP_FUTURE;
+ 		drm_dbg(&xe->drm, "Media GMD_ID revid value %d treated as future stepping\n",
+ 			media_gmdid_revid);
+ 	}
+ 
+-	return step;
++	xe->info.step.graphics = graphics;
++	xe->info.step.media = media;
+ }
+ 
+ #define STEP_NAME_CASE(name)	\
+diff --git a/drivers/gpu/drm/xe/xe_step.h b/drivers/gpu/drm/xe/xe_step.h
+index 686cb59200c28..6febb7fac476d 100644
+--- a/drivers/gpu/drm/xe/xe_step.h
++++ b/drivers/gpu/drm/xe/xe_step.h
+@@ -12,10 +12,10 @@
+ 
+ struct xe_device;
+ 
+-struct xe_step_info xe_step_pre_gmdid_get(struct xe_device *xe);
+-struct xe_step_info xe_step_gmdid_get(struct xe_device *xe,
+-				      u32 graphics_gmdid_revid,
+-				      u32 media_gmdid_revid);
++void xe_step_pre_gmdid_get(struct xe_device *xe);
++void xe_step_gmdid_get(struct xe_device *xe,
++		       u32 graphics_gmdid_revid,
++		       u32 media_gmdid_revid);
+ static inline u32 xe_step_to_gmdid(enum xe_step step) { return step - STEP_A0; }
+ 
+ const char *xe_step_name(enum xe_step step);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Translate-C-state-reset-value-into-RC6.patch
+++ b/backport/patches/base/0001-drm-xe-Translate-C-state-reset-value-into-RC6.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gustavo Sousa <gustavo.sousa@intel.com>
+Date: Mon, 9 Mar 2026 21:42:12 -0300
+Subject: drm/xe: Translate C-state "reset value" into RC6
+
+There are higher level sleep states that will cause RC6 state readout to
+come back with an "in-reset" value. That is the case with NVL-P. As
+those states are only possible if the GT is already in C6, let's just
+translate the "reset value" into C6 when doing the readout.
+
+Bspec: 67651
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patch.msgid.link/20260309-extra-nvl-p-enabling-patches-v5-7-be9c902ee34e@intel.com
+Signed-off-by: Gustavo Sousa <gustavo.sousa@intel.com>
+(cherry-picked from commit 68bed0d6bfae422b7297c62736fee0134b3b0c24 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h | 1 +
+ drivers/gpu/drm/xe/xe_guc_pc.c       | 8 ++++++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index 6902bba43c2b9..e0b99fbcc210b 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -20,6 +20,7 @@
+ #define MTL_MIRROR_TARGET_WP1				XE_REG(0xc60)
+ #define   MTL_CAGF_MASK					REG_GENMASK(8, 0)
+ #define   MTL_CC_MASK					REG_GENMASK(12, 9)
++#define   MTL_CRST					0xf
+ 
+ /* RPM unit config (Gen8+) */
+ #define RPM_CONFIG0					XE_REG(0xd00)
+diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
+index 5e5495a39a3c9..f4276bb6eede5 100644
+--- a/drivers/gpu/drm/xe/xe_guc_pc.c
++++ b/drivers/gpu/drm/xe/xe_guc_pc.c
+@@ -730,6 +730,14 @@ enum xe_gt_idle_state xe_guc_pc_c_status(struct xe_guc_pc *pc)
+ 	if (GRAPHICS_VERx100(gt_to_xe(gt)) >= 1270) {
+ 		reg = xe_mmio_read32(&gt->mmio, MTL_MIRROR_TARGET_WP1);
+ 		gt_c_state = REG_FIELD_GET(MTL_CC_MASK, reg);
++
++		/*
++		 * There are higher level sleep states that will cause this
++		 * field to read out as its reset state, and those are only
++		 * possible after the GT is already in C6.
++		 */
++		if (gt_c_state == MTL_CRST)
++			gt_c_state = GT_C6;
+ 	} else {
+ 		reg = xe_mmio_read32(&gt->mmio, GT_CORE_STATUS);
+ 		gt_c_state = REG_FIELD_GET(RCN_MASK, reg);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-nvlp-Implement-Wa_14026539277.patch
+++ b/backport/patches/base/0001-drm-xe-nvlp-Implement-Wa_14026539277.patch
@@ -1,0 +1,121 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gustavo Sousa <gustavo.sousa@intel.com>
+Date: Mon, 9 Mar 2026 21:42:10 -0300
+Subject: drm/xe/nvlp: Implement Wa_14026539277
+
+Implement the KMD part of Wa_14026539277, which applies to NVL-P A0.
+The KMD implementation is just one component of the workaround, which
+also depends on Pcode to implement its part in order to be complete.
+
+v2:
+  - Add FUNC(xe_rtp_match_not_sriov_vf) to skip applying the workaround
+    to SRIOV VFs. (Matt)
+v3:
+  - Make Wa_14026539277 a device workaround instead of a GT workaround.
+    (Matt)
+v4:
+  - Drop FUNC(xe_rtp_match_not_sriov_vf) and use a direct check with
+    IS_SRIOV_VF() in the workaround implementation. (Matt)
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com> # v3
+Link: https://patch.msgid.link/20260309-extra-nvl-p-enabling-patches-v5-5-be9c902ee34e@intel.com
+Signed-off-by: Gustavo Sousa <gustavo.sousa@intel.com>
+(cherry-picked from commit 0919b266456d81e71277c5963d4e806e85b65232 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h      |  4 +++
+ drivers/gpu/drm/xe/xe_device_wa_oob.rules |  1 +
+ drivers/gpu/drm/xe/xe_gt.c                | 39 +++++++++++++++++++++++
+ 3 files changed, 44 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index 1d652266f4f39..43af7830cc254 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -447,6 +447,10 @@
+ 
+ #define XEHPC_L3CLOS_MASK(i)			XE_REG_MCR(0xb194 + (i) * 8)
+ 
++#define L2COMPUTESIDECTRL			XE_REG_MCR(0xb1c0)
++#define   CECTRL				REG_GENMASK(2, 1)
++#define   CECTRL_CENODATA_ALWAYS		REG_FIELD_PREP(CECTRL, 0x0)
++
+ #define XE2_GLOBAL_INVAL			XE_REG(0xb404)
+ 
+ #define XE2LPM_L3SQCREG2			XE_REG_MCR(0xb604)
+diff --git a/drivers/gpu/drm/xe/xe_device_wa_oob.rules b/drivers/gpu/drm/xe/xe_device_wa_oob.rules
+index 55ba01bc8f38a..d129cddb6ead4 100644
+--- a/drivers/gpu/drm/xe/xe_device_wa_oob.rules
++++ b/drivers/gpu/drm/xe/xe_device_wa_oob.rules
+@@ -3,3 +3,4 @@
+ 		PLATFORM(PANTHERLAKE)
+ 22019338487_display	PLATFORM(LUNARLAKE)
+ 14022085890	SUBPLATFORM(BATTLEMAGE, G21)
++14026539277	PLATFORM(NOVALAKE_P), PLATFORM_STEP(A0, B0)
+diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
+index 9d090d0f24383..568f3a0cc4824 100644
+--- a/drivers/gpu/drm/xe/xe_gt.c
++++ b/drivers/gpu/drm/xe/xe_gt.c
+@@ -10,6 +10,7 @@
+ #include <drm/drm_managed.h>
+ #include <uapi/drm/xe_drm.h>
+ 
++#include <generated/xe_device_wa_oob.h>
+ #include <generated/xe_wa_oob.h>
+ 
+ #include "instructions/xe_alu_commands.h"
+@@ -410,6 +411,35 @@ int xe_gt_record_default_lrcs(struct xe_gt *gt)
+ 	return err;
+ }
+ 
++static void wa_14026539277(struct xe_gt *gt)
++{
++	struct xe_device *xe = gt_to_xe(gt);
++	u32 val;
++
++	/*
++	 * FIXME: We currently can't use FUNC(xe_rtp_match_not_sriov_vf) in the
++	 * rules for Wa_14026539277 due to xe_wa_process_device_oob() being
++	 * called before xe_sriov_probe_early(); and we can't move the call to
++	 * the former to happen after the latter because MMIO read functions
++	 * already depend on a device OOB workaround.  This needs to be fixed by
++	 * allowing workaround checks to happen at different stages of driver
++	 * initialization.
++	 */
++	if (IS_SRIOV_VF(xe))
++		return;
++
++	if (!XE_DEVICE_WA(xe, 14026539277))
++		return;
++
++	if (!xe_gt_is_main_type(gt))
++		return;
++
++	val = xe_gt_mcr_unicast_read_any(gt, L2COMPUTESIDECTRL);
++	val &= ~CECTRL;
++	val |= CECTRL_CENODATA_ALWAYS;
++	xe_gt_mcr_multicast_write(gt, L2COMPUTESIDECTRL, val);
++}
++
+ int xe_gt_init_early(struct xe_gt *gt)
+ {
+ 	int err;
+@@ -531,6 +561,15 @@ static int gt_init_with_gt_forcewake(struct xe_gt *gt)
+ 	 */
+ 	gt->info.gmdid = xe_mmio_read32(&gt->mmio, GMD_ID);
+ 
++	/*
++	 * Wa_14026539277 can't be implemented as a regular GT workaround (i.e.
++	 * as an entry in gt_was[]) for two reasons: it is actually a device
++	 * workaround that happens to involve programming a GT register; and it
++	 * needs to be applied early to avoid getting the hardware in a bad
++	 * state before we have a chance to do the necessary programming.
++	 */
++	wa_14026539277(gt);
++
+ 	return 0;
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-nvlp-Read-platform-level-stepping-info.patch
+++ b/backport/patches/base/0001-drm-xe-nvlp-Read-platform-level-stepping-info.patch
@@ -1,0 +1,109 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gustavo Sousa <gustavo.sousa@intel.com>
+Date: Mon, 9 Mar 2026 21:42:08 -0300
+Subject: drm/xe/nvlp: Read platform-level stepping info
+
+There will be a NVL-P workaround for which we will need to know the
+platform-level stepping information in order to decide whether to apply
+it or not.
+
+While NVL-P has a nice mapping between the PCI revid and our symbolic
+stepping enumeration, not all platforms are like that: (i) Some
+platforms will have a single PCI revid used for a set platform level
+steppings (ii) and some might even require specific mappings.
+
+To make things simpler, let's include stepping information in the device
+info only on demand, for those platforms where it is needed for
+workaround checks.
+
+v2:
+  - Call xe_step_platform_get() very early, to allow device workarounds
+    to use it in early stages of device initialization. (Matt)
+
+Bspec: 74201
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com> # v1
+Link: https://patch.msgid.link/20260309-extra-nvl-p-enabling-patches-v5-3-be9c902ee34e@intel.com
+Signed-off-by: Gustavo Sousa <gustavo.sousa@intel.com>
+(cherry-picked from commit 19da26bce08a5686515b877099af78169148a3b3 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci.c        |  2 ++
+ drivers/gpu/drm/xe/xe_step.c       | 22 ++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_step.h       |  2 ++
+ drivers/gpu/drm/xe/xe_step_types.h |  1 +
+ 4 files changed, 27 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index 4882c0fea86b8..a95d9c65532b4 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -752,6 +752,8 @@ static int xe_info_init_early(struct xe_device *xe,
+ 	xe->info.max_gt_per_tile = desc->max_gt_per_tile;
+ 	xe->info.tile_count = 1 + desc->max_remote_tiles;
+ 
++	xe_step_platform_get(xe);
++
+ 	err = xe_tile_init_early(xe_device_get_root_tile(xe), xe, 0);
+ 	if (err)
+ 		return err;
+diff --git a/drivers/gpu/drm/xe/xe_step.c b/drivers/gpu/drm/xe/xe_step.c
+index 064b604b5b942..d0f888c31831f 100644
+--- a/drivers/gpu/drm/xe/xe_step.c
++++ b/drivers/gpu/drm/xe/xe_step.c
+@@ -108,6 +108,28 @@ static const int pvc_basedie_subids[] = {
+ 
+ __diag_pop();
+ 
++/**
++ * xe_step_platform_get - Determine platform-level stepping from PCI revid
++ * @xe: Xe device
++ *
++ * Convert the PCI revid into a platform-level stepping value and store that
++ * in the device info.
++ */
++void xe_step_platform_get(struct xe_device *xe)
++{
++	/*
++	 * Not all platforms map PCI revid directly into our symbolic stepping
++	 * enumeration. Some platforms will have a single PCI revid used for a
++	 * range platform level steppings and some might even require specific
++	 * mappings. So prefer to err on the side of caution and include only
++	 * the platforms from which we need the stepping info for workaround
++	 * checks.
++	 */
++
++	if (xe->info.platform == XE_NOVALAKE_P)
++		xe->info.step.platform = STEP_A0 + xe->info.revid;
++}
++
+ /**
+  * xe_step_pre_gmdid_get - Determine IP steppings from PCI revid
+  * @xe: Xe device
+diff --git a/drivers/gpu/drm/xe/xe_step.h b/drivers/gpu/drm/xe/xe_step.h
+index 6febb7fac476d..41f1c95c46e5c 100644
+--- a/drivers/gpu/drm/xe/xe_step.h
++++ b/drivers/gpu/drm/xe/xe_step.h
+@@ -12,6 +12,8 @@
+ 
+ struct xe_device;
+ 
++void xe_step_platform_get(struct xe_device *xe);
++
+ void xe_step_pre_gmdid_get(struct xe_device *xe);
+ void xe_step_gmdid_get(struct xe_device *xe,
+ 		       u32 graphics_gmdid_revid,
+diff --git a/drivers/gpu/drm/xe/xe_step_types.h b/drivers/gpu/drm/xe/xe_step_types.h
+index d978cc2512f25..43ca738507396 100644
+--- a/drivers/gpu/drm/xe/xe_step_types.h
++++ b/drivers/gpu/drm/xe/xe_step_types.h
+@@ -9,6 +9,7 @@
+ #include <linux/types.h>
+ 
+ struct xe_step_info {
++	u8 platform;
+ 	u8 graphics;
+ 	u8 media;
+ 	u8 basedie;
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-rtp-Add-support-for-matching-platform-level-s.patch
+++ b/backport/patches/base/0001-drm-xe-rtp-Add-support-for-matching-platform-level-s.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gustavo Sousa <gustavo.sousa@intel.com>
+Date: Mon, 9 Mar 2026 21:42:09 -0300
+Subject: drm/xe/rtp: Add support for matching platform-level stepping
+
+Add support for matching platform-level stepping, which will be used for
+an upcoming NVL-P workaround.
+
+As support for reading platform-level stepping information is added only
+as needed in the driver, add a warning when the rule finds a STEP_NONE
+value, which is an indication that the driver is missing such a support.
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patch.msgid.link/20260309-extra-nvl-p-enabling-patches-v5-4-be9c902ee34e@intel.com
+Signed-off-by: Gustavo Sousa <gustavo.sousa@intel.com>
+(cherry-picked from commit 557c05034ffaa0614d2ed57fff435b6630b92e70 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_rtp.c       |  7 +++++++
+ drivers/gpu/drm/xe/xe_rtp.h       | 20 ++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_rtp_types.h |  1 +
+ 3 files changed, 28 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_rtp.c b/drivers/gpu/drm/xe/xe_rtp.c
+index b7c26e2fb411e..db36b811dfe08 100644
+--- a/drivers/gpu/drm/xe/xe_rtp.c
++++ b/drivers/gpu/drm/xe/xe_rtp.c
+@@ -55,6 +55,13 @@ static bool rule_matches(const struct xe_device *xe,
+ 			match = xe->info.platform == r->platform &&
+ 				xe->info.subplatform == r->subplatform;
+ 			break;
++		case XE_RTP_MATCH_PLATFORM_STEP:
++			if (drm_WARN_ON(&xe->drm, xe->info.step.platform == STEP_NONE))
++				return false;
++
++			match = xe->info.step.platform >= r->step_start &&
++				xe->info.step.platform < r->step_end;
++			break;
+ 		case XE_RTP_MATCH_GRAPHICS_VERSION:
+ 			if (drm_WARN_ON(&xe->drm, !gt))
+ 				return false;
+diff --git a/drivers/gpu/drm/xe/xe_rtp.h b/drivers/gpu/drm/xe/xe_rtp.h
+index ba5f940c0a961..5ef1b1b2abb59 100644
+--- a/drivers/gpu/drm/xe/xe_rtp.h
++++ b/drivers/gpu/drm/xe/xe_rtp.h
+@@ -35,6 +35,10 @@ struct xe_reg_sr;
+ 	{ .match_type = XE_RTP_MATCH_SUBPLATFORM,				\
+ 	  .platform = plat__, .subplatform = sub__ }
+ 
++#define _XE_RTP_RULE_PLATFORM_STEP(start__, end__)				\
++	{ .match_type = XE_RTP_MATCH_PLATFORM_STEP,				\
++	  .step_start = start__, .step_end = end__ }
++
+ #define _XE_RTP_RULE_GRAPHICS_STEP(start__, end__)				\
+ 	{ .match_type = XE_RTP_MATCH_GRAPHICS_STEP,				\
+ 	  .step_start = start__, .step_end = end__ }
+@@ -66,6 +70,22 @@ struct xe_reg_sr;
+ #define XE_RTP_RULE_SUBPLATFORM(plat_, sub_)					\
+ 	_XE_RTP_RULE_SUBPLATFORM(XE_##plat_, XE_SUBPLATFORM_##plat_##_##sub_)
+ 
++/**
++ * XE_RTP_RULE_PLATFORM_STEP - Create rule matching platform-level stepping
++ * @start_: First stepping matching the rule
++ * @end_: First stepping that does not match the rule
++ *
++ * Note that the range matching this rule is [ @start_, @end_ ), i.e. inclusive
++ * on the left, exclusive on the right.
++ *
++ * You need to make sure that proper support for reading platform-level stepping
++ * information is present for the target platform before using this rule.
++ *
++ * Refer to XE_RTP_RULES() for expected usage.
++ */
++#define XE_RTP_RULE_PLATFORM_STEP(start_, end_)					\
++	_XE_RTP_RULE_PLATFORM_STEP(STEP_##start_, STEP_##end_)
++
+ /**
+  * XE_RTP_RULE_GRAPHICS_STEP - Create rule matching graphics stepping
+  * @start_: First stepping matching the rule
+diff --git a/drivers/gpu/drm/xe/xe_rtp_types.h b/drivers/gpu/drm/xe/xe_rtp_types.h
+index 6ba7f226c2274..166251615be13 100644
+--- a/drivers/gpu/drm/xe/xe_rtp_types.h
++++ b/drivers/gpu/drm/xe/xe_rtp_types.h
+@@ -41,6 +41,7 @@ struct xe_rtp_action {
+ enum {
+ 	XE_RTP_MATCH_PLATFORM,
+ 	XE_RTP_MATCH_SUBPLATFORM,
++	XE_RTP_MATCH_PLATFORM_STEP,
+ 	XE_RTP_MATCH_GRAPHICS_VERSION,
+ 	XE_RTP_MATCH_GRAPHICS_VERSION_RANGE,
+ 	XE_RTP_MATCH_GRAPHICS_VERSION_ANY_GT,
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-xe3p-Drop-Wa_16028780921.patch
+++ b/backport/patches/base/0001-drm-xe-xe3p-Drop-Wa_16028780921.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gustavo Sousa <gustavo.sousa@intel.com>
+Date: Mon, 9 Mar 2026 21:42:11 -0300
+Subject: drm/xe/xe3p: Drop Wa_16028780921
+
+Wa_16028780921 involves writing to a register that is locked by firmware
+prior to driver loading and doesn't have any effect if implemented by
+the KMD.  Since the implementation of the workaround actually belongs
+the firmware, just drop the ineffective implementation by the KMD.
+
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patch.msgid.link/20260309-extra-nvl-p-enabling-patches-v5-6-be9c902ee34e@intel.com
+Signed-off-by: Gustavo Sousa <gustavo.sousa@intel.com>
+(cherry-picked from commit 44b512754d168b9ed7b8bc128565150203c9ac38 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h | 3 ---
+ drivers/gpu/drm/xe/xe_wa.c           | 4 ----
+ 2 files changed, 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index 43af7830cc254..6902bba43c2b9 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -216,9 +216,6 @@
+ 
+ #define GSCPSMI_BASE				XE_REG(0x880c)
+ 
+-#define CCCHKNREG2				XE_REG_MCR(0x881c)
+-#define   LOCALITYDIS				REG_BIT(7)
+-
+ #define CCCHKNREG1				XE_REG_MCR(0x8828)
+ #define   L3CMPCTRL				REG_BIT(23)
+ #define   ENCOMPPERFFIX				REG_BIT(18)
+diff --git a/drivers/gpu/drm/xe/xe_wa.c b/drivers/gpu/drm/xe/xe_wa.c
+index 50906e5d59a44..ec8ec6b18dda1 100644
+--- a/drivers/gpu/drm/xe/xe_wa.c
++++ b/drivers/gpu/drm/xe/xe_wa.c
+@@ -314,10 +314,6 @@ static const struct xe_rtp_entry_sr gt_was[] = {
+ 	  XE_RTP_ACTIONS(SET(MMIOATSREQLIMIT_GAM_WALK_3D,
+ 			     DIS_ATS_WRONLY_PG))
+ 	},
+-	{ XE_RTP_NAME("16028780921"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION(3510), GRAPHICS_STEP(A0, B0)),
+-	  XE_RTP_ACTIONS(SET(CCCHKNREG2, LOCALITYDIS))
+-	},
+ 	{ XE_RTP_NAME("14026144927"),
+ 	  XE_RTP_RULES(GRAPHICS_VERSION(3510), GRAPHICS_STEP(A0, B0)),
+ 	  XE_RTP_ACTIONS(SET(L3SQCREG2, L3_SQ_DISABLE_COAMA_2WAY_COH |
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -18,4 +18,11 @@ backport/patches/base/0001-drm-xe-nvlp-Define-GuC-firmware-for-NVL-P.patch
 backport/patches/base/0001-drm-xe-nvlp-Bump-maximum-WOPCM-size.patch
 backport/patches/base/0001-drivers-gpu-nvlp-Drop-force_probe-requ.patch
 backport/patches/base/0001-drm-xe-vf-Allow-VF-to-initialize-MCR-tables.patch
+backport/patches/base/0001-drm-xe-Modify-stepping-info-directly-in-xe_step_-_ge.patch
+backport/patches/base/0001-drm-xe-Drop-unused-IS_PLATFORM_STEP-and-IS_SUBPLATFO.patch
+backport/patches/base/0001-drm-xe-nvlp-Read-platform-level-stepping-info.patch
+backport/patches/base/0001-drm-xe-rtp-Add-support-for-matching-platform-level-s.patch
+backport/patches/base/0001-drm-xe-nvlp-Implement-Wa_14026539277.patch
+backport/patches/base/0001-drm-xe-xe3p-Drop-Wa_16028780921.patch
+backport/patches/base/0001-drm-xe-Translate-C-state-reset-value-into-RC6.patch
 # fixes


### PR DESCRIPTION
drm/xe: Add NVL-P platform stepping support and related cleanups

Prepare the driver for NVL-P enablement by introducing support for
platform-level stepping and related infrastructure updates.

Modify xe_step_*_get() helpers to update xe->info.step directly in
preparation for adding platform-level stepping information to
struct xe_step_info. Add support for reading platform-level stepping
from PCI RevID on NVL-P systems and extend the RTP matching logic to
allow rules to match against platform-level stepping.

Implement the device workaround Wa_14026539277 for NVL-P A0 while
skipping application on SR-IOV VFs. Remove unused macros
IS_PLATFORM_STEP() and IS_SUBPLATFORM_STEP() that are no longer used
by the driver.

Drop the ineffective Wa_16028780921 implementation since the register
is locked by firmware before driver load and the workaround belongs
to firmware.

Finally, translate the C-state "reset value" returned on NVL-P systems
to RC6 when reading the GT sleep state, since higher-level sleep
states imply the GT is already in C6.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>