### PR TITLE
drm/xe: Restrict wedged_mode configuration and validate supported modes

### DIFF
--- a/backport/patches/features/sriov/0001-drm-xe-Validate-wedged_mode-parameter-and-define-enu.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-Validate-wedged_mode-parameter-and-define-enu.patch
@@ -1,0 +1,298 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lukasz Laguna <lukasz.laguna@intel.com>
+Date: Wed, 7 Jan 2026 18:47:38 +0100
+Subject: drm/xe: Validate wedged_mode parameter and define enum for
+ modes
+
+Check correctness of the wedged_mode parameter input to ensure only
+supported values are accepted. Additionally, replace magic numbers with
+a clearly defined enum.
+
+Signed-off-by: Lukasz Laguna <lukasz.laguna@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Link: https://patch.msgid.link/20260107174741.29163-2-lukasz.laguna@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit 17d3c3365ba9e52596855d6acb71c3159be1b9c3 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_debugfs.c      |  5 +--
+ drivers/gpu/drm/xe/xe_device.c       | 54 ++++++++++++++++++++++++----
+ drivers/gpu/drm/xe/xe_device.h       |  2 ++
+ drivers/gpu/drm/xe/xe_device_types.h | 21 ++++++++++-
+ drivers/gpu/drm/xe/xe_guc_ads.c      |  4 +--
+ drivers/gpu/drm/xe/xe_guc_capture.c  |  9 ++++-
+ drivers/gpu/drm/xe/xe_guc_submit.c   |  7 ++--
+ drivers/gpu/drm/xe/xe_module.c       | 10 +++---
+ drivers/gpu/drm/xe/xe_module.h       |  2 +-
+ 9 files changed, 94 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_debugfs.c b/drivers/gpu/drm/xe/xe_debugfs.c
+index f18b7792a77e9..cdc6ced39e88c 100644
+--- a/drivers/gpu/drm/xe/xe_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_debugfs.c
+@@ -265,8 +265,9 @@ static ssize_t wedged_mode_set(struct file *f, const char __user *ubuf,
+ 	if (ret)
+ 		return ret;
+ 
+-	if (wedged_mode > 2)
+-		return -EINVAL;
++	ret = xe_device_validate_wedged_mode(xe, wedged_mode);
++	if (ret)
++		return ret;
+ 
+ 	if (xe->wedged.mode == wedged_mode)
+ 		return size;
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index 51a6034600a79..f5b1bfa553a1e 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -749,7 +749,10 @@ int xe_device_probe_early(struct xe_device *xe)
+ 	if (err)
+ 		return err;
+ 
+-	xe->wedged.mode = xe_modparam.wedged_mode;
++	xe->wedged.mode = xe_device_validate_wedged_mode(xe, xe_modparam.wedged_mode) ?
++			  XE_WEDGED_MODE_DEFAULT : xe_modparam.wedged_mode;
++	drm_dbg(&xe->drm, "wedged_mode: setting mode (%u) %s\n",
++		xe->wedged.mode, xe_wedged_mode_to_string(xe->wedged.mode));
+ 
+ 	err = xe_device_vram_alloc(xe);
+ 	if (err)
+@@ -1157,10 +1160,10 @@ static void xe_device_wedged_fini(struct drm_device *drm, void *arg)
+  * DOC: Xe Device Wedging
+  *
+  * Xe driver uses drm device wedged uevent as documented in Documentation/gpu/drm-uapi.rst.
+- * When device is in wedged state, every IOCTL will be blocked and GT cannot be
+- * used. Certain critical errors like gt reset failure, firmware failures can cause
+- * the device to be wedged. The default recovery method for a wedged state
+- * is rebind/bus-reset.
++ * When device is in wedged state, every IOCTL will be blocked and GT cannot
++ * be used. The conditions under which the driver declares the device wedged
++ * depend on the wedged mode configuration (see &enum xe_wedged_mode). The
++ * default recovery method for a wedged state is rebind/bus-reset.
+  *
+  * Another recovery method is vendor-specific. Below are the cases that send
+  * ``WEDGED=vendor-specific`` recovery method in drm device wedged uevent.
+@@ -1225,7 +1228,7 @@ void xe_device_declare_wedged(struct xe_device *xe)
+ 	struct xe_gt *gt;
+ 	u8 id;
+ 
+-	if (xe->wedged.mode == 0) {
++	if (xe->wedged.mode == XE_WEDGED_MODE_NEVER) {
+ 		drm_dbg(&xe->drm, "Wedged mode is forcibly disabled\n");
+ 		return;
+ 	}
+@@ -1259,3 +1262,42 @@ void xe_device_declare_wedged(struct xe_device *xe)
+ 		drm_dev_wedged_event(&xe->drm, xe->wedged.method, NULL);
+ 	}
+ }
++
++/**
++ * xe_device_validate_wedged_mode - Check if given mode is supported
++ * @xe: the &xe_device
++ * @mode: requested mode to validate
++ *
++ * Check whether the provided wedged mode is supported.
++ *
++ * Return: 0 if mode is supported, error code otherwise.
++ */
++int xe_device_validate_wedged_mode(struct xe_device *xe, unsigned int mode)
++{
++	if (mode > XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET) {
++		drm_dbg(&xe->drm, "wedged_mode: invalid value (%u)\n", mode);
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++/**
++ * xe_wedged_mode_to_string - Convert enum value to string.
++ * @mode: the &xe_wedged_mode to convert
++ *
++ * Returns: wedged mode as a user friendly string.
++ */
++const char *xe_wedged_mode_to_string(enum xe_wedged_mode mode)
++{
++	switch (mode) {
++	case XE_WEDGED_MODE_NEVER:
++		return "never";
++	case XE_WEDGED_MODE_UPON_CRITICAL_ERROR:
++		return "upon-critical-error";
++	case XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET:
++		return "upon-any-hang-no-reset";
++	default:
++		return "<invalid>";
++	}
++}
+diff --git a/drivers/gpu/drm/xe/xe_device.h b/drivers/gpu/drm/xe/xe_device.h
+index 32cc6323b7f64..2fffa88f91b03 100644
+--- a/drivers/gpu/drm/xe/xe_device.h
++++ b/drivers/gpu/drm/xe/xe_device.h
+@@ -189,6 +189,8 @@ static inline bool xe_device_wedged(struct xe_device *xe)
+ 
+ void xe_device_set_wedged_method(struct xe_device *xe, unsigned long method);
+ void xe_device_declare_wedged(struct xe_device *xe);
++int xe_device_validate_wedged_mode(struct xe_device *xe, unsigned int mode);
++const char *xe_wedged_mode_to_string(enum xe_wedged_mode mode);
+ 
+ struct xe_file *xe_file_get(struct xe_file *xef);
+ void xe_file_put(struct xe_file *xef);
+diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
+index e7923b631529c..6c454680e025c 100644
+--- a/drivers/gpu/drm/xe/xe_device_types.h
++++ b/drivers/gpu/drm/xe/xe_device_types.h
+@@ -39,6 +39,25 @@ struct xe_pat_ops;
+ struct xe_pxp;
+ struct xe_vram_region;
+ 
++/**
++ * enum xe_wedged_mode - possible wedged modes
++ * @XE_WEDGED_MODE_NEVER: Device will never be declared wedged.
++ * @XE_WEDGED_MODE_UPON_CRITICAL_ERROR: Device will be declared wedged only
++ *	when critical error occurs like GT reset failure or firmware failure.
++ *	This is the default mode.
++ * @XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET: Device will be declared wedged on
++ *	any hang. In this mode, engine resets are disabled to avoid automatic
++ *	recovery attempts. This mode is primarily intended for debugging hangs.
++ */
++enum xe_wedged_mode {
++	XE_WEDGED_MODE_NEVER = 0,
++	XE_WEDGED_MODE_UPON_CRITICAL_ERROR = 1,
++	XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET = 2,
++};
++
++#define XE_WEDGED_MODE_DEFAULT		XE_WEDGED_MODE_UPON_CRITICAL_ERROR
++#define XE_WEDGED_MODE_DEFAULT_STR	"upon-critical-error"
++
+ #define XE_BO_INVALID_OFFSET	LONG_MAX
+ 
+ #define GRAPHICS_VER(xe) ((xe)->info.graphics_verx100 / 100)
+@@ -542,7 +561,7 @@ struct xe_device {
+ 		/** @wedged.flag: Xe device faced a critical error and is now blocked. */
+ 		atomic_t flag;
+ 		/** @wedged.mode: Mode controlled by kernel parameter and debugfs */
+-		int mode;
++		enum xe_wedged_mode mode;
+ 		/** @wedged.method: Recovery method to be sent in the drm device wedged uevent */
+ 		unsigned long method;
+ 	} wedged;
+diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
+index 8ff8626227ae4..0a18b978998ba 100644
+--- a/drivers/gpu/drm/xe/xe_guc_ads.c
++++ b/drivers/gpu/drm/xe/xe_guc_ads.c
+@@ -505,7 +505,7 @@ static void guc_policies_init(struct xe_guc_ads *ads)
+ 	ads_blob_write(ads, policies.max_num_work_items,
+ 		       GLOBAL_POLICY_MAX_NUM_WI);
+ 
+-	if (xe->wedged.mode == 2)
++	if (xe->wedged.mode == XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET)
+ 		global_flags |= GLOBAL_POLICY_DISABLE_ENGINE_RESET;
+ 
+ 	ads_blob_write(ads, policies.global_flags, global_flags);
+@@ -1054,7 +1054,7 @@ int xe_guc_ads_scheduler_policy_toggle_reset(struct xe_guc_ads *ads)
+ 	policies->dpc_promote_time = ads_blob_read(ads, policies.dpc_promote_time);
+ 	policies->max_num_work_items = ads_blob_read(ads, policies.max_num_work_items);
+ 	policies->is_valid = 1;
+-	if (xe->wedged.mode == 2)
++	if (xe->wedged.mode == XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET)
+ 		policies->global_flags |= GLOBAL_POLICY_DISABLE_ENGINE_RESET;
+ 	else
+ 		policies->global_flags &= ~GLOBAL_POLICY_DISABLE_ENGINE_RESET;
+diff --git a/drivers/gpu/drm/xe/xe_guc_capture.c b/drivers/gpu/drm/xe/xe_guc_capture.c
+index 243dad3e24185..313a8bd65de2f 100644
+--- a/drivers/gpu/drm/xe/xe_guc_capture.c
++++ b/drivers/gpu/drm/xe/xe_guc_capture.c
+@@ -1862,7 +1862,14 @@ xe_guc_capture_get_matching_and_lock(struct xe_exec_queue *q)
+ 		return NULL;
+ 
+ 	xe = gt_to_xe(q->gt);
+-	if (xe->wedged.mode >= 2 || !xe_device_uc_enabled(xe) || IS_SRIOV_VF(xe))
++
++	if (xe->wedged.mode == XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET)
++		return NULL;
++
++	if (!xe_device_uc_enabled(xe))
++		return NULL;
++
++	if (IS_SRIOV_VF(xe))
+ 		return NULL;
+ 
+ 	ss = &xe->devcoredump.snapshot;
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index 439725fc4fe61..c85deb720e176 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -941,8 +941,9 @@ void xe_guc_submit_wedge(struct xe_guc *guc)
+ 	err = devm_add_action_or_reset(guc_to_xe(guc)->drm.dev,
+ 				       guc_submit_wedged_fini, guc);
+ 	if (err) {
+-		xe_gt_err(gt, "Failed to register clean-up on wedged.mode=2; "
+-			  "Although device is wedged.\n");
++		xe_gt_err(gt, "Failed to register clean-up in wedged.mode=%s; "
++			  "Although device is wedged.\n",
++			  xe_wedged_mode_to_string(XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET));
+ 		return;
+ 	}
+ 
+@@ -957,7 +958,7 @@ static bool guc_submit_hint_wedged(struct xe_guc *guc)
+ {
+ 	struct xe_device *xe = guc_to_xe(guc);
+ 
+-	if (xe->wedged.mode != 2)
++	if (xe->wedged.mode != XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET)
+ 		return false;
+ 
+ 	if (xe_device_wedged(xe))
+diff --git a/drivers/gpu/drm/xe/xe_module.c b/drivers/gpu/drm/xe/xe_module.c
+index d9391bd081941..8856688fa670c 100644
+--- a/drivers/gpu/drm/xe/xe_module.c
++++ b/drivers/gpu/drm/xe/xe_module.c
+@@ -10,6 +10,7 @@
+ 
+ #include <drm/drm_module.h>
+ 
++#include "xe_device.h"
+ #include "xe_drv.h"
+ #include "xe_configfs.h"
+ #include "xe_hw_fence.h"
+@@ -29,7 +30,8 @@
+ #define DEFAULT_FORCE_PROBE		CONFIG_DRM_XE_FORCE_PROBE
+ #define DEFAULT_MAX_VFS			~0
+ #define DEFAULT_MAX_VFS_STR		"unlimited"
+-#define DEFAULT_WEDGED_MODE		1
++#define DEFAULT_WEDGED_MODE		XE_WEDGED_MODE_DEFAULT
++#define DEFAULT_WEDGED_MODE_STR		XE_WEDGED_MODE_DEFAULT_STR
+ #define DEFAULT_SVM_NOTIFIER_SIZE	512
+ 
+ struct xe_modparam xe_modparam = {
+@@ -88,10 +90,10 @@ MODULE_PARM_DESC(max_vfs,
+ 		 "[default=" DEFAULT_MAX_VFS_STR "])");
+ #endif
+ 
+-module_param_named_unsafe(wedged_mode, xe_modparam.wedged_mode, int, 0600);
++module_param_named_unsafe(wedged_mode, xe_modparam.wedged_mode, uint, 0600);
+ MODULE_PARM_DESC(wedged_mode,
+-		 "Module's default policy for the wedged mode (0=never, 1=upon-critical-errors, 2=upon-any-hang "
+-		 "[default=" __stringify(DEFAULT_WEDGED_MODE) "])");
++		 "Module's default policy for the wedged mode (0=never, 1=upon-critical-error, 2=upon-any-hang-no-reset "
++		 "[default=" DEFAULT_WEDGED_MODE_STR "])");
+ 
+ static int xe_check_nomodeset(void)
+ {
+diff --git a/drivers/gpu/drm/xe/xe_module.h b/drivers/gpu/drm/xe/xe_module.h
+index 5a3bfea8b7b4c..1c75f38ca3933 100644
+--- a/drivers/gpu/drm/xe/xe_module.h
++++ b/drivers/gpu/drm/xe/xe_module.h
+@@ -21,7 +21,7 @@ struct xe_modparam {
+ #ifdef CONFIG_PCI_IOV
+ 	unsigned int max_vfs;
+ #endif
+-	int wedged_mode;
++	unsigned int wedged_mode;
+ 	u32 svm_notifier_size;
+ };
+ 
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-pf-Allow-upon-any-hang-wedged-mode-only-in-de.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-pf-Allow-upon-any-hang-wedged-mode-only-in-de.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lukasz Laguna <lukasz.laguna@intel.com>
+Date: Wed, 7 Jan 2026 18:47:41 +0100
+Subject: drm/xe/pf: Allow upon-any-hang wedged mode only in debug
+ config
+
+The GuC reset policy is global, so disabling it on PF can affect all
+running VFs. To avoid unintended side effects, restrict setting
+upon-any-hang (2) wedged mode on the PF to debug builds only.
+
+Signed-off-by: Lukasz Laguna <lukasz.laguna@intel.com>
+Reviewed-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://patch.msgid.link/20260107174741.29163-5-lukasz.laguna@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit 96d45e34f8f9a459ae1a8d7a74638a96375d8597 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index e13bfb22251f9..57c9a422b8d1a 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -1277,7 +1277,8 @@ int xe_device_validate_wedged_mode(struct xe_device *xe, unsigned int mode)
+ 	if (mode > XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET) {
+ 		drm_dbg(&xe->drm, "wedged_mode: invalid value (%u)\n", mode);
+ 		return -EINVAL;
+-	} else if (mode == XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET && IS_SRIOV_VF(xe)) {
++	} else if (mode == XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET && (IS_SRIOV_VF(xe) ||
++		   (IS_SRIOV_PF(xe) && !IS_ENABLED(CONFIG_DRM_XE_DEBUG)))) {
+ 		drm_dbg(&xe->drm, "wedged_mode: (%u) %s mode is not supported for %s\n",
+ 			mode, xe_wedged_mode_to_string(mode),
+ 			xe_sriov_mode_to_string(xe_device_sriov_mode(xe)));
+-- 
+2.43.0
+

--- a/backport/patches/features/sriov/0001-drm-xe-vf-Disallow-setting-wedged-mode-to-upon-any-h.patch
+++ b/backport/patches/features/sriov/0001-drm-xe-vf-Disallow-setting-wedged-mode-to-upon-any-h.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lukasz Laguna <lukasz.laguna@intel.com>
+Date: Wed, 7 Jan 2026 18:47:40 +0100
+Subject: drm/xe/vf: Disallow setting wedged mode to upon-any-hang
+
+In upon-any-hang (2) wedged mode, engine resets need to be disabled,
+which requires changing the GuC reset policy. VFs are not permitted to
+do that.
+
+Signed-off-by: Lukasz Laguna <lukasz.laguna@intel.com>
+Reviewed-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Link: https://patch.msgid.link/20260107174741.29163-4-lukasz.laguna@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit 43d78aca8ed01a643f198b831231a6231f52d9d5 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index f5b1bfa553a1e..e13bfb22251f9 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -1277,6 +1277,11 @@ int xe_device_validate_wedged_mode(struct xe_device *xe, unsigned int mode)
+ 	if (mode > XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET) {
+ 		drm_dbg(&xe->drm, "wedged_mode: invalid value (%u)\n", mode);
+ 		return -EINVAL;
++	} else if (mode == XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET && IS_SRIOV_VF(xe)) {
++		drm_dbg(&xe->drm, "wedged_mode: (%u) %s mode is not supported for %s\n",
++			mode, xe_wedged_mode_to_string(mode),
++			xe_sriov_mode_to_string(xe_device_sriov_mode(xe)));
++		return -EPERM;
+ 	}
+ 
+ 	return 0;
+-- 
+2.43.0
+

--- a/backport/patches/fixes/base/0001-drm-xe-Drop-registration-of-guc_submit_wedged_fini-f.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-Drop-registration-of-guc_submit_wedged_fini-f.patch
@@ -20,11 +20,11 @@ Link: https://patch.msgid.link/20260326210116.202585-3-matthew.brost@intel.com
 (backported from commit 4a706bd93c4fb156a13477e26ffdf2e633edeb10 linux-next)
 Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
 ---
- drivers/gpu/drm/xe/xe_guc_submit.c | 33 ++++++++----------------------
- 1 file changed, 9 insertions(+), 24 deletions(-)
+ drivers/gpu/drm/xe/xe_guc_submit.c | 32 +++++++++---------------------
+ 1 file changed, 9 insertions(+), 23 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
-index fb916ddcb927c..0c0cadcfe1f97 100644
+index 72b324bfa6437..78f05fbe2237a 100644
 --- a/drivers/gpu/drm/xe/xe_guc_submit.c
 +++ b/drivers/gpu/drm/xe/xe_guc_submit.c
 @@ -291,24 +291,12 @@ static void guc_submit_sw_fini(struct drm_device *drm, void *arg)
@@ -79,16 +79,15 @@ index fb916ddcb927c..0c0cadcfe1f97 100644
  
  	xe_gt_assert(guc_to_gt(guc), guc_to_xe(guc)->wedged.mode);
  
-@@ -1036,15 +1030,6 @@ void xe_guc_submit_wedge(struct xe_guc *guc)
+@@ -1036,14 +1030,6 @@ void xe_guc_submit_wedge(struct xe_guc *guc)
  		return;
  
  	if (xe->wedged.mode == 2) {
 -		err = devm_add_action_or_reset(guc_to_xe(guc)->drm.dev,
--				guc_submit_wedged_fini, guc);
--
+-					       guc_submit_wedged_fini, guc);
 -		if (err) {
 -			xe_gt_err(gt, "Failed to register clean-up on wedged.mode=2; "
--					"Although device is wedged.\n");
+-				  "Although device is wedged.\n");
 -			return;
 -		}
 -

--- a/backport/patches/fixes/base/0001-drm-xe-Trigger-queue-cleanup-if-not-in-wedged-mode-2.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-Trigger-queue-cleanup-if-not-in-wedged-mode-2.patch
@@ -13,14 +13,14 @@ Cc: stable@vger.kernel.org
 Reviewed-by: Zhanjun Dong <zhanjun.dong@intel.com>
 Signed-off-by: Matthew Brost <matthew.brost@intel.com>
 Link: https://patch.msgid.link/20260310225039.1320161-4-zhanjun.dong@intel.com
-(backported from commit e25ba41c8227c5393c16e4aab398076014bd345f linux-next)
+(cherry-picked from commit e25ba41c8227c5393c16e4aab398076014bd345f linux-next)
 Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
 ---
- drivers/gpu/drm/xe/xe_guc_submit.c | 35 ++++++++++++++++++++----------
- 1 file changed, 23 insertions(+), 12 deletions(-)
+ drivers/gpu/drm/xe/xe_guc_submit.c | 35 +++++++++++++++++++-----------
+ 1 file changed, 22 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
-index 3c5258b89..fb916ddcb 100644
+index 229cc7554a0e3..72b324bfa6437 100644
 --- a/drivers/gpu/drm/xe/xe_guc_submit.c
 +++ b/drivers/gpu/drm/xe/xe_guc_submit.c
 @@ -1020,6 +1020,7 @@ static void xe_guc_exec_queue_trigger_cleanup(struct xe_exec_queue *q)
@@ -31,32 +31,32 @@ index 3c5258b89..fb916ddcb 100644
  	struct xe_gt *gt = guc_to_gt(guc);
  	struct xe_exec_queue *q;
  	unsigned long index;
-@@ -1034,19 +1035,29 @@ void xe_guc_submit_wedge(struct xe_guc *guc)
+@@ -1034,20 +1035,28 @@ void xe_guc_submit_wedge(struct xe_guc *guc)
  	if (!guc->submission_state.initialized)
  		return;
  
 -	err = devm_add_action_or_reset(guc_to_xe(guc)->drm.dev,
 -				       guc_submit_wedged_fini, guc);
 -	if (err) {
--		xe_gt_err(gt, "Failed to register clean-up on wedged.mode=2; "
--			  "Although device is wedged.\n");
+-		xe_gt_err(gt, "Failed to register clean-up in wedged.mode=%s; "
+-			  "Although device is wedged.\n",
+-			  xe_wedged_mode_to_string(XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET));
 -		return;
 -	}
 +	if (xe->wedged.mode == 2) {
 +		err = devm_add_action_or_reset(guc_to_xe(guc)->drm.dev,
-+				guc_submit_wedged_fini, guc);
++					       guc_submit_wedged_fini, guc);
++		if (err) {
++			xe_gt_err(gt, "Failed to register clean-up on wedged.mode=2; "
++				  "Although device is wedged.\n");
++			return;
++		}
  
 -	mutex_lock(&guc->submission_state.lock);
 -	xa_for_each(&guc->submission_state.exec_queue_lookup, index, q)
 -		if (xe_exec_queue_get_unless_zero(q))
 -			set_exec_queue_wedged(q);
 -	mutex_unlock(&guc->submission_state.lock);
-+		if (err) {
-+			xe_gt_err(gt, "Failed to register clean-up on wedged.mode=2; "
-+					"Although device is wedged.\n");
-+			return;
-+		}
-+
 +		mutex_lock(&guc->submission_state.lock);
 +		xa_for_each(&guc->submission_state.exec_queue_lookup, index, q)
 +			if (xe_exec_queue_get_unless_zero(q))

--- a/backport/patches/fixes/base/0001-drm-xe-Update-wedged.mode-only-after-successful-rese.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-Update-wedged.mode-only-after-successful-rese.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Lukasz Laguna <lukasz.laguna@intel.com>
-Date: Wed, 21 Jan 2026 15:33:04 +0100
-Subject: drm/xe: Update wedged.mode only after successful reset policy
+Date: Wed, 7 Jan 2026 18:47:39 +0100
+Subject: [PATCH] drm/xe: Update wedged.mode only after successful reset policy
  change
 
 Previously, the driver's internal wedged.mode state was updated without
@@ -36,16 +36,16 @@ Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
 Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
 ---
  drivers/gpu/drm/xe/xe_debugfs.c      | 74 ++++++++++++++++++++++------
- drivers/gpu/drm/xe/xe_device_types.h | 18 +++++++
+ drivers/gpu/drm/xe/xe_device_types.h |  2 +
  drivers/gpu/drm/xe/xe_guc_ads.c      | 14 +++---
  drivers/gpu/drm/xe/xe_guc_ads.h      |  5 +-
- 4 files changed, 89 insertions(+), 22 deletions(-)
+ 4 files changed, 73 insertions(+), 22 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_debugfs.c b/drivers/gpu/drm/xe/xe_debugfs.c
-index f18b7792a77e..31b0e766c4f0 100644
+index 4fe0d7b91e0de..8f969d40b1b39 100644
 --- a/drivers/gpu/drm/xe/xe_debugfs.c
 +++ b/drivers/gpu/drm/xe/xe_debugfs.c
-@@ -252,14 +252,66 @@ static ssize_t wedged_mode_show(struct file *f, char __user *ubuf,
+@@ -254,14 +254,66 @@ static ssize_t wedged_mode_show(struct file *f, char __user *ubuf,
  	return simple_read_from_buffer(ubuf, size, pos, buf, len);
  }
  
@@ -114,9 +114,9 @@ index f18b7792a77e..31b0e766c4f0 100644
  
  	ret = kstrtouint_from_user(ubuf, size, 0, &wedged_mode);
  	if (ret)
-@@ -268,22 +320,14 @@ static ssize_t wedged_mode_set(struct file *f, const char __user *ubuf,
- 	if (wedged_mode > 2)
- 		return -EINVAL;
+@@ -271,22 +323,14 @@ static ssize_t wedged_mode_set(struct file *f, const char __user *ubuf,
+ 	if (ret)
+ 		return ret;
  
 -	if (xe->wedged.mode == wedged_mode)
 -		return size;
@@ -143,34 +143,11 @@ index f18b7792a77e..31b0e766c4f0 100644
  }
  
 diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
-index e7923b631529..37d12960fb98 100644
+index d470f15ef58e7..7910381136aef 100644
 --- a/drivers/gpu/drm/xe/xe_device_types.h
 +++ b/drivers/gpu/drm/xe/xe_device_types.h
-@@ -39,6 +39,22 @@ struct xe_pat_ops;
- struct xe_pxp;
- struct xe_vram_region;
- 
-+/**
-+ * enum xe_wedged_mode - possible wedged modes
-+ * @XE_WEDGED_MODE_NEVER: Device will never be declared wedged.
-+ * @XE_WEDGED_MODE_UPON_CRITICAL_ERROR: Device will be declared wedged only
-+ *	when critical error occurs like GT reset failure or firmware failure.
-+ *	This is the default mode.
-+ * @XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET: Device will be declared wedged on
-+ *	any hang. In this mode, engine resets are disabled to avoid automatic
-+ *	recovery attempts. This mode is primarily intended for debugging hangs.
-+ */
-+enum xe_wedged_mode {
-+	XE_WEDGED_MODE_NEVER = 0,
-+	XE_WEDGED_MODE_UPON_CRITICAL_ERROR = 1,
-+	XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET = 2,
-+};
-+
- #define XE_BO_INVALID_OFFSET	LONG_MAX
- 
- #define GRAPHICS_VER(xe) ((xe)->info.graphics_verx100 / 100)
-@@ -545,6 +561,8 @@ struct xe_device {
- 		int mode;
+@@ -588,6 +588,8 @@ struct xe_device {
+ 		enum xe_wedged_mode mode;
  		/** @wedged.method: Recovery method to be sent in the drm device wedged uevent */
  		unsigned long method;
 +		/** @wedged.inconsistent_reset: Inconsistent reset policy state between GTs */
@@ -179,7 +156,7 @@ index e7923b631529..37d12960fb98 100644
  
  	/** @bo_device: Struct to control async free of BOs */
 diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
-index 8ff8626227ae..8688a74f2759 100644
+index 0a18b978998ba..d206e3482bf7e 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ads.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ads.c
 @@ -1033,16 +1033,17 @@ static int guc_ads_action_update_policies(struct xe_guc_ads *ads, u32 policy_off
@@ -207,7 +184,7 @@ index 8ff8626227ae..8688a74f2759 100644
  	policies->dpc_promote_time = ads_blob_read(ads, policies.dpc_promote_time);
  	policies->max_num_work_items = ads_blob_read(ads, policies.max_num_work_items);
  	policies->is_valid = 1;
--	if (xe->wedged.mode == 2)
+-	if (xe->wedged.mode == XE_WEDGED_MODE_UPON_ANY_HANG_NO_RESET)
 -		policies->global_flags |= GLOBAL_POLICY_DISABLE_ENGINE_RESET;
 -	else
 +
@@ -219,7 +196,7 @@ index 8ff8626227ae..8688a74f2759 100644
  	return guc_ads_action_update_policies(ads, xe_guc_buf_flush(buf));
  }
 diff --git a/drivers/gpu/drm/xe/xe_guc_ads.h b/drivers/gpu/drm/xe/xe_guc_ads.h
-index 2e6674c760ff..7a39f361cb17 100644
+index 2e6674c760ff9..7a39f361cb17d 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ads.h
 +++ b/drivers/gpu/drm/xe/xe_guc_ads.h
 @@ -6,6 +6,8 @@

--- a/series
+++ b/series
@@ -266,6 +266,9 @@ backport/patches/features/sriov/0001-drm-xe-vf-Allow-VF-to-initialize-MCR-tables
 backport/patches/features/sriov/0001-drm-xe-Wrappers-for-setting-and-getting-LRC-referenc.patch
 backport/patches/features/sriov/0001-drm-xe-vf-Wait-for-all-fixups-before-using-default-L.patch
 backport/patches/features/sriov/0001-drm-xe-vf-Redo-LRC-creation-while-in-VF-fixups.patch
+backport/patches/features/sriov/0001-drm-xe-Validate-wedged_mode-parameter-and-define-enu.patch
+backport/patches/features/sriov/0001-drm-xe-vf-Disallow-setting-wedged-mode-to-upon-any-h.patch
+backport/patches/features/sriov/0001-drm-xe-pf-Allow-upon-any-hang-wedged-mode-only-in-de.patch
 # features/vf-double-migration
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Enable-VF-migration-only-on-supported-GuC-.patch
 backport/patches/features/vf-double-migration/0001-drm-xe-vf-Introduce-RESFIX-start-marker-support.patch


### PR DESCRIPTION
Validate wedged_mode input to accept only supported values and replace
magic numbers with a defined enum for clarity.

Disallow setting upon-any-hang wedged mode on VFs, since it requires
disabling engine resets through GuC reset policy, which VFs are not
allowed to modify.

On PF, allow upon-any-hang wedged mode only in debug builds because the
GuC reset policy is global and changing it may impact all running VFs.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>