### PR TITLE
devcoredump: add dev_coredump_put() from v6.10

### DIFF
--- a/backport/patches/base/0001-devcoredump-Add-dev_coredump_put.patch
+++ b/backport/patches/base/0001-devcoredump-Add-dev_coredump_put.patch
@@ -1,0 +1,92 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jos_ Roberto de Souza <jose.souza@intel.com>
+Date: Tue, 9 Apr 2024 13:02:05 -0700
+Subject: devcoredump: Add dev_coredump_put()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It is useful for modules that do not want to keep coredump available
+after its unload.
+Otherwise, the coredump would only be removed after DEVCD_TIMEOUT
+seconds.
+
+v2:
+- dev_coredump_put() documentation updated (Mukesh)
+
+Cc: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Cc: Mukesh Ojha <quic_mojha@quicinc.com>
+Cc: Johannes Berg <johannes@sipsolutions.net>
+Cc: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Reviewed-by: Johannes Berg <johannes@sipsolutions.net>
+Acked-by: Jonathan Cavitt <jonathan.cavitt@intel.com>
+Signed-off-by: José Roberto de Souza <jose.souza@intel.com>
+Acked-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Link: https://patchwork.freedesktop.org/patch/msgid/20240409200206.108452-1-jose.souza@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit a28380f119a918135c6b7155fb4eb95eaabb62dc linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/base/devcoredump.c  | 23 +++++++++++++++++++++++
+ include/linux/devcoredump.h |  5 +++++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/drivers/base/devcoredump.c b/drivers/base/devcoredump.c
+index 7e2d1f0d903a..82aeb09b3d1b 100644
+--- a/drivers/base/devcoredump.c
++++ b/drivers/base/devcoredump.c
+@@ -304,6 +304,29 @@ static ssize_t devcd_read_from_sgtable(char *buffer, loff_t offset,
+ 				  offset);
+ }
+ 
++/**
++ * dev_coredump_put - remove device coredump
++ * @dev: the struct device for the crashed device
++ *
++ * dev_coredump_put() removes coredump, if exists, for a given device from
++ * the file system and free its associated data otherwise, does nothing.
++ *
++ * It is useful for modules that do not want to keep coredump
++ * available after its unload.
++ */
++void dev_coredump_put(struct device *dev)
++{
++	struct device *existing;
++
++	existing = class_find_device(&devcd_class, NULL, dev,
++				     devcd_match_failing);
++	if (existing) {
++		devcd_free(existing, NULL);
++		put_device(existing);
++	}
++}
++EXPORT_SYMBOL_GPL(dev_coredump_put);
++
+ /**
+  * dev_coredumpm - create device coredump with read/free methods
+  * @dev: the struct device for the crashed device
+diff --git a/include/linux/devcoredump.h b/include/linux/devcoredump.h
+index c008169ed2c6..c8f7eb6cc191 100644
+--- a/include/linux/devcoredump.h
++++ b/include/linux/devcoredump.h
+@@ -63,6 +63,8 @@ void dev_coredumpm(struct device *dev, struct module *owner,
+ 
+ void dev_coredumpsg(struct device *dev, struct scatterlist *table,
+ 		    size_t datalen, gfp_t gfp);
++
++void dev_coredump_put(struct device *dev);
+ #else
+ static inline void dev_coredumpv(struct device *dev, void *data,
+ 				 size_t datalen, gfp_t gfp)
+@@ -85,6 +87,9 @@ static inline void dev_coredumpsg(struct device *dev, struct scatterlist *table,
+ {
+ 	_devcd_free_sgtable(table);
+ }
++static inline void dev_coredump_put(struct device *dev)
++{
++}
+ #endif /* CONFIG_DEV_COREDUMP */
+ 
+ #endif /* __DEVCOREDUMP_H */
+-- 
+2.34.1

--- a/series
+++ b/series
@@ -1,3 +1,4 @@
 # base
 backport/patches/base/0001-vfio-Create-vfio_fs_type-with-inode-per-device.patch
 backport/patches/base/0001-vfio-pci-Use-unmap_mapping_range.patch
+backport/patches/base/0001-devcoredump-Add-dev_coredump_put.patch


### PR DESCRIPTION
dev_coredump_put() is absent on 6.6. xe device teardown path calls it
unconditionally at module unload, triggering a mutex lock corruption:

WARNING: CPU: 16 PID: 3264 at kernel/locking/mutex.c:582 __mutex_lock
DEBUG_LOCKS_WARN_ON(lock->magic != lock)

A backports-only implementation is not feasible because the API
depends on devcd_class, devcd_match_failing(), and devcd_free(), all
of which are static symbols in drivers/base/devcoredump.c and
inaccessible to out-of-tree modules.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>