### PR TITLE
Implement selective patch application with flavor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Note:
 2. Patches present in features are dynamic in nature, they may change frequently and removed once merged in drm-tip.
 3. Patches present in features will use prelim uapi to aviod conflict in updates, once patches are merged in drm-tip, uapi will change from prelim to normal.
 4. prelim uapi will be maintained at [drm-uapi-helper](https://github.com/intel-gpu/drm-uapi-helper/tree/xe).
+5. Patches present in oot directory are applied only when using the `-c <oot>` option.
 
 # Available Branches
 
@@ -39,10 +40,18 @@ backport.sh < options >
 
 ||options |description |
 |-- |--|--| 
-|1. |create-tree| Create kernel tree based on given option <base/features> (default)|
+|1. |create-tree| Create kernel tree based on given option <base/features/oot> (default)|
 |2. |delete-tree| Delete the tree|
 |3. |reset-tree| Delete the existing tree and re-create it|
 |4. |override| Overrides existing tree|
+
+## Examples
+
+### Create tree with out-of-tree (OOT) patches included
+```bash
+./backport.sh -c oot
+```
+This applies all patches including those in `backport/patches/oot/` directory.
 
 # Debugging
 
@@ -88,10 +97,13 @@ Place the patch in the appropriate directory based on patch type:
 ```
 backport/patches/
 ├── base/           # All fixes and patches merged in drm-tip
-└── features/       # Feature patches under review
-    ├── eu-debug/
-    ├── sriov/
-    └── xe-late-bind-fw/
+├── features/       # Feature patches under review
+│   ├── eu-debug/
+│   ├── sriov/
+│   ├── vf-double-migration/
+│   ├── vf-vram-provision/
+│   └── xe-late-bind-fw/
+└── oot/            # Out-of-tree patches
 ```
 
 #### Placement Rules:
@@ -99,6 +111,7 @@ backport/patches/
 - **`backport/patches/features/<feature-name>/`** - For new feature patches under review
   - Place feature patches in the appropriate feature subdirectory
   - If the feature directory doesn't exist, create one with a descriptive name
+- **`backport/patches/oot/`** - For out-of-tree patches.
 
 **Examples:**
 - Bug fix → `backport/patches/base/0001-fix-memory-leak.patch`

--- a/backport.sh
+++ b/backport.sh
@@ -26,7 +26,7 @@ SHORT=:c,d,h,r,o
 LONG=create-tree:delete-tree,help,reset-tree,override
 OPTS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 
-flavor="features"
+flavor=""
 is_existing_tree=0
 is_override=0
 xkb_tag=""
@@ -36,7 +36,7 @@ usage () {
           echo "Usage: $0 [-c|--create-tree] [-d|--delete-tree] [-r|--reset-tree]"
           echo ""
           echo "Options:"
-          echo "  -c, --create-tree                   	Create kernel tree based on given option <base/features>"
+          echo "  -c, --create-tree                   Create kernel tree based on given option <base/features/oot>"
           echo "  -d, --delete-tree    	      		Delete the tree"
           echo "  -r, --reset-tree    	      		Delete the existing tree and re-create it"
           echo "  -o, --override    	      		Overrides the existing tree"
@@ -45,20 +45,38 @@ usage () {
 
 apply_patches() {
 	echo "Applying local patches"
+	echo "Flavor: $flavor"
 	while read p; do
 		case "$p" in \#*)
-			if [ ! -z "$flavor" ]; then
-				echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
-				if [[ "$flavor" == "base" ]]; then
-					echo "Only base patches will be  applied"
-					flavor=""
+			patch_category=$(echo $p | tr -d "#" | xargs)
+			if [[ "$flavor" == "base" ]]; then
+				# Apply only the base section
+				if [[ "$patch_category" == "base" ]]; then
+					echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
+					continue
+				else
+					echo "Base patches completed, stopping"
+					break
 				fi
+
+			elif [ -z "$flavor" ] || [[ "$flavor" == "features" ]]; then
+				# Default or features: Apply everything EXCEPT oot
+				if [[ "$patch_category" != "oot" ]]; then
+					echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
+					continue
+				else
+					echo "features patches completed, stopping"
+					break
+				fi
+
+			elif [[ "$flavor" == "oot" ]]; then
+				# Apply everything including oot
+				echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
 				continue
-			else
-				break
 			fi
 			;;
 		esac
+
 		git am -q -s "$WORKING_DIR/$p"
 		if [ $? -ne 0 ]; then
 			echo "Failed to apply patch $p"
@@ -157,6 +175,7 @@ while [ $# -gt 0 ]; do
                 -c|--create-tree|-o|--override)
 			if [ ! $# -gt 1 ]; then
 				echo "No option provided for creating the tree"
+				flavor=""
 			else
 				flavor=$2
 			fi

--- a/backport/patches/oot/0001-drm-xe-pf-Handle-VF-BAR-resize-without-PCI-VF-REBAR-.patch
+++ b/backport/patches/oot/0001-drm-xe-pf-Handle-VF-BAR-resize-without-PCI-VF-REBAR-.patch
@@ -1,0 +1,136 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marcin Bernatowicz <marcin.bernatowicz@linux.intel.com>
+Date: Thu, 22 Jan 2026 00:00:00 +0000
+Subject: drm/xe/pf: Handle VF BAR resize without PCI VF REBAR helpers
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Implement VF BAR resizing via the VF Resizable BAR capability directly
+in PCI config space for kernels that lack PCI VF REBAR helper APIs.
+
+Reference:
+	xe only implementation of PCIE
+	7e5020293 drm/xe/pf: Handle VF BAR resize without PCI VF REBAR helpers
+	tag: xeb_v6.17.13_260130.26.1
+
+Suggested-by: Michał Winiarski <michal.winiarski@intel.com>
+Signed-off-by: Marcin Bernatowicz <marcin.bernatowicz@linux.intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci_sriov.c | 94 +++++++++++++++++++++++++++++--
+ 1 file changed, 90 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci_sriov.c b/drivers/gpu/drm/xe/xe_pci_sriov.c
+index 9ff69c484..1246ffc76 100644
+--- a/drivers/gpu/drm/xe/xe_pci_sriov.c
++++ b/drivers/gpu/drm/xe/xe_pci_sriov.c
+@@ -82,16 +82,102 @@ static void pf_engine_activity_stats(struct xe_device *xe, unsigned int num_vfs,
+ 	}
+ }
+ 
++/*
++ * Backport-only fallback: program VF REBAR directly when PCI-core helpers
++ * are not available.
++ */
++
++#ifndef PCI_EXT_CAP_ID_VF_REBAR
++#define PCI_EXT_CAP_ID_VF_REBAR 0x24 /* VF Resizable BAR */
++#endif
++
++static inline resource_size_t pci_rebar_size_to_bytes(int size)
++{
++	return 1ULL << (size + ilog2((resource_size_t)SZ_1M));
++}
++
++/*
++ * The real 'struct pci_sriov' is PCI-core internal (drivers/pci/pci.h).
++ * This local copy is used only to update pdev->sriov->barsz[].
++ */
++struct pci_sriov {
++	int		pos;			/* Capability position */
++	int		nres;			/* Number of resources */
++	u32		cap;			/* SR-IOV Capabilities */
++	u16		ctrl;			/* SR-IOV Control */
++	u16		total_VFs;		/* Total VFs associated with the PF */
++	u16		initial_VFs;		/* Initial VFs associated with the PF */
++	u16		num_VFs;			/* Number of VFs available */
++	u16		offset;			/* First VF Routing ID offset */
++	u16		stride;			/* Following VF stride */
++	u16		vf_device;		/* VF device ID */
++	u32		pgsz;			/* Page size for BAR alignment */
++	u8		link;			/* Function Dependency Link */
++	u8		max_VF_buses;		/* Max buses consumed by VFs */
++	u16		driver_max_VFs;		/* Max num VFs driver supports */
++	struct pci_dev	*dev;			/* Lowest numbered PF */
++	struct pci_dev	*self;			/* This PF */
++	u32		class;			/* VF device */
++	u8		hdr_type;		/* VF header type */
++	u16		subsystem_vendor;	/* VF subsystem vendor */
++	u16		subsystem_device;	/* VF subsystem device */
++	resource_size_t	barsz[PCI_SRIOV_NUM_BARS]; /* VF BAR size */
++	bool		drivers_autoprobe;	/* Auto probing of VFs by driver */
++};
++
+ static int resize_vf_vram_bar(struct xe_device *xe, int num_vfs)
+ {
+ 	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+-	u32 sizes;
++	resource_size_t size, total;
++	int pos, i, vf_bar_idx = VF_LMEM_BAR - PCI_IOV_RESOURCES;
++	u32 rebar, ctrl;
++	int err;
+ 
+-	sizes = pci_iov_vf_bar_get_sizes(pdev, VF_LMEM_BAR, num_vfs);
+-	if (!sizes)
++	pos = pci_find_ext_capability(pdev, PCI_EXT_CAP_ID_VF_REBAR);
++	if (!pos)
+ 		return 0;
+ 
+-	return pci_iov_vf_bar_set_size(pdev, VF_LMEM_BAR, __fls(sizes));
++	/* Expecting a single VF resizable BAR, and it to be BAR2. */
++	err = pci_read_config_dword(pdev, pos + PCI_REBAR_CTRL, &ctrl);
++	if (err)
++		return err;
++
++	if (FIELD_GET(PCI_REBAR_CTRL_NBAR_MASK, ctrl) != 1 ||
++	    FIELD_GET(PCI_REBAR_CTRL_BAR_IDX, ctrl) != vf_bar_idx) {
++		xe_sriov_warn(xe, "Unexpected resource in VF resizable BAR, skipping resize\\n");
++		return 0;
++	}
++
++	err = pci_read_config_dword(pdev, pos + PCI_REBAR_CAP, &rebar);
++	if (err)
++		return err;
++
++	rebar = FIELD_GET(PCI_REBAR_CAP_SIZES, rebar);
++	total = pci_resource_len(pdev, VF_LMEM_BAR);
++
++	while (rebar) {
++		i = __fls(rebar);
++		size = pci_rebar_size_to_bytes(i);
++
++		if (num_vfs && size <= div_u64(total, num_vfs)) {
++			ctrl &= ~PCI_REBAR_CTRL_BAR_SIZE;
++			ctrl |= i << PCI_REBAR_CTRL_BAR_SHIFT;
++
++			err = pci_write_config_dword(pdev, pos + PCI_REBAR_CTRL, ctrl);
++			if (err)
++				return err;
++
++			((struct pci_sriov *)pdev->sriov)->barsz[vf_bar_idx] = size;
++
++			xe_sriov_info(xe, "VF BAR%d resized to %llu MiB\\n",
++				      vf_bar_idx, (unsigned long long)(size >> 20));
++			break;
++		}
++
++		rebar &= ~BIT(i);
++	}
++
++	return 0;
+ }
+ 
+ static int pf_prepare_vfs_enabling(struct xe_device *xe)
+-- 
+2.34.1
+

--- a/series
+++ b/series
@@ -397,3 +397,5 @@ backport/patches/features/eu-debug/0001-fixup-drm-xe-Add-PRELIM-infrastructure.p
 backport/patches/features/eu-debug/0001-uapi-drm-xe-Update-prelim-definitions-for-EU-Debugge.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Update-prelim-vm-bind-attach-debug.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Eudebug-prelim-fix-for-exec-queue-pro.patch
+# oot
+backport/patches/oot/0001-drm-xe-pf-Handle-VF-BAR-resize-without-PCI-VF-REBAR-.patch


### PR DESCRIPTION
using (-c base|features|oot).

./backport.sh -c (default)
	Apply base + features + fixes
./backport.sh -c base
	'base': Apply only base patches
./backport.sh -c features
	Apply base + features + fixes this is same as deafult
./backport.sh -c oot
	'oot': Apply all patches including oot

Update documentation with oot flavor details

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>