### PR TITLE
Add rpm package support for xe dkms release

### DIFF
--- a/autotools/Makefile
+++ b/autotools/Makefile
@@ -1,5 +1,88 @@
+# Check if being called by kernel build system
+ifneq ($(KERNELRELEASE),)
+# Called by kernel build system - descend into src/
+obj-y := src/
+else
+# User/packaging mode
+
+# Version extraction from backport versions file
+# Extract value after = and remove quotes, then split by _
+BKPT_VER=$(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '=' -f 2 | tr -d '"' | cut -d '_' -f 3 2>/dev/null || echo 1)
+BP_TAG=$(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '=' -f 2 | tr -d '"' | cut -d '_' -f 2 2>/dev/null || echo 1)
+BP_DATE=$(shell echo $(BKPT_VER) | cut -d "." -f 1 2>/dev/null || echo 1)
+
+# Get kernel version - from KLIB/KLIB_BUILD headers if provided, else from uname -r
+ifneq ($(origin KLIB), undefined)
+  KLIB_BUILD ?= $(KLIB)/build/
+  TARGET_KERN_VER=$(shell cat $(KLIB_BUILD)/include/generated/autoconf.h 2>/dev/null | grep 'CONFIG_BUILD_SALT' | cut -d '"' -f2 2>/dev/null || cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep "UTS_RELEASE" | cut -d '"' -f2 2>/dev/null || uname -r)
+else ifneq ($(origin KLIB_BUILD), undefined)
+  KLIB ?= $(patsubst %/build,%,$(KLIB_BUILD))
+  TARGET_KERN_VER=$(shell cat $(KLIB_BUILD)/include/generated/autoconf.h 2>/dev/null | grep 'CONFIG_BUILD_SALT' | cut -d '"' -f2 2>/dev/null || cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep "UTS_RELEASE" | cut -d '"' -f2 2>/dev/null || uname -r)
+else
+  KLIB := /lib/modules/$(shell uname -r)/
+  KLIB_BUILD ?= $(KLIB)/build/
+  TARGET_KERN_VER=$(shell uname -r)
+endif
+
+BACKPORT_DIR = src
+CONFIG_SHELL = /bin/bash
+
+# Extract kernel version components
+FULL_KERN_STR=$(shell echo "$(TARGET_KERN_VER)" | sed 's/\.el[0-9]*_[0-9]*\.x86_64//' | sed 's/\.x86_64//' | tr -d '+')
+KER_VER=$(subst -,.,$(FULL_KERN_STR))
+DISTRO_SUFFIX=$(shell echo "$(TARGET_KERN_VER)" | grep -oE 'el(9|10)_[0-9]+' | head -1)
+
+# Extract DEV_TAG from BASE_KERNEL_TAG e.g. "xe-v6.17.13.46" extracts "6.17.13.46"
+# Remove 'v' prefix if present
+DEV_TAG_RAW=$(shell cat $(BACKPORT_DIR)/versions 2>/dev/null | grep BASE_KERNEL_TAG | cut -f 2 -d '"' | cut -d '-' -f 2 || echo "")
+DEV_TAG=$(shell echo $(DEV_TAG_RAW) | sed 's/^v//')
+
+# Package version format: only kernel version in VERSION field
+# DEV_TAG and BP_DATE go into RELEASE with dot separator (RPM Release field restriction)
+VERSION=$(KER_VER)
+RELEASE_VERSION=$(DEV_TAG).$(BP_DATE)
+
+XE_PKG_NAME=intel-xe-dkms
+XE_PKG_VERSION=$(VERSION)
+XE_PKG_RELEASE=$(RELEASE_VERSION)_1
+XE_RPM_MK_SPEC=$(BACKPORT_DIR)/scripts/backport-mkdrmdkmsspec
+XE_RPM_MK_DKMS=$(BACKPORT_DIR)/scripts/backport-mkdrmdkmsconf
+
+# Export variables for sub-makes
+export KLIB KLIB_BUILD
+
+.PHONY: all clean xe-dkms-deb-pkg
 all clean xe-dkms-deb-pkg:
 	$(MAKE) -C src $@
 
+.PHONY: modules olddefconfig menuconfig savedefconfig
 modules olddefconfig menuconfig savedefconfig:
-	$(MAKE) -C src KLIB=$(LINUX_OBJ) KLIB_BUILD=$(LINUX_OBJ) $@
+	$(MAKE) -C src KLIB=$(KLIB) KLIB_BUILD=$(KLIB_BUILD) $@
+
+.PHONY: show-version
+show-version:
+	@echo "Target Kernel Version : $(TARGET_KERN_VER)"
+	@echo "Kernel Headers Path   : $(KLIB_BUILD)"
+	@echo "Package Version       : $(XE_PKG_VERSION)"
+	@echo "Package Release       : $(XE_PKG_RELEASE)$(if $(DISTRO_SUFFIX),.$(DISTRO_SUFFIX))"
+	@echo "Expected RPM Name     : $(XE_PKG_NAME)-$(XE_PKG_VERSION)-$(XE_PKG_RELEASE)$(if $(DISTRO_SUFFIX),.$(DISTRO_SUFFIX)).x86_64.rpm"
+
+.PHONY: xe-dkms-rpm-pkg
+xe-dkms-rpm-pkg: clean
+	@echo "========================================"
+	@echo "Building DKMS RPM package"
+	@echo "Target Kernel: $(TARGET_KERN_VER)"
+	@echo "Package version: $(XE_PKG_VERSION)-$(XE_PKG_RELEASE)"
+	@echo "========================================"
+	@echo "Pre-configuring source for DKMS..."
+	@cd src && test -f .config || $(MAKE) defconfig-xe
+	@echo "Pre-generating backport autoconf.h..."
+	@cd src && $(MAKE) backport-include/backport/autoconf.h
+	mkdir -p rpm
+	mkdir -p ~/rpmbuild/SOURCES
+	$(CONFIG_SHELL) $(XE_RPM_MK_SPEC) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r $(XE_PKG_RELEASE) $(if $(DISTRO_SUFFIX),-d $(DISTRO_SUFFIX)) -z dkms > rpm/$(XE_PKG_NAME).spec
+	$(CONFIG_SHELL) $(XE_RPM_MK_DKMS) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r $(XE_PKG_RELEASE) > rpm/$(XE_PKG_NAME).dkms.conf
+	cp -r src m4 debian Makefile* configure* aclocal.m4 AUTHORS ChangeLog COPYING INSTALL NEWS README compile.sh ~/rpmbuild/SOURCES/ 2>/dev/null || true
+	+rpmbuild -bb --define "_sourcedir $(PWD)" rpm/$(XE_PKG_NAME).spec
+
+endif # End of user/packaging mode

--- a/autotools/Makefile.am
+++ b/autotools/Makefile.am
@@ -20,18 +20,36 @@
 # OSV GENERIC VARIABLES
 #
 
+# Kernel build directory - defaults to running kernel
+KLIB_BUILD ?= /lib/modules/@DOLLAR_SIGN@(shell uname -r)/build
+
 RELEASE=1
 
+# Extract kernel version from running kernel or KLIB_BUILD
+# Try CONFIG_BUILD_SALT first (has full version like 6.12.0-124.49.1.el10_1.x86_64)
+# Fall back to UTS_RELEASE if not found, then uname -r
+TARGET_KERN_VER=@DOLLAR_SIGN@(shell cat @DOLLAR_SIGN@(KLIB_BUILD)/include/generated/autoconf.h 2>/dev/null | grep 'CONFIG_BUILD_SALT' | cut -d '"' -f2 2>/dev/null || cat @DOLLAR_SIGN@(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep UTS_RELEASE | cut -d '"' -f2 || uname -r)
+FULL_KERN_STR=@DOLLAR_SIGN@(shell echo "@DOLLAR_SIGN@(TARGET_KERN_VER)" | sed 's/\.el[0-9]*_[0-9]*\.x86_64//' | sed 's/\.x86_64//' | tr -d '+')
+KER_VER=@DOLLAR_SIGN@(subst -,.,@DOLLAR_SIGN@(FULL_KERN_STR))
+
 # BKPT_VER consist of backported release version.
-# Expected input: 'BACKPORTS_RELEASE_TAG="XE_586_241121.0"'
-# Filtered output: 241121.0
-BKPT_VER=@DOLLAR_SIGN@(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d "_" -f 5 | cut -d "\"" -f 1 | cut -d "-" -f 1 2>/dev/null || echo 1)
+# Expected input: 'BACKPORTS_RELEASE_TAG="xeb_v6.17.13.49_260409.4"'
+# Extract value after ="...", then get field 3 after splitting by _: 260409.4
+BKPT_VER=@DOLLAR_SIGN@(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '=' -f 2 | tr -d '"' | cut -d '_' -f 3 2>/dev/null || echo 1)
 
-# DEV_TAG is extracted from BASE_KERNEL_TAG, which is auto genereated from Dev kernel source.
-# Tagging is needed for decoding
-DEV_TAG=@DOLLAR_SIGN@(shell cat src/versions | grep BASE_KERNEL_TAG | cut -f 2 -d "\"" | cut -d "-" -f 3 2>/dev/null || echo 1)
+# DEV_TAG is extracted from BASE_KERNEL_TAG.
+# Expected format: "xe-v6.17.13.49" -> extracts "v6.17.13.49" and removes 'v' prefix
+DEV_TAG_RAW=@DOLLAR_SIGN@(shell cat src/versions | grep BASE_KERNEL_TAG | cut -f 2 -d "\"" | cut -d "-" -f 2 2>/dev/null || echo 1)
+DEV_TAG=@DOLLAR_SIGN@(shell echo @DOLLAR_SIGN@(DEV_TAG_RAW) | sed 's/^v//')
 
-VERSION=0.$(BKPT_VER)
+# Debian package version: 0.<BKPT_VER> (e.g., 0.260409.5)
+# RPM package version: kernel version (e.g., 6.12.0.124.8.1)
+# Note: VERSION is reserved by automake (set via AC_INIT in configure.ac), use KERN_PKG_VERSION for RPM
+KERN_PKG_VERSION=$(KER_VER)
+RELEASE_VERSION=$(DEV_TAG).$(BKPT_VER)
+
+# Distro suffix (e.g., el10_1) for RPM packaging - supports RHEL 9 and 10 only
+DISTRO_SUFFIX=@DOLLAR_SIGN@(shell cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep UTS_RELEASE | cut -d '"' -f2 | grep -oE 'el(9|10)_[0-9]+' | head -1)
 
 #------------------------------------------------------------------------------
 #
@@ -41,8 +59,14 @@ VERSION=0.$(BKPT_VER)
 
 XE_PKG_NAME_BASENAME=intel-xe-dkms
 XE_PKG_NAME=$(XE_PKG_NAME_BASENAME)
-XE_PKG_VERSION=$(VERSION)
+
+# Debian version format: 0.<BKPT_VER> e.g. intel-xe-dkms_0.260409.5+i1-1_all.deb
+XE_PKG_VERSION=0.$(BKPT_VER)
 XE_PKG_RELEASE=$(RELEASE)
+
+# RPM version format: <kernel-ver>-<dev_tag>.<bkpt_ver>.<release> e.g. intel-xe-dkms-6.12.0.124.8.1-6.17.13.54.260409.5.1.el10_1.x86_64.rpm
+XE_RPM_PKG_VERSION=$(KERN_PKG_VERSION)
+XE_RPM_PKG_RELEASE=$(RELEASE_VERSION).$(RELEASE)
 
 #------------------------------------------------------------------------------
 #
@@ -75,6 +99,15 @@ XE_DKMS_MK_DKMS=$(BACKPORT_DIR)/scripts/backport-mkxedebdkms
 XE_DKMS_MK_README=$(BACKPORT_DIR)/scripts/backport-mkdebreadme
 XE_DKMS_MK_COPYRIGHT=$(BACKPORT_DIR)/scripts/backport-mkdebcopyright
 
+#------------------------------------------------------------------------------
+#
+# RPM Package Targets
+#
+#------------------------------------------------------------------------------
+
+XE_RPM_MK_SPEC=$(BACKPORT_DIR)/scripts/backport-mkdrmdkmsspec
+XE_RPM_MK_DKMS=$(BACKPORT_DIR)/scripts/backport-mkdrmdkmsconf
+
 .PHONY: xe-dkms-deb-pkg
 xe-dkms-deb-pkg: clean
 	$(CONFIG_SHELL) $(XE_DKMS_MK_CONTROL) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r $(XE_PKG_RELEASE) -z dkms > debian/control
@@ -100,6 +133,14 @@ xe-dkms-deb-pkg: clean
 	+dch -l "+i${XE_PKG_RELEASE}-" -m "build ${XE_PKG_RELEASE}"
 	+dpkg-buildpackage -j`nproc --all` -us -uc -b -rfakeroot
 
+.PHONY: xe-dkms-rpm-pkg
+xe-dkms-rpm-pkg: clean
+	mkdir -p rpm
+	mkdir -p ~/rpmbuild/SOURCES
+	@DOLLAR_SIGN@(CONFIG_SHELL) @DOLLAR_SIGN@(XE_RPM_MK_SPEC) -n @DOLLAR_SIGN@(XE_PKG_NAME) -v @DOLLAR_SIGN@(XE_RPM_PKG_VERSION) -r @DOLLAR_SIGN@(XE_RPM_PKG_RELEASE) @DOLLAR_SIGN@(if @DOLLAR_SIGN@(DISTRO_SUFFIX),-d @DOLLAR_SIGN@(DISTRO_SUFFIX)) -z dkms > rpm/@DOLLAR_SIGN@(XE_PKG_NAME).spec
+	@DOLLAR_SIGN@(CONFIG_SHELL) @DOLLAR_SIGN@(XE_RPM_MK_DKMS) -n @DOLLAR_SIGN@(XE_PKG_NAME) -v @DOLLAR_SIGN@(XE_RPM_PKG_VERSION) -r @DOLLAR_SIGN@(XE_RPM_PKG_RELEASE) > rpm/@DOLLAR_SIGN@(XE_PKG_NAME).dkms.conf
+	cp -r src m4 debian Makefile* configure* aclocal.m4 AUTHORS ChangeLog COPYING INSTALL NEWS README.md compile.sh ~/rpmbuild/SOURCES/ 2>/dev/null || true
+	+rpmbuild -bb --define "_sourcedir @DOLLAR_SIGN@(PWD)" rpm/@DOLLAR_SIGN@(XE_PKG_NAME).spec
 
 all clean:
 	$(MAKE) -C src $@

--- a/autotools/README.md
+++ b/autotools/README.md
@@ -10,6 +10,7 @@ We are using [backport project](https://backports.wiki.kernel.org/index.php/Main
 
 ## Prerequisite
 We have dependencies on the following packages
+### Ubuntu Supported OS Kernel/Distribution
   - automake
   - dkms
   - make
@@ -19,9 +20,18 @@ We have dependencies on the following packages
 ```
 $ sudo apt install automake dkms make debhelper devscripts
 ```
-For DKMS modules, we need to install `dkms` package too.
+
+### Redhat Supported OS Kernel/Distribution
+  - automake
+  - dkms
+  - make
+  - rpm-build
+  - rpmdevtools
+  - bison
+  - flex
+
 ```
-$ sudo apt install dkms
+$ sudo dnf install automake dkms make rpm-build rpmdevtools bison flex
 ```
 
 ## Dependencies
@@ -37,9 +47,12 @@ Each project is tagged consistently, so when pulling these repos, pull the same 
 ### Dynamic Kernel Module Support(DKMS)
 
 Creating xe DKMS packages
+
 ```
 $ make <DKMS Package Target>
+```
 
+```
 Example:
 	$./compile.sh configure
 	$ make xe-dkms-deb-pkg
@@ -49,10 +62,33 @@ Generated package name :
 ```
 Above command will create Debian package in parent folder. **intel-xe-dkms_<**release version**>.<**kernel-version**>.deb**
 
+```
+Example:
+	$ ./compile.sh configure
+	$ make xe-dkms-rpm-pkg
+
+Generated package name:
+	intel-xe-dkms-<kernel-version>-<release-version>.<distro-suffix>.x86_64.rpm
+	Example: intel-xe-dkms-6.12.0.124.8.1-6.17.13.54.260409.4.1.el10_1.x86_64.rpm
+```
+Above command will create RPM package in `~/rpmbuild/RPMS/x86_64/` directory.
+
+**Note:** You can check the expected package version and name before building:
+```
+$ make show-version
+```
 ## Installation and verification
+
+### Ubuntu/Debian
 ```
 $ sudo dpkg -i intel-xe*.deb
 ```
+
+### Redhat
+```
+$ sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/intel-xe-dkms-*.rpm
+```
+
 Reboot the device after installation of all packages.
 ```
 $ sudo reboot
@@ -63,9 +99,17 @@ $ sudo dmesg |grep -i backport
 [.....] COMPAT: Backport init, Module is backported from xe-586
 ```
 ## Uninstallation
+
+### Ubuntu/Debian
 ```
 $ sudo dpkg -r intel-xe*
 ```
+
+### Redhat
+```
+$ sudo rpm -e intel-xe-dkms*
+```
+
 Reboot the device after uninstallation of all packages.
 ```
 $ sudo reboot

--- a/backport/Makefile
+++ b/backport/Makefile
@@ -2,11 +2,19 @@
 # Makefile for the output source package
 #
 
+# Set BACKPORT_DIR early so it's available in all contexts
+# When called by kernel build system, use $(src) which points to this directory
+# Otherwise use current directory
+ifeq ($(KERNELRELEASE),)
+BACKPORT_DIR ?= $(shell pwd)
+else
+BACKPORT_DIR ?= $(src)
+endif
+
 ifeq ($(KERNELRELEASE),)
 
 MAKEFLAGS += --no-print-directory
 SHELL := /bin/bash
-BACKPORT_DIR := $(shell pwd)
 
 KMODDIR ?= updates
 ifneq ($(origin KLIB), undefined)
@@ -29,7 +37,7 @@ export KLIB KLIB_BUILD BACKPORT_DIR KMODDIR KMODPATH_ARG TARGET_KERNEL_NAME
 # Packaging targets Available
 #
 DEB_PKG_DISTRO_TARGETS := xe-dkms-deb-pkg
-RPM_PKG_DISTRO_TARGETS :=
+RPM_PKG_DISTRO_TARGETS := xe-dkms-rpm-pkg
 
 # PKG_DISTRO_TARGETS
 # DKMS Package Targets
@@ -176,5 +184,6 @@ help: defconfig-help
 	@echo ""
 	@echo "Execute "make" or "make all" to build all targets marked with [*]"
 else
+# Called by kernel build system (KERNELRELEASE is set)
 include $(BACKPORT_DIR)/Makefile.kernel
 endif

--- a/backport/Makefile.real
+++ b/backport/Makefile.real
@@ -1,4 +1,5 @@
-include versions
+BACKPORT_DIR ?= $(shell pwd)
+include $(BACKPORT_DIR)/versions
 
 # Remove # from the tag to avoid issue of src folder flag corruption during NOSTDINC_FLAGS update
 TAG_EXTRACT := $(shell cat $(BACKPORT_DIR)/versions | grep BASE_KERNEL_TAG | sed "s/#//" | cut -d '"' -f 2 )

--- a/backport/scripts/backport-mkdrmdkmsconf
+++ b/backport/scripts/backport-mkdrmdkmsconf
@@ -1,0 +1,84 @@
+#!/bin/sh
+#
+# Creates a dkms.conf file for RPM DKMS package
+#
+
+PKG_NAME="intel-xe-dkms"
+PKG_VER="1.0"
+REL_NAME="1"
+BUILD_TYPE=""
+
+helpFunction()
+{
+	echo ""
+	echo "Usage: $0 -n packagename -v packageversion -r releaseversion -s buildversion"
+	echo -e "\t-n packagename"
+	echo -e "\t-v packageversion"
+	echo -e "\t-r releaseversion"
+	echo -e "\t-s buildversion"
+	exit 1
+}
+
+while getopts "n:v:r:s:" opt
+do
+	case "$opt" in
+		n ) PKG_NAME="$OPTARG" ;;
+		v ) PKG_VER="$OPTARG" ;;
+		r ) REL_NAME="$OPTARG" ;;
+		s ) BUILD_TYPE="$OPTARG" ;;
+		? ) helpFunction ;;
+	esac
+done
+
+# Control below line by conditionally adding DEL at the beginning of line
+# those lines will be disabled by sed
+#
+sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+	PACKAGE_NAME="$PKG_NAME"
+	PACKAGE_VERSION="$PKG_VER"
+	AUTOINSTALL="yes"
+
+	MAKE="KSRC=/usr/src/kernels/\\\$kernelver; if [ ! -d \\\$KSRC ]; then KSRC=/lib/modules/\\\$kernelver/build; fi; ./compile.sh compile \\\$KSRC"
+
+	CLEAN="'make' -C src clean 2>/dev/null || true; 'make' mrproper 2>/dev/null || true"
+
+	BUILT_MODULE_NAME[0]="xe-compat"
+	BUILT_MODULE_LOCATION[0]="src/compat"
+	DEST_MODULE_LOCATION[0]="/updates"
+
+	BUILT_MODULE_NAME[1]="xe"
+	BUILT_MODULE_LOCATION[1]="src/drivers/gpu/drm/xe"
+	DEST_MODULE_LOCATION[1]="/updates"
+
+	BUILT_MODULE_NAME[2]="ttm"
+	BUILT_MODULE_LOCATION[2]="src/drivers/gpu/drm/ttm"
+	DEST_MODULE_LOCATION[2]="/updates"
+
+	BUILT_MODULE_NAME[3]="drm_ttm_helper"
+	BUILT_MODULE_LOCATION[3]="src"
+	DEST_MODULE_LOCATION[3]="/updates"
+
+	BUILT_MODULE_NAME[4]="gpu-sched"
+	BUILT_MODULE_LOCATION[4]="src/drivers/gpu/drm/scheduler"
+	DEST_MODULE_LOCATION[4]="/updates"
+
+	BUILT_MODULE_NAME[5]="intel-vsec"
+	BUILT_MODULE_LOCATION[5]="src/drivers/platform/x86/intel"
+	DEST_MODULE_LOCATION[5]="/updates"
+
+	BUILT_MODULE_NAME[6]="pmt_class"
+	BUILT_MODULE_LOCATION[6]="src/drivers/platform/x86/intel/pmt"
+	DEST_MODULE_LOCATION[6]="/updates"
+
+	BUILT_MODULE_NAME[7]="pmt_telemetry"
+	BUILT_MODULE_LOCATION[7]="src/drivers/platform/x86/intel/pmt"
+	DEST_MODULE_LOCATION[7]="/updates"
+
+	BUILT_MODULE_NAME[8]="pmt_crashlog"
+	BUILT_MODULE_LOCATION[8]="src/drivers/platform/x86/intel/pmt"
+	DEST_MODULE_LOCATION[8]="/updates"
+
+	BUILT_MODULE_NAME[9]="mtd_intel_dg"
+	BUILT_MODULE_LOCATION[9]="src"
+	DEST_MODULE_LOCATION[9]="/updates"
+EOF

--- a/backport/scripts/backport-mkdrmdkmsspec
+++ b/backport/scripts/backport-mkdrmdkmsspec
@@ -1,0 +1,163 @@
+#!/bin/sh
+#
+# Output a .spec file for RPM DKMS package
+#
+
+PKG_NAME="intel-xe"
+PKG_VER="1.0"
+REL_NAME="1"
+DISTRO_SUFFIX=""
+PKG_TYPE=""
+DKMS=""
+BIN="DEL"
+
+helpFunction()
+{
+	echo ""
+	echo "Usage: $0 -n packagename -v packageversion -r releaseversion -d distrosuffix -z Package Type"
+	echo -e "\t-n packagename"
+	echo -e "\t-v packageversion"
+	echo -e "\t-r releaseversion"
+	echo -e "\t-d distrosuffix (e.g., el10_1)"
+	echo -e "\t-z Package Type : binary/dkms"
+	exit 1
+}
+
+while getopts "n:v:r:d:z:" opt
+do
+	case "$opt" in
+		n ) PKG_NAME="$OPTARG" ;;
+		v ) PKG_VER="$OPTARG" ;;
+		r ) REL_NAME="$OPTARG" ;;
+		d ) DISTRO_SUFFIX="$OPTARG" ;;
+		z )
+			PKG_TYPE="$OPTARG"
+			if [ "$PKG_TYPE" = "binary" ]; then
+				DKMS=DEL
+				BIN=
+			else
+				DKMS=
+				BIN=DEL
+			fi
+			;;
+		* ) helpFunction ;;
+	esac
+done
+
+# Construct release string with distro suffix if provided
+if [ -n "$DISTRO_SUFFIX" ]; then
+	RELEASE_STR="${REL_NAME}.${DISTRO_SUFFIX}"
+else
+	RELEASE_STR="${REL_NAME}"
+fi
+
+
+sed -e 's/^[[:space:]]*//' -e '/^DEL/d' <<EOF
+	Name:           $PKG_NAME
+	Version:        $PKG_VER
+	Release:        $RELEASE_STR
+	Summary:        Intel Xe DRM Driver
+	License:        MIT/GPL
+	Packager:       Intel Linux Graphics Team <linux-graphics@intel.com>
+	BuildArch:      x86_64
+
+	$DKMS %define __os_install_post %{nil}
+	$DKMS %define debug_package %{nil}
+
+	$BIN BuildRequires: gcc, make, kernel-devel
+
+	Requires: dkms, kernel-devel, gcc, make, flex, bison
+
+	Provides: xe-modules
+
+	%description
+	Out of tree xe driver.
+
+	%build
+	$BIN \$(MAKE) modules
+
+	%install
+	mkdir -p %{buildroot}/usr/src/%{name}-%{version}
+	$DKMS cp -r %{_sourcedir}/src %{buildroot}/usr/src/%{name}-%{version}/ 2>/dev/null || true
+	$DKMS cp -r %{_sourcedir}/m4 %{buildroot}/usr/src/%{name}-%{version}/ 2>/dev/null || true
+	$DKMS cp -r %{_sourcedir}/debian %{buildroot}/usr/src/%{name}-%{version}/ 2>/dev/null || true
+	$DKMS cp %{_sourcedir}/Makefile* %{_sourcedir}/configure* %{_sourcedir}/aclocal.m4 %{buildroot}/usr/src/%{name}-%{version}/ 2>/dev/null || true
+	$DKMS cp %{_sourcedir}/AUTHORS %{_sourcedir}/ChangeLog %{_sourcedir}/COPYING %{_sourcedir}/INSTALL %{_sourcedir}/NEWS %{_sourcedir}/README.md %{_sourcedir}/compile.sh %{buildroot}/usr/src/%{name}-%{version}/ 2>/dev/null || true
+	$DKMS cp -r %{_sourcedir}/src/backport-include %{buildroot}/usr/src/%{name}-%{version}/ 2>/dev/null || true
+	$DKMS cp -r %{_sourcedir}/src/include %{buildroot}/usr/src/%{name}-%{version}/ 2>/dev/null || true
+	$DKMS cp %{_sourcedir}/rpm/%{name}.dkms.conf %{buildroot}/usr/src/%{name}-%{version}/dkms.conf 2>/dev/null || true
+	$BIN \$(MAKE) modules_install INSTALL_MOD_PATH=%{buildroot}
+
+	%post
+	$DKMS dkms add -m $PKG_NAME -v $PKG_VER --rpm_safe_upgrade || true
+	$DKMS CREATE_INITRD="0"
+	$DKMS for i in /lib/modules/[5-7]*; do
+	$DKMS   H="\$i/build"
+	$DKMS   K=\$(echo \$i | cut -d '/' -f 4)
+	$DKMS   if [ -d /usr/src/kernels/\$K ]; then
+	$DKMS     KDIR=/usr/src/kernels/\$K
+	$DKMS   elif [ -d \$H ]; then
+	$DKMS     KDIR=\$H
+	$DKMS   else
+	$DKMS     KDIR=""
+	$DKMS   fi
+	$DKMS   if [ -n "\$KDIR" ]; then
+	$DKMS     dkms build -m $PKG_NAME -v $PKG_VER --kernelsourcedir "\$KDIR" --rpm_safe_upgrade || true
+	$DKMS     dkms install --force -m $PKG_NAME -v $PKG_VER --kernelsourcedir "\$KDIR" --rpm_safe_upgrade || true
+	$DKMS     echo -e "Creating initramfs for :\$K"
+	$DKMS     if [ -e /boot/vmlinuz-\$K ] && [ -e /sbin/depmod ] && [ -x %{_bindir}/dracut ]; then
+	$DKMS       /sbin/depmod -a "\$K"
+	$DKMS       if [ -e /etc/redhat-release ] || [ -e /etc/fedora-release ]; then
+	$DKMS         %{_bindir}/dracut -f --kver "\$K"
+	$DKMS       else
+	$DKMS         CREATE_INITRD="1"
+	$DKMS       fi
+	$DKMS     else
+	$DKMS       echo -e "Unable to create initramfs for :\$K"
+	$DKMS     fi
+	$DKMS   else
+	$DKMS     echo "SKIP DKMS Installation: kernel headers not available for \$K"
+	$DKMS   fi
+	$DKMS done
+	$DKMS if [ "\$CREATE_INITRD" == "1" ]; then
+	$DKMS   /sbin/mkinitrd
+	$DKMS fi
+
+	%preun
+	$DKMS CREATE_INITRD="0"
+	$DKMS for i in /var/lib/dkms/$PKG_NAME/$PKG_VER/[^a-zA-Z]*; do
+	$DKMS   if [[ \$i = *^* ]]; then continue; fi
+	$DKMS   K=\$(echo \$i | cut -d '/' -f 7)
+	$DKMS   if [ -d /usr/src/kernels/\$K ]; then
+	$DKMS     KDIR=/usr/src/kernels/\$K
+	$DKMS   elif [ -d /lib/modules/\$K/build ]; then
+	$DKMS     KDIR=/lib/modules/\$K/build
+	$DKMS   else
+	$DKMS     KDIR=""
+	$DKMS   fi
+	$DKMS   if [ -n "\$KDIR" ]; then
+	$DKMS     dkms uninstall -m $PKG_NAME -v $PKG_VER --kernelsourcedir "\$KDIR" --rpm_safe_upgrade || true
+	$DKMS   else
+	$DKMS     dkms uninstall -m $PKG_NAME -v $PKG_VER -k \$K --rpm_safe_upgrade || true
+	$DKMS   fi
+	$DKMS   echo -e "Creating initramfs for :\$K"
+	$DKMS   if [ -e /boot/vmlinuz-\$K ] && [ -e /sbin/depmod ] && [ -x %{_bindir}/dracut ]; then
+	$DKMS     /sbin/depmod -a "\$K"
+	$DKMS     if [ -e /etc/redhat-release ] || [ -e /etc/fedora-release ]; then
+	$DKMS       %{_bindir}/dracut -f --kver "\$K"
+	$DKMS     else
+	$DKMS       CREATE_INITRD="1"
+	$DKMS     fi
+	$DKMS   else
+	$DKMS     echo -e "Unable to create initramfs for :\$K"
+	$DKMS   fi
+	$DKMS done
+	$DKMS if [ "\$CREATE_INITRD" == "1" ]; then
+	$DKMS   /sbin/mkinitrd
+	$DKMS fi
+	$DKMS dkms remove -m $PKG_NAME -v $PKG_VER --all --rpm_safe_upgrade || true
+
+	%files
+	$DKMS /usr/src/%{name}-%{version}/
+	$BIN /lib/modules/
+EOF


### PR DESCRIPTION
This commit introduces rpm package generation capability alongside the existing Debian packaging, enabling deployment on RHEL-based distributions using dksm framework.

Changes:
- Add xe-dkms-rpm-pkg target to generate DKMS-enabled RPM packages
- Support for kernel-version-specific package naming
- Automatic version extraction from target kernel headers
- RHEL distro suffix support (e.g., el10_1) e.g. for now
- Support for KLIB and KLIB_BUILD parameters for cross-kernel builds

New files:
- backport/scripts/backport-mkrpmcontrol: Generates RPM spec with DKMS hooks
- backport/scripts/backport-mkxerpmdkms: Generates dkms.conf for module build

Modified files:
- backport/Makefile: Add RPM_PKG_DISTRO_TARGETS, fix BACKPORT_DIR handling
- backport/Makefile.real: Fix BACKPORT_DIR path resolution



Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>