### PR TITLE
drm/xe: Fix Xe3p tuning and masked register handling

### DIFF
--- a/backport/patches/base/0001-drm-xe-Add-Wa_14026578760.patch
+++ b/backport/patches/base/0001-drm-xe-Add-Wa_14026578760.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Varun Gupta <varun.gupta@intel.com>
+Date: Mon, 9 Mar 2026 12:09:23 +0530
+Subject: drm/xe: Add Wa_14026578760
+
+Add GT workaround Wa_14026578760 for graphics versions 35.10, 35.11
+and media version 35.03.
+
+Signed-off-by: Varun Gupta <varun.gupta@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patch.msgid.link/20260309063923.4031933-1-varun.gupta@intel.com
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from commit efaf86be62d34b13b8e2293805d3c96299a92960 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h | 3 +++
+ drivers/gpu/drm/xe/xe_wa.c           | 5 +++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index ffe279bc993d8..fdbd0edd43419 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -101,6 +101,9 @@
+ #define VE1_AUX_INV				XE_REG(0x42b8)
+ #define   AUX_INV				REG_BIT(0)
+ 
++#define GAMSTLB_CTRL				XE_REG_MCR(0x477c)
++#define   DIS_PEND_GPA_LINK			REG_BIT(13)
++
+ #define GAMSTLB_CTRL2				XE_REG_MCR(0x4788)
+ #define   STLB_SINGLE_BANK_MODE			REG_BIT(11)
+ 
+diff --git a/drivers/gpu/drm/xe/xe_wa.c b/drivers/gpu/drm/xe/xe_wa.c
+index 4903162d2600d..9b155e47e9d32 100644
+--- a/drivers/gpu/drm/xe/xe_wa.c
++++ b/drivers/gpu/drm/xe/xe_wa.c
+@@ -308,6 +308,11 @@ static const struct xe_rtp_entry_sr gt_was[] = {
+ 	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(3000, 3005)),
+ 	  XE_RTP_ACTIONS(SET(GUC_INTR_CHICKEN, DISABLE_SIGNALING_ENGINES))
+ 	},
++	{ XE_RTP_NAME("14026578760"),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(3510, 3511), OR,
++		       MEDIA_VERSION(3503)),
++	  XE_RTP_ACTIONS(SET(GAMSTLB_CTRL, DIS_PEND_GPA_LINK))
++	},
+ 
+ 	/* Xe3P_LPG */
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-Mark-ROW_CHICKEN5-as-a-masked-register.patch
+++ b/backport/patches/base/0001-drm-xe-Mark-ROW_CHICKEN5-as-a-masked-register.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Roper <matthew.d.roper@intel.com>
+Date: Fri, 10 Apr 2026 15:50:30 -0700
+Subject: drm/xe: Mark ROW_CHICKEN5 as a masked register
+
+ROW_CHICKEN5 is a masked register (i.e., to adjust the value of any of
+the lower 16 bits, the corresponding bit in the upper 16 bits must also
+be set).  Add the XE_REG_OPTION_MASKED to its definition; failure to do
+so will cause workaround updates of this register to not apply properly.
+
+Bspec: 56853
+Fixes: 835cd6cbb0d0 ("drm/xe/xe3p_lpg: Add initial workarounds for graphics version 35.10")
+Reviewed-by: Gustavo Sousa <gustavo.sousa@intel.com>
+Link: https://patch.msgid.link/20260410-xe3p_tuning-v1-3-e206a62ee38f@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(cherry-picked from commit cd84bfbba7feb4c1e72356f14de026dfda1a9e2a drm-tip)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/regs/xe_gt_regs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/regs/xe_gt_regs.h b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+index f987dce5407df..29a981c523e6c 100644
+--- a/drivers/gpu/drm/xe/regs/xe_gt_regs.h
++++ b/drivers/gpu/drm/xe/regs/xe_gt_regs.h
+@@ -594,7 +594,7 @@
+ #define   DISABLE_128B_EVICTION_COMMAND_UDW	REG_BIT(36 - 32)
+ #define   LSCFE_SAME_ADDRESS_ATOMICS_COALESCING_DISABLE	REG_BIT(35 - 32)
+ 
+-#define ROW_CHICKEN5				XE_REG_MCR(0xe7f0)
++#define ROW_CHICKEN5				XE_REG_MCR(0xe7f0, XE_REG_OPTION_MASKED)
+ #define   CPSS_AWARE_DIS			REG_BIT(3)
+ 
+ #define SARB_CHICKEN1				XE_REG_MCR(0xe90c)
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-tuning-Stop-applying-CCCHKNREG1-tuning-from-X.patch
+++ b/backport/patches/base/0001-drm-xe-tuning-Stop-applying-CCCHKNREG1-tuning-from-X.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Roper <matthew.d.roper@intel.com>
+Date: Fri, 10 Apr 2026 15:50:28 -0700
+Subject: drm/xe/tuning: Stop applying CCCHKNREG1 tuning from Xe3p
+ onward
+
+Whereas the tuning guide gave guidance on adjusting various CCCHKNREG1
+on past platforms, starting from Xe3p the guidance is "Leave register at
+HW default settings."  Set a version range upper bound of "34.99" so
+that the current programming will stop being applied on any Xe3p
+platforms that have graphics version 35.
+
+Bspec: 72161
+Reviewed-by: Gustavo Sousa <gustavo.sousa@intel.com>
+Link: https://patch.msgid.link/20260410-xe3p_tuning-v1-1-e206a62ee38f@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(cherry-picked from commit 288b775a1cd4c569ec3ffba2f4d0b13b117e8be4 drm-tip)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_tuning.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_tuning.c b/drivers/gpu/drm/xe/xe_tuning.c
+index 614a1a99ff128..84c1d76c90516 100644
+--- a/drivers/gpu/drm/xe/xe_tuning.c
++++ b/drivers/gpu/drm/xe/xe_tuning.c
+@@ -42,7 +42,7 @@ static const struct xe_rtp_entry_sr gt_tunings[] = {
+ 				   REG_FIELD_PREP(L3_PWM_TIMER_INIT_VAL_MASK, 0x7f)))
+ 	},
+ 	{ XE_RTP_NAME("Tuning: Compression Overfetch"),
+-	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, XE_RTP_END_VERSION_UNDEFINED),
++	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(2001, 3499),
+ 		       FUNC(xe_rtp_match_has_flat_ccs)),
+ 	  XE_RTP_ACTIONS(CLR(CCCHKNREG1, ENCOMPPERFFIX),
+ 			 SET(CCCHKNREG1, L3CMPCTRL))
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-tuning-Use-proper-register-offset-for-GAMSTLB.patch
+++ b/backport/patches/base/0001-drm-xe-tuning-Use-proper-register-offset-for-GAMSTLB.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Roper <matthew.d.roper@intel.com>
+Date: Fri, 10 Apr 2026 15:50:29 -0700
+Subject: drm/xe/tuning: Use proper register offset for GAMSTLB_CTRL
+
+From Xe2 onward (i.e., all platforms officially supported by the Xe
+driver), the GAMSTLB_CTRL register is located at offset 0x477C and
+represented by the macro "GAMSTLB_CTRL" in code.  However the register
+formerly resided at offset 0xCF4C on Xe1-era platforms, and we also have
+macro XEHP_GAMSTLB_CTRL that represents this old offset in the
+unofficial/developer-only Xe1 code.  When tuning for the register was
+added for Xe3p_LPG, the old Xe1-era macro was accidentally used instead
+of the proper macro for Xe2 and beyond, causing the tuning to not be
+applied properly.  Use the proper definition so that the correct offset
+is written to.
+
+Bspec: 59298
+Fixes: 377c89bfaa5d ("drm/xe/xe3p_lpg: Set STLB bank hash mode to 4KB")
+Reviewed-by: Gustavo Sousa <gustavo.sousa@intel.com>
+Link: https://patch.msgid.link/20260410-xe3p_tuning-v1-2-e206a62ee38f@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(cherry-picked from commit 0b1676eafdd1ba5a5436bdca0d2a25ce56699783 drm-tip)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_tuning.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_tuning.c b/drivers/gpu/drm/xe/xe_tuning.c
+index 84c1d76c90516..20a761d675bb8 100644
+--- a/drivers/gpu/drm/xe/xe_tuning.c
++++ b/drivers/gpu/drm/xe/xe_tuning.c
+@@ -96,7 +96,7 @@ static const struct xe_rtp_entry_sr gt_tunings[] = {
+ 	{ XE_RTP_NAME("Tuning: Set STLB Bank Hash Mode to 4KB"),
+ 	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(3510, XE_RTP_END_VERSION_UNDEFINED),
+ 		       IS_INTEGRATED),
+-	  XE_RTP_ACTIONS(FIELD_SET(XEHP_GAMSTLB_CTRL, BANK_HASH_MODE,
++	  XE_RTP_ACTIONS(FIELD_SET(GAMSTLB_CTRL, BANK_HASH_MODE,
+ 				   BANK_HASH_4KB_MODE))
+ 	},
+ };
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -25,6 +25,10 @@ backport/patches/base/0001-drm-xe-rtp-Add-support-for-matching-platform-level-s.
 backport/patches/base/0001-drm-xe-nvlp-Implement-Wa_14026539277.patch
 backport/patches/base/0001-drm-xe-xe3p-Drop-Wa_16028780921.patch
 backport/patches/base/0001-drm-xe-Translate-C-state-reset-value-into-RC6.patch
+backport/patches/base/0001-drm-xe-tuning-Stop-applying-CCCHKNREG1-tuning-from-X.patch
+backport/patches/base/0001-drm-xe-tuning-Use-proper-register-offset-for-GAMSTLB.patch
+backport/patches/base/0001-drm-xe-Mark-ROW_CHICKEN5-as-a-masked-register.patch
+backport/patches/base/0001-drm-xe-Add-Wa_14026578760.patch
 # fixes
 backport/patches/base/0001-drm-xe-xe3p_lpg-Add-missing-indirect-ring-state-feat.patch
 # features/eu-debug


### PR DESCRIPTION
Update Xe3p tuning and workaround programming to match platform
requirements and correct register definitions.

Stop applying CCCHKNREG1 tuning on Xe3p and newer platforms, since
graphics version 35+ requires leaving the register at hardware default
settings.

Use the correct Xe2+ GAMSTLB_CTRL register offset (0x477C) instead of
the obsolete Xe1-era definition, ensuring STLB bank hash tuning is
applied properly on supported platforms.

Mark ROW_CHICKEN5 as a masked register so workaround writes update
lower 16-bit fields correctly.

These fixes ensure Xe3p tuning and workaround settings are programmed to
the intended registers with correct semantics.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>