### PR TITLE
Add rpm package support for xe dkms release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,80 @@
+# Check if being called by kernel build system
+ifneq ($(KERNELRELEASE),)
+# Called by kernel build system - descend into src/
+obj-y := src/
+else
+# User/packaging mode
+
+# Version extraction from backport versions file
+BKPT_VER=$(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '"' -f 2 | cut -d '_' -f 3 2>/dev/null || echo 1)
+BP_TAG=$(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '"' -f 2 | cut -d '_' -f 2 2>/dev/null || echo 1)
+BP_DATE=$(shell echo $(BKPT_VER) | cut -d "." -f 1 2>/dev/null || echo 1)
+
+# Get kernel version - from KLIB/KLIB_BUILD headers if provided, else from uname -r
+ifneq ($(origin KLIB), undefined)
+  KLIB_BUILD ?= $(KLIB)/build/
+  TARGET_KERN_VER=$(shell cat $(KLIB_BUILD)/include/generated/autoconf.h 2>/dev/null | grep 'CONFIG_BUILD_SALT' | cut -d '"' -f2 2>/dev/null || cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep "UTS_RELEASE" | cut -d '"' -f2 2>/dev/null || uname -r)
+else ifneq ($(origin KLIB_BUILD), undefined)
+  KLIB ?= $(patsubst %/build,%,$(KLIB_BUILD))
+  TARGET_KERN_VER=$(shell cat $(KLIB_BUILD)/include/generated/autoconf.h 2>/dev/null | grep 'CONFIG_BUILD_SALT' | cut -d '"' -f2 2>/dev/null || cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep "UTS_RELEASE" | cut -d '"' -f2 2>/dev/null || uname -r)
+else
+  KLIB := /lib/modules/$(shell uname -r)/
+  KLIB_BUILD ?= $(KLIB)/build/
+  TARGET_KERN_VER=$(shell uname -r)
+endif
+
+BACKPORT_DIR = src
+CONFIG_SHELL = /bin/bash
+
+# Extract kernel version components
+FULL_KERN_STR=$(shell echo "$(TARGET_KERN_VER)" | sed 's/\.el[0-9]*_[0-9]*\.x86_64//' | sed 's/\.x86_64//' | tr -d '+')
+KER_VER=$(subst -,.,$(FULL_KERN_STR))
+DISTRO_SUFFIX=$(shell echo "$(TARGET_KERN_VER)" | grep -o 'el[0-9]*_[0-9]*' | head -1)
+
+# Package version format: kernel_version.bp_tag.date
+VERSION=$(KER_VER).$(BP_TAG).$(BP_DATE)
+
+XE_PKG_NAME=intel-xe-dkms
+XE_PKG_VERSION=$(VERSION)
+XE_PKG_RELEASE=1
+XE_RPM_MK_SPEC=$(BACKPORT_DIR)/scripts/backport-mkrpmcontrol
+XE_RPM_MK_DKMS=$(BACKPORT_DIR)/scripts/backport-mkxerpmdkms
+
+# Export variables for sub-makes
+export KLIB KLIB_BUILD
+
+.PHONY: all clean xe-dkms-deb-pkg
 all clean xe-dkms-deb-pkg:
 	$(MAKE) -C src $@
 
+.PHONY: modules olddefconfig menuconfig savedefconfig
 modules olddefconfig menuconfig savedefconfig:
-	$(MAKE) -C src KLIB=$(LINUX_OBJ) KLIB_BUILD=$(LINUX_OBJ) $@
+	$(MAKE) -C src KLIB=$(KLIB) KLIB_BUILD=$(KLIB_BUILD) $@
+
+.PHONY: show-version
+show-version:
+	@echo "Target Kernel Version : $(TARGET_KERN_VER)"
+	@echo "Kernel Headers Path   : $(KLIB_BUILD)"
+	@echo "Package Version       : $(XE_PKG_VERSION)"
+	@echo "Package Release       : $(XE_PKG_RELEASE)$(if $(DISTRO_SUFFIX),.$(DISTRO_SUFFIX))"
+	@echo "Expected RPM Name     : $(XE_PKG_NAME)-$(XE_PKG_VERSION)-$(XE_PKG_RELEASE)$(if $(DISTRO_SUFFIX),.$(DISTRO_SUFFIX)).x86_64.rpm"
+
+.PHONY: xe-dkms-rpm-pkg
+xe-dkms-rpm-pkg: clean
+	@echo "========================================"
+	@echo "Building DKMS RPM package"
+	@echo "Target Kernel: $(TARGET_KERN_VER)"
+	@echo "Package version: $(XE_PKG_VERSION)-$(XE_PKG_RELEASE)"
+	@echo "========================================"
+	@echo "Pre-configuring source for DKMS..."
+	@cd src && test -f .config || $(MAKE) defconfig-xe
+	@echo "Pre-generating backport autoconf.h..."
+	@cd src && $(MAKE) backport-include/backport/autoconf.h
+	mkdir -p rpm
+	mkdir -p ~/rpmbuild/SOURCES
+	$(CONFIG_SHELL) $(XE_RPM_MK_SPEC) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r $(XE_PKG_RELEASE) $(if $(DISTRO_SUFFIX),-d $(DISTRO_SUFFIX)) -z dkms > rpm/$(XE_PKG_NAME).spec
+	$(CONFIG_SHELL) $(XE_RPM_MK_DKMS) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r 1 > rpm/$(XE_PKG_NAME).dkms.conf
+	cp -r src m4 debian Makefile* configure* aclocal.m4 AUTHORS ChangeLog COPYING INSTALL NEWS README compile.sh ~/rpmbuild/SOURCES/ 2>/dev/null || true
+	+rpmbuild -bb --define "_sourcedir $(PWD)" rpm/$(XE_PKG_NAME).spec
+
+endif # End of user/packaging mode

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,18 +20,50 @@
 # OSV GENERIC VARIABLES
 #
 
+# Kernel build directory - defaults to running kernel
+KLIB_BUILD ?= /lib/modules/@DOLLAR_SIGN@(shell uname -r)/build
+
 RELEASE=1
 
 # BKPT_VER consist of backported release version.
-# Expected input: 'BACKPORTS_RELEASE_TAG="XE_586_241121.0"'
-# Filtered output: 241121.0
+# Expected input: 'BACKPORTS_RELEASE_TAG="xeb_v6.17.13.43_260317.0"'
+# Filtered output: 260317.0
 BKPT_VER=@DOLLAR_SIGN@(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d "_" -f 5 | cut -d "\"" -f 1 | cut -d "-" -f 1 2>/dev/null || echo 1)
+
+# BP_TAG is the backport tag from versions file  
+# Expected input: 'BACKPORTS_RELEASE_TAG="xeb_v6.17.13.43_260317.0"'
+# Filtered output: v6.17.13.43
+BP_TAG=@DOLLAR_SIGN@(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d "_" -f 2-4 | sed 's/_/-/g' 2>/dev/null || echo 1)
+
+# Extract date portion from BKPT_VER (first 6 digits before any dot)
+# Expected input: 260317.0
+# Filtered output: 260317
+BP_DATE=@DOLLAR_SIGN@(shell echo $(BKPT_VER) | cut -d "." -f 1 2>/dev/null || echo 1)
 
 # DEV_TAG is extracted from BASE_KERNEL_TAG, which is auto genereated from Dev kernel source.
 # Tagging is needed for decoding
 DEV_TAG=@DOLLAR_SIGN@(shell cat src/versions | grep BASE_KERNEL_TAG | cut -f 2 -d "\"" | cut -d "-" -f 3 2>/dev/null || echo 1)
 
-VERSION=0.$(BKPT_VER)
+# Extract kernel version from build system
+UTS_RELEASE=@DOLLAR_SIGN@(shell cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep "UTS_RELEASE" | cut -d "\"" -f 2 | tr -d '~+')
+
+# Base kernel version (X.Y.Z)
+KERN_VER_XYZ=@DOLLAR_SIGN@(shell cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep "UTS_RELEASE" | cut -d '"' -f2 | cut -d '.' -f1-3 | cut -d '-' -f1 | tr -d '+')
+
+# Extract extended version for RHEL/similar (e.g., 124.49.1 from 6.12.0-124.49.1.el10_1.x86_64)
+EXTENDED_VERSION_STR=@DOLLAR_SIGN@(shell cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep UTS_RELEASE | cut -d '"' -f2 | cut -d '-' -f2 | sed 's/\.el.*//' | sed 's/\.x86_64//')
+
+# Construct full kernel version: X.Y.Z-EXT.VER.STR
+BASE_KERNEL_NAME=@DOLLAR_SIGN@(shell test -n "$(EXTENDED_VERSION_STR)" && echo "$(KERN_VER_XYZ)-$(EXTENDED_VERSION_STR)" || echo "$(KERN_VER_XYZ)")
+
+# Kernel version with dots instead of hyphens  
+KER_VER=@DOLLAR_SIGN@(subst -,.,$(BASE_KERNEL_NAME))
+
+# Distro suffix (e.g., el10_1)
+DISTRO_SUFFIX=@DOLLAR_SIGN@(shell cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep UTS_RELEASE | cut -d '"' -f2 | grep -o 'el[0-9]*_[0-9]*' | head -1)
+
+# Package version format: kernel_version-bp_tag-date
+VERSION=$(KER_VER)-$(BP_TAG)-$(BP_DATE)
 
 #------------------------------------------------------------------------------
 #
@@ -75,6 +107,15 @@ XE_DKMS_MK_DKMS=$(BACKPORT_DIR)/scripts/backport-mkxedebdkms
 XE_DKMS_MK_README=$(BACKPORT_DIR)/scripts/backport-mkdebreadme
 XE_DKMS_MK_COPYRIGHT=$(BACKPORT_DIR)/scripts/backport-mkdebcopyright
 
+#------------------------------------------------------------------------------
+#
+# RPM Package Targets
+#
+#------------------------------------------------------------------------------
+
+XE_RPM_MK_SPEC=$(BACKPORT_DIR)/scripts/backport-mkrpmcontrol
+XE_RPM_MK_DKMS=$(BACKPORT_DIR)/scripts/backport-mkxerpmdkms
+
 .PHONY: xe-dkms-deb-pkg
 xe-dkms-deb-pkg: clean
 	$(CONFIG_SHELL) $(XE_DKMS_MK_CONTROL) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r $(XE_PKG_RELEASE) -z dkms > debian/control
@@ -100,6 +141,14 @@ xe-dkms-deb-pkg: clean
 	+dch -l "+i${XE_PKG_RELEASE}-" -m "build ${XE_PKG_RELEASE}"
 	+dpkg-buildpackage -j`nproc --all` -us -uc -b -rfakeroot
 
+.PHONY: xe-dkms-rpm-pkg
+xe-dkms-rpm-pkg: clean
+	mkdir -p rpm
+	mkdir -p ~/rpmbuild/SOURCES
+	$(CONFIG_SHELL) $(XE_RPM_MK_SPEC) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r $(XE_PKG_RELEASE) -d $(DISTRO_SUFFIX) -z dkms > rpm/$(XE_PKG_NAME).spec
+	$(CONFIG_SHELL) $(XE_RPM_MK_DKMS) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r $(XE_PKG_RELEASE) > rpm/$(XE_PKG_NAME).dkms.conf
+	cp -r src m4 debian Makefile* configure* aclocal.m4 AUTHORS ChangeLog COPYING INSTALL NEWS README compile.sh ~/rpmbuild/SOURCES/ 2>/dev/null || true
+	+rpmbuild -bb --define "_sourcedir $(PWD)" rpm/$(XE_PKG_NAME).spec
 
 all clean:
 	$(MAKE) -C src $@
@@ -139,6 +188,9 @@ mrproper:
 	@rm -f debian/$(XE_PKG_NAME_BASENAME)*.install.in
 	@rm -rf debian/$(XE_PKG_NAME_BASENAME)*
 	@rm -f debian/rules
+	@rm -f rpm/$(XE_PKG_NAME).spec
+	@rm -f rpm/$(XE_PKG_NAME).dkms.conf
+	@rm -rf rpm/
 	@rm -f src/dkms.conf
 	@test -f .config && $(MAKE) clean || true
 


### PR DESCRIPTION
Modified files:
- Makefile: Add RPM packaging target with version detection logic
- Makefile.am: Integrate RPM build into automake workflow  

Implemented features:
- Detects target kernel version from headers (CONFIG_BUILD_SALT/UTS_RELEASE)
- Prefers /usr/src/kernels on RHEL, falls back to /lib/modules/*/build
- Uses compile.sh for consistent build process across distributions
- Automatic initramfs update via dracut/mkinitrd in %post/%preun scripts
- Multi-kernel support: builds for all installed kernels automatically
- Passes --kernelsourcedir to DKMS for explicit kernel header paths

Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>