### PR TITLE
drm/i915/psr: Improve async flip handling with Selective Fetch

### DIFF
--- a/backport/patches/features/psr/0001-drm-i915-psr-Perform-full-frame-update-on-async-flip.patch
+++ b/backport/patches/features/psr/0001-drm-i915-psr-Perform-full-frame-update-on-async-flip.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jouni=20H=C3=B6gander?= <jouni.hogander@intel.com>
+Date: Thu, 4 Dec 2025 09:07:17 +0200
+Subject: drm/i915/psr: Perform full frame update on async flip
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+According to bspec selective fetch is not supported with async flips and
+instructing full frame update on async flip.
+
+v4:
+  - check crtc_state->async_flip_planes in
+    psr2_sel_fetch_pipe_state_supported
+v3:
+  - rebase
+  - fix old_crtc_state->pipe_srcsz_early_tpt
+  - fix using intel_atomic_get_new_crtc_state
+v2:
+  - check also crtc_state->async_flip_planes in
+    psr2_sel_fetch_plane_state_supported
+
+Bspec: 55229
+Signed-off-by: Jouni Högander <jouni.hogander@intel.com>
+Reviewed-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Link: https://patch.msgid.link/20251204070718.1090778-3-jouni.hogander@intel.com
+(cherry-picked from commit e540c47fc08e4480118e1f1b68adaf688d172528 xe internal)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/i915/display/intel_psr.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_psr.c b/drivers/gpu/drm/i915/display/intel_psr.c
+index 624f4985ea46..92a470dc2692 100644
+--- a/drivers/gpu/drm/i915/display/intel_psr.c
++++ b/drivers/gpu/drm/i915/display/intel_psr.c
+@@ -2654,7 +2654,8 @@ static bool psr2_sel_fetch_plane_state_supported(const struct intel_plane_state
+  */
+ static bool psr2_sel_fetch_pipe_state_supported(const struct intel_crtc_state *crtc_state)
+ {
+-	if (crtc_state->scaler_state.scaler_id >= 0)
++	if (crtc_state->scaler_state.scaler_id >= 0 ||
++	    crtc_state->async_flip_planes)
+ 		return false;
+ 
+ 	return true;
+-- 
+2.43.0
+

--- a/backport/patches/features/psr/0001-drm-i915-psr-Set-plane-id-bit-in-crtc_state-async_fl.patch
+++ b/backport/patches/features/psr/0001-drm-i915-psr-Set-plane-id-bit-in-crtc_state-async_fl.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jouni=20H=C3=B6gander?= <jouni.hogander@intel.com>
+Date: Thu, 4 Dec 2025 09:07:16 +0200
+Subject: drm/i915/psr: Set plane id bit in
+ crtc_state->async_flip_planes for PSR
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently plane id bit is set in crtc_state->async_flip_planes only when
+async flip toggle workaround is needed. We want to utilize
+crtc_state->async_flip_planes further in Selective Fetch calculation.
+
+v2:
+  - rework if-else if to if-if
+  - added comment updated
+
+Signed-off-by: Jouni Högander <jouni.hogander@intel.com>
+Reviewed-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Link: https://patch.msgid.link/20251204070718.1090778-2-jouni.hogander@intel.com
+(cherry-picked from commit 1f5df537fa7910a6bdc96a7cb73c65fd30e2aab5 xe internal)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/i915/display/intel_plane.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_plane.c b/drivers/gpu/drm/i915/display/intel_plane.c
+index 36fb07471deb..0ba6c1b302d4 100644
+--- a/drivers/gpu/drm/i915/display/intel_plane.c
++++ b/drivers/gpu/drm/i915/display/intel_plane.c
+@@ -640,11 +640,10 @@ static int intel_plane_atomic_calc_changes(const struct intel_crtc_state *old_cr
+ 	    ilk_must_disable_cxsr(new_crtc_state, old_plane_state, new_plane_state))
+ 		new_crtc_state->disable_cxsr = true;
+ 
+-	if (intel_plane_do_async_flip(plane, old_crtc_state, new_crtc_state)) {
++	if (intel_plane_do_async_flip(plane, old_crtc_state, new_crtc_state))
+ 		new_crtc_state->do_async_flip = true;
+-		new_crtc_state->async_flip_planes |= BIT(plane->id);
+-	} else if (plane->need_async_flip_toggle_wa &&
+-		   new_crtc_state->uapi.async_flip) {
++
++	if (new_crtc_state->uapi.async_flip) {
+ 		/*
+ 		 * On platforms with double buffered async flip bit we
+ 		 * set the bit already one frame early during the sync
+@@ -652,6 +651,9 @@ static int intel_plane_atomic_calc_changes(const struct intel_crtc_state *old_cr
+ 		 * hardware will therefore be ready to perform a real
+ 		 * async flip during the next commit, without having
+ 		 * to wait yet another frame for the bit to latch.
++		 *
++		 * async_flip_planes bitmask is also used by selective
++		 * fetch calculation to choose full frame update.
+ 		 */
+ 		new_crtc_state->async_flip_planes |= BIT(plane->id);
+ 	}
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -290,6 +290,9 @@ backport/patches/base/0001-drm-xe-pat-Add-helper-to-query-compression-enable-st.
 backport/patches/base/0001-drm-xe-add-VM_BIND-DECOMPRESS-uapi-flag.patch
 backport/patches/base/0001-drm-xe-add-xe_migrate_resolve-wrapper-and-is_vram_re.patch
 backport/patches/base/0001-drm-xe-implement-VM_BIND-decompression-in-vm_bind_io.patch
+# features/psr
+backport/patches/features/psr/0001-drm-i915-psr-Set-plane-id-bit-in-crtc_state-async_fl.patch
+backport/patches/features/psr/0001-drm-i915-psr-Perform-full-frame-update-on-async-flip.patch
 # fixes
 backport/patches/fixes/base/0001-drm-me-gsc-mei-interrupt-top-half-should-be-in-irq-d.patch
 backport/patches/fixes/base/0001-drm-xe-Adjust-long-running-workload-timeslices-to-re.patch


### PR DESCRIPTION
Track async flip planes in crtc_state->async_flip_planes and use it in
Selective Fetch handling. Since Selective Fetch is not supported with
async flips, force full frame updates when async flip is detected.

With full updates and proper vblank handling in place, allow async flip
even when Selective Fetch is enabled.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>