### PR TITLE
drm/xe: Fix misapplied remap prev/next unwind patch on v6.17

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-always-keep-track-of-remap-prev-next.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-always-keep-track-of-remap-prev-next.patch
@@ -126,7 +126,7 @@ index 8376b4b7d..26f485e97 100644
  				       fence, fence2, false);
  		break;
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index 706549def..fa616f78b 100644
+index 706549def..be2f30034 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
 @@ -2674,7 +2674,6 @@ static int xe_vma_op_commit(struct xe_vm *vm, struct xe_vma_op *op)
@@ -162,7 +162,7 @@ index 706549def..fa616f78b 100644
  
  			flags |= op->base.remap.unmap->va->flags &
  				XE_VMA_READ_ONLY ?
-@@ -2914,8 +2917,19 @@ static void xe_vma_op_unwind(struct xe_vm *vm, struct xe_vma_op *op,
+@@ -2935,8 +2938,19 @@ static void xe_vma_op_unwind(struct xe_vm *vm, struct xe_vma_op *op,
  			down_read(&vm->userptr.notifier_lock);
  			vma->gpuva.flags &= ~XE_VMA_DESTROYED;
  			up_read(&vm->userptr.notifier_lock);


### PR DESCRIPTION
The backport of commit aec6969f75af ("drm/xe: always keep track of
remap prev/next") incorrectly placed the old_start/old_range VA
range restoration block in the DRM_GPUVA_OP_UNMAP case of
xe_vma_op_unwind() instead of the DRM_GPUVA_OP_REMAP case.

The patch hunk lacked sufficient context to uniquely identify the
target location. The context lines (down_read/vma->gpuva.flags/
up_read/if (post_commit)) appear identically in both the UNMAP and
REMAP switch cases, causing git apply to match the first occurrence
(UNMAP).

In the UNMAP case, op->base.remap.unmap is NULL (wrong union member),
leading to a NULL pointer dereference:

  BUG: kernel NULL pointer dereference, address: 0000000000000000
  RIP: 0010:xe_vma_op_unwind+0x1d8/0x2a0 [xe]

Seen as igt@xe_vm@bind-array-conflict-error-inject abort on
v6.17.13-lgci-xe-xkb-6.17-254.

Fix by moving the restoration block to the correct DRM_GPUVA_OP_REMAP
case and update the patch file hunk to use xe_vma_destroy_unlocked()
as unique context, which only exists in the REMAP case.

Fixes: 0e50af3b6aa7 ("drm/xe: Backport upstream fixes set 6 on v6.17")

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>