### PR TITLE
handle unknown flavor parameters and features treat as default behavior

### DIFF
--- a/backport.sh
+++ b/backport.sh
@@ -59,8 +59,13 @@ apply_patches() {
 					break
 				fi
 
-			elif [ -z "$flavor" ] || [[ "$flavor" == "features" ]]; then
-				# Default or features: Apply everything EXCEPT oot
+			elif [[ "$flavor" == "oot" ]]; then
+				# Apply everything including oot
+				echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
+				continue
+
+			else
+				# Default: features or any other parameter - Apply everything EXCEPT oot
 				if [[ "$patch_category" != "oot" ]]; then
 					echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
 					continue
@@ -68,11 +73,6 @@ apply_patches() {
 					echo "features patches completed, stopping"
 					break
 				fi
-
-			elif [[ "$flavor" == "oot" ]]; then
-				# Apply everything including oot
-				echo $p | tr -d "#" | (read name; echo "Applying $name patches..!" >&2)
-				continue
 			fi
 			;;
 		esac


### PR DESCRIPTION
Previously, unknown flavor parameters (e.g., ./backport.sh -c xyz) would cause
a file not found error. Now they default to features behavior, applying all
patches except oot. This prevents script failures from typos or new flavor
options while maintaining explicit handling for base and oot.

Fixes: 6fd09f300 ("Implement selective patch application with flavor options")

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>