### PR TITLE
drm/xe/guc: Exclude indirect ring state page from ADS size

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-guc-Exclude-indirect-ring-state-page-from-ADS.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-guc-Exclude-indirect-ring-state-page-from-ADS.patch
@@ -1,0 +1,139 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Date: Mon, 4 May 2026 09:49:26 +0000
+Subject: drm/xe/guc: Exclude indirect ring state page from ADS engine
+ state size
+
+The engine state size reported to GuC via ADS should only include the
+engine state portion and should not include the indirect ring state page
+that comes after it in the context image. The GuC uses this size to
+overwrite the engine state in the LRC on watchdog resets and we don't
+want it to overwrite the indirect ring state as well.
+
+Fixes: d6219e1cd5e3 ("drm/xe: Add Indirect Ring State support")
+Suggested-by: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Signed-off-by: Satyanarayana K V P <satyanarayana.k.v.p@intel.com>
+Cc: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Signed-off-by: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Link: https://patch.msgid.link/20260504094924.3760713-4-satyanarayana.k.v.p@intel.com
+(backported from commit 3ec5f003f6c377beda8bd5438941f5a7795e1848 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc_ads.c |  5 +----
+ drivers/gpu/drm/xe/xe_lrc.c     | 36 +++++++++++++++++++++++++--------
+ drivers/gpu/drm/xe/xe_lrc.h     |  3 ++-
+ 3 files changed, 31 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
+index 8688a74f2..32cadd0db 100644
+--- a/drivers/gpu/drm/xe/xe_guc_ads.c
++++ b/drivers/gpu/drm/xe/xe_guc_ads.c
+@@ -568,12 +568,9 @@ static void guc_golden_lrc_init(struct xe_guc_ads *ads)
+ 		 * that starts after the execlists LRC registers. This is
+ 		 * required to allow the GuC to restore just the engine state
+ 		 * when a watchdog reset occurs.
+-		 * We calculate the engine state size by removing the size of
+-		 * what comes before it in the context image (which is identical
+-		 * on all engines).
+ 		 */
+ 		ads_blob_write(ads, ads.eng_state_size[guc_class],
+-			       real_size - xe_lrc_skip_size(xe));
++			       xe_lrc_engine_state_size(gt, class));
+ 		ads_blob_write(ads, ads.golden_context_lrca[guc_class],
+ 			       addr_ggtt);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_lrc.c b/drivers/gpu/drm/xe/xe_lrc.c
+index 383c22bab..3ccc6ef99 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.c
++++ b/drivers/gpu/drm/xe/xe_lrc.c
+@@ -83,13 +83,19 @@ gt_engine_needs_indirect_ctx(struct xe_gt *gt, enum xe_engine_class class)
+ 	return false;
+ }
+ 
+-size_t xe_gt_lrc_size(struct xe_gt *gt, enum xe_engine_class class)
++/**
++ * xe_gt_lrc_hang_replay_size() - Hang replay size
++ * @gt: The GT
++ * @class: Hardware engine class
++ *
++ * Determine size of GPU hang replay state for a GT and hardware engine class.
++ *
++ * Return: Size of GPU hang replay size
++ */
++size_t xe_gt_lrc_hang_replay_size(struct xe_gt *gt, enum xe_engine_class class)
+ {
+ 	struct xe_device *xe = gt_to_xe(gt);
+-	size_t size;
+-
+-	/* Per-process HW status page (PPHWSP) */
+-	size = LRC_PPHWSP_SIZE;
++	size_t size = 0;
+ 
+ 	/* Engine context image */
+ 	switch (class) {
+@@ -115,11 +121,18 @@ size_t xe_gt_lrc_size(struct xe_gt *gt, enum xe_engine_class class)
+ 		size += 1 * SZ_4K;
+ 	}
+ 
++	return size;
++}
++
++size_t xe_gt_lrc_size(struct xe_gt *gt, enum xe_engine_class class)
++{
++	size_t size = xe_gt_lrc_hang_replay_size(gt, class);
++
+ 	/* Add indirect ring state page */
+ 	if (xe_gt_has_indirect_ring_state(gt))
+ 		size += LRC_INDIRECT_RING_STATE_SIZE;
+ 
+-	return size;
++	return size + LRC_PPHWSP_SIZE;
+ }
+ 
+ /*
+@@ -710,9 +723,16 @@ size_t xe_lrc_reg_size(struct xe_device *xe)
+ 		return 80 * sizeof(u32);
+ }
+ 
+-size_t xe_lrc_skip_size(struct xe_device *xe)
++/**
++ * xe_lrc_engine_state_size() - Get size of the engine state within LRC
++ * @gt: the &xe_gt struct instance
++ * @class: Hardware engine class
++ *
++ * Returns: Size of the engine state
++ */
++size_t xe_lrc_engine_state_size(struct xe_gt *gt, enum xe_engine_class class)
+ {
+-	return LRC_PPHWSP_SIZE + xe_lrc_reg_size(xe);
++	return xe_gt_lrc_hang_replay_size(gt, class) - xe_lrc_reg_size(gt_to_xe(gt));
+ }
+ 
+ static inline u32 __xe_lrc_seqno_offset(struct xe_lrc *lrc)
+diff --git a/drivers/gpu/drm/xe/xe_lrc.h b/drivers/gpu/drm/xe/xe_lrc.h
+index 96ae31df3..d937e3b5f 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.h
++++ b/drivers/gpu/drm/xe/xe_lrc.h
+@@ -87,6 +87,7 @@ static inline size_t xe_lrc_ring_size(void)
+ 	return SZ_16K;
+ }
+ 
++size_t xe_gt_lrc_hang_replay_size(struct xe_gt *gt, enum xe_engine_class class);
+ size_t xe_gt_lrc_size(struct xe_gt *gt, enum xe_engine_class class);
+ u32 xe_lrc_pphwsp_offset(struct xe_lrc *lrc);
+ u32 xe_lrc_regs_offset(struct xe_lrc *lrc);
+@@ -126,7 +127,7 @@ u32 xe_lrc_parallel_ggtt_addr(struct xe_lrc *lrc);
+ struct iosys_map xe_lrc_parallel_map(struct xe_lrc *lrc);
+ 
+ size_t xe_lrc_reg_size(struct xe_device *xe);
+-size_t xe_lrc_skip_size(struct xe_device *xe);
++size_t xe_lrc_engine_state_size(struct xe_gt *gt, enum xe_engine_class class);
+ 
+ void xe_lrc_dump_default(struct drm_printer *p,
+ 			 struct xe_gt *gt,
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -378,6 +378,7 @@ backport/patches/fixes/sriov/0001-drm-xe-pf-Fix-MMIO-access-using-PF-view-instea
 backport/patches/fixes/base/0001-drm-xe-dma-buf-handle-empty-bo-and-UAF-races.patch
 backport/patches/fixes/base/0001-drm-xe-dma-buf-fix-UAF-with-retry-loop.patch
 backport/patches/fixes/base/0001-drm-xe-Make-decision-to-use-Xe2-style-blitter-instru.patch
+backport/patches/fixes/base/0001-drm-xe-guc-Exclude-indirect-ring-state-page-from-ADS.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
The ADS engine state size should only include the engine state and not
the indirect ring state page appended in the context image.

GuC uses this size during watchdog reset restore, so including the
indirect ring state page may overwrite its contents.

Fixes: d6219e1cd5e3 ("drm/xe: Add Indirect Ring State support")

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>