### PR TITLE
xe_drm_prelim: Allign prelim header as per drm-tip-eudebug

### DIFF
--- a/backport/patches/features/eu-debug/0001-xe_drm_prelim-Add-prelim-for-missing-structures.patch
+++ b/backport/patches/features/eu-debug/0001-xe_drm_prelim-Add-prelim-for-missing-structures.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pravalika Gurram <pravalika.gurram@intel.com>
+Date: Fri, 10 Apr 2026 19:23:58 +0530
+Subject: xe_drm_prelim: Add prelim for missing structures
+
+Add missing prelim to structures in
+xe_drm_prelim.h that were not previously marked as prelim.
+
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ include/uapi/drm/xe_drm_prelim.h | 33 ++++++++++++++++----------------
+ 1 file changed, 17 insertions(+), 16 deletions(-)
+
+diff --git a/include/uapi/drm/xe_drm_prelim.h b/include/uapi/drm/xe_drm_prelim.h
+index d48139cc6..76a452b3b 100644
+--- a/include/uapi/drm/xe_drm_prelim.h
++++ b/include/uapi/drm/xe_drm_prelim.h
+@@ -141,7 +141,7 @@ struct prelim_drm_xe_eudebug_connect {
+ };
+ 
+ /*
+- * struct drm_xe_debug_metadata_create - Create debug metadata
++ * struct prelim_drm_xe_debug_metadata_create - Create debug metadata
+  *
+  * Add a region of user memory to be marked as debug metadata.
+  * When the debugger attaches, the metadata regions will be delivered
+@@ -176,7 +176,7 @@ struct prelim_drm_xe_debug_metadata_create {
+ };
+ 
+ /**
+- * struct drm_xe_debug_metadata_destroy - Destroy debug metadata
++ * struct prelim_drm_xe_debug_metadata_destroy - Destroy debug metadata
+  *
+  * Destroy debug metadata.
+  */
+@@ -204,21 +204,22 @@ struct prelim_drm_xe_eudebug_event {
+ 	__u32 len;
+ 
+ 	__u16 type;
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_NONE		0
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_READ		1
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_OPEN		2
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM			3
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE		4
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_EU_ATTENTION	5
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND		6
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP		7
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE	8
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_METADATA		9
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA	10
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_PAGEFAULT		11
+-#define PRELIM_DRM_XE_EUDEBUG_EVENT_SYNC_HOST 		12
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_NONE			0
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_READ			1
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_OPEN			2
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM				3
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE			4
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_EU_ATTENTION		5
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND			6
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP			7
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE		8
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_METADATA			9
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA		10
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_PAGEFAULT			11
++#define PRELIM_DRM_XE_EUDEBUG_EVENT_SYNC_HOST 			12
+ #define PRELIM_DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE_PLACEMENTS	13
+ 
++
+ 	__u16 flags;
+ #define PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
+ #define PRELIM_DRM_XE_EUDEBUG_EVENT_DESTROY		(1 << 1)
+@@ -334,7 +335,7 @@ struct prelim_drm_xe_eudebug_eu_control {
+  * Client's UFENCE sync will be held by the driver: client's
+  * drm_xe_wait_ufence will not complete and the value of the ufence
+  * won't appear until ufence is acked by the debugger process calling
+- * DRM_XE_EUDEBUG_IOCTL_ACK_EVENT with the event_ufence.base.seqno.
++ * PRELIM_DRM_XE_EUDEBUG_IOCTL_ACK_EVENT with the event_ufence.base.seqno.
+  * This will signal the fence, .value will update and the wait will
+  * complete allowing the client to continue.
+  *
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -389,3 +389,4 @@ backport/patches/features/eu-debug/0001-fixup-drm-xe-Add-PRELIM-infrastructure.p
 backport/patches/features/eu-debug/0001-uapi-drm-xe-Update-prelim-definitions-for-EU-Debugge.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Update-prelim-vm-bind-attach-debug.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Eudebug-prelim-fix-for-exec-queue-pro.patch
+backport/patches/features/eu-debug/0001-xe_drm_prelim-Add-prelim-for-missing-structures.patch


### PR DESCRIPTION
Add missing prelim to structures in
xe_drm_prelim.h that were not previously marked as prelim.

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>