### PR TITLE
Backport add missing indirect ring state feature flag

### DIFF
--- a/backport/patches/base/0001-drm-xe-xe3p_lpg-Add-missing-indirect-ring-state-feat.patch
+++ b/backport/patches/base/0001-drm-xe-xe3p_lpg-Add-missing-indirect-ring-state-feat.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gustavo Sousa <gustavo.sousa@intel.com>
+Date: Wed, 1 Apr 2026 19:10:51 -0300
+Subject: drm/xe/xe3p_lpg: Add missing indirect ring state feature flag
+
+Even though commit 8fcb7dfb8bbf ("drm/xe/xe3p_lpg: Add support for
+graphics IP 35.10") mentions that the support for Indirect Ring State
+exists for Xe3p_LPG, it missed actually setting the feature flag in
+graphics_xe3p_lpg.  Fix that by adding the missing member.
+
+Fixes: 8fcb7dfb8bbf ("drm/xe/xe3p_lpg: Add support for graphics IP 35.10")
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patch.msgid.link/20260401-xe3p_lpg-indirect-ring-state-v1-1-0e4b5edf6898@intel.com
+Signed-off-by: Gustavo Sousa <gustavo.sousa@intel.com>
+(cherry-picked from commit ec4f4970eb744fd7d6d135f40f5c83bd05982e72 linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
+index 26eb58e11056..b1b89d09e42b 100644
+--- a/drivers/gpu/drm/xe/xe_pci.c
++++ b/drivers/gpu/drm/xe/xe_pci.c
+@@ -118,6 +118,7 @@ static const struct xe_graphics_desc graphics_xe2 = {
+ 
+ static const struct xe_graphics_desc graphics_xe3p_lpg = {
+ 	XE2_GFX_FEATURES,
++	.has_indirect_ring_state = 1,
+ 	.multi_queue_engine_class_mask = BIT(XE_ENGINE_CLASS_COPY) | BIT(XE_ENGINE_CLASS_COMPUTE),
+ 	.num_geometry_xecore_fuse_regs = 3,
+ 	.num_compute_xecore_fuse_regs = 3,
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -26,3 +26,4 @@ backport/patches/base/0001-drm-xe-nvlp-Implement-Wa_14026539277.patch
 backport/patches/base/0001-drm-xe-xe3p-Drop-Wa_16028780921.patch
 backport/patches/base/0001-drm-xe-Translate-C-state-reset-value-into-RC6.patch
 # fixes
+backport/patches/base/0001-drm-xe-xe3p_lpg-Add-missing-indirect-ring-state-feat.patch


### PR DESCRIPTION
Even though commit 8fcb7dfb8bbf ("drm/xe/xe3p_lpg: Add support for
graphics IP 35.10") mentions that the support for Indirect Ring State
exists for Xe3p_LPG, it missed actually setting the feature flag in
graphics_xe3p_lpg. This causes issues when the feature is expected to
be available. Fix that by adding the missing member.

Fixes: 8fcb7dfb8bbf ("drm/xe/xe3p_lpg: Add support for graphics IP 35.10")

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>