### PR TITLE
autotools/m4: fix drm_driver date member detection

### DIFF
--- a/autotools/Makefile.am
+++ b/autotools/Makefile.am
@@ -65,7 +65,7 @@ DEF_VER=@DOLLAR_SIGN@(shell cat debian/changelog.in | head -1 | cut -d '(' -f 2 
 
 export KBUILD_ONLYXEDIRS := src/drivers/gpu src/include src/scripts src/drivers/platform src/drivers/mtd
 export KBUILD_XEVFIOPCIDIRS := src/drivers/vfio/pci/xe
-export KBUILD_AUTOTOOLS := m4 AUTHORS  ChangeLog  configure.ac  COPYING  INSTALL Makefile  Makefile.am  NEWS  README compile.sh
+export KBUILD_AUTOTOOLS := m4 AUTHORS  ChangeLog  configure.ac  COPYING  INSTALL Makefile  Makefile.am  NEWS  README.md compile.sh
 XE_TAR_CONTENT=$(KBUILD_ONLYXEDIRS) $(KBUILD_AUTOTOOLS) $(KBUILD_XEVFIOPCIDIRS) src/Makefile* src/local-symbols src/MAINTAINERS src/local-symbols-autoconf \
 	src/Kconfig src/Kconfig.sources src/Kconfig.package.hacks src/COPYING src/versions src/defconfigs src/backport-include src/kconf src/compat
 

--- a/autotools/m4/drv_date.m4
+++ b/autotools/m4/drv_date.m4
@@ -7,14 +7,8 @@ AC_DEFUN([AC_DRV_DATE_NOT_PRESENT], [
 		AC_KERNEL_TRY_COMPILE([
 			#include <drm/drm_drv.h>
 		],[
-			struct drm_driver driver = {
-				.name = "test",
-				.desc = "test",
-				.date = "20201103",
-				.major = 1,
-				.minor = 1,
-				.patchlevel = 0,
-			};
+			struct drm_driver driver;
+			driver.date = "20201103";
 		],[
 		],[
 			AC_DEFINE(BPM_DRV_DATE_NOT_PRESENT, 1,


### PR DESCRIPTION
The struct initialization used to detect struct drm_driver::date
triggers cascading compiler errors on 6.6 that AC_KERNEL_DO_BACKGROUND
does not capture reliably, leaving BPM_DRV_DATE_NOT_PRESENT unset and
causing a "(null)" date string at module load time.

Replace with a direct member assignment, consistent with other m4 files.

Verified on RHEL 10.1, 6.6, and 6.12: no compilation errors and no
"(null)" in the [drm] Initialized xe message.

Fixes: fbc93c6e1 ("autotools/m4: fix struct drm_driver date member logic")

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>