### PR TITLE
drm/xe/dma-buf: Handle empty BO and UAF races during import

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-dma-buf-fix-UAF-with-retry-loop.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-dma-buf-fix-UAF-with-retry-loop.patch
@@ -1,0 +1,139 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Auld <matthew.auld@intel.com>
+Date: Fri, 8 May 2026 11:26:37 +0100
+Subject: drm/xe/dma-buf: fix UAF with retry loop
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Retry doesn't work here, since bo will be freed on error, leading to
+UAF. However, now that we do the alloc & init before the attach, we can
+now combine this as one unit and have the init do the alloc for us. This
+should make the retry safe.
+
+Reported by Sashiko.
+
+v2: Fix up the error unwind (CI)
+
+Closes: https://sashiko.dev/#/patchset/20260506184332.86743-2-matthew.auld%40intel.com
+Fixes: eb289a5f6cc6 ("drm/xe: Convert xe_dma_buf.c for exhaustive eviction")
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Cc: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: <stable@vger.kernel.org> # v6.18+
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patch.msgid.link/20260508102635.149172-4-matthew.auld@intel.com
+(backported from commit 479669418253e0f27f8cf5db01a731352ea592e7 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_dma_buf.c | 49 ++++++++-------------------------
+ 1 file changed, 12 insertions(+), 37 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_dma_buf.c b/drivers/gpu/drm/xe/xe_dma_buf.c
+index aaa1bc0bb..fe35b7bd1 100644
+--- a/drivers/gpu/drm/xe/xe_dma_buf.c
++++ b/drivers/gpu/drm/xe/xe_dma_buf.c
+@@ -226,16 +226,8 @@ struct dma_buf *xe_gem_prime_export(struct drm_gem_object *obj, int flags)
+ 	return buf;
+ }
+ 
+-/*
+- * Takes ownership of @storage: on success it is transferred to the returned
+- * drm_gem_object; on failure it is freed before returning the error.
+- * This matches the contract of xe_bo_init_locked() which frees @storage on
+- * its error paths, so callers need not (and must not) free @storage after
+- * this call.
+- */
+ static struct drm_gem_object *
+-xe_dma_buf_init_obj(struct drm_device *dev, struct xe_bo *storage,
+-		    struct dma_buf *dma_buf)
++xe_dma_buf_create_obj(struct drm_device *dev, struct dma_buf *dma_buf)
+ {
+ 	struct dma_resv *resv = dma_buf->resv;
+ 	struct xe_device *xe = to_xe_device(dev);
+@@ -246,10 +238,8 @@ xe_dma_buf_init_obj(struct drm_device *dev, struct xe_bo *storage,
+ 	int ret = 0;
+ 
+ 	dummy_obj = drm_gpuvm_resv_object_alloc(&xe->drm);
+-	if (!dummy_obj) {
+-		xe_bo_free(storage);
++	if (!dummy_obj)
+ 		return ERR_PTR(-ENOMEM);
+-	}
+ 
+ 	dummy_obj->resv = resv;
+ 	xe_validation_guard(&ctx, &xe->val, &exec, (struct xe_val_flags) {}, ret) {
+@@ -258,8 +248,7 @@ xe_dma_buf_init_obj(struct drm_device *dev, struct xe_bo *storage,
+ 		if (ret)
+ 			break;
+ 
+-		/* xe_bo_init_locked() frees storage on error */
+-		bo = xe_bo_init_locked(xe, storage, NULL, resv, NULL, dma_buf->size,
++		bo = xe_bo_init_locked(xe, NULL, NULL, resv, NULL, dma_buf->size,
+ 				       0, /* Will require 1way or 2way for vm_bind */
+ 				       ttm_bo_type_sg, XE_BO_FLAG_SYSTEM, &exec);
+ 		drm_exec_retry_on_contention(&exec);
+@@ -310,7 +299,6 @@ struct drm_gem_object *xe_gem_prime_import(struct drm_device *dev,
+ 	const struct dma_buf_attach_ops *attach_ops;
+ 	struct dma_buf_attachment *attach;
+ 	struct drm_gem_object *obj;
+-	struct xe_bo *bo;
+ 
+ 	if (dma_buf->ops == &xe_dmabuf_ops) {
+ 		obj = dma_buf->priv;
+@@ -325,22 +313,14 @@ struct drm_gem_object *xe_gem_prime_import(struct drm_device *dev,
+ 		}
+ 	}
+ 
+-	bo = xe_bo_alloc();
+-	if (IS_ERR(bo))
+-		return ERR_CAST(bo);
+-
+ 	/*
+-	 * xe_dma_buf_init_obj() takes ownership of the raw bo, so do not touch
+-	 * on fail, since it will already take care of cleanup. On success we
+-	 * still need to drop the ref, if something later fails.
+-	 *
+-	 * In addition this needs to happen before the attach, since
+-	 * it will create a new attachment for this, and add it to the list of
+-	 * attachments, at which point it is globally visible, and at any point
+-	 * the export side can call into on invalidate_mappings callback, which
+-	 * require a working object.
++	 * This needs to happen before the attach, since it will create a new
++	 * attachment for this, and add it to the list of attachments, at which
++	 * point it is globally visible, and at any point the export side can
++	 * call into on invalidate_mappings callback, which require a working
++	 * object.
+ 	 */
+-	obj = xe_dma_buf_init_obj(dev, bo, dma_buf);
++	obj = xe_dma_buf_create_obj(dev, dma_buf);
+ 	if (IS_ERR(obj))
+ 		return obj;
+ 
+@@ -350,20 +330,15 @@ struct drm_gem_object *xe_gem_prime_import(struct drm_device *dev,
+ 		attach_ops = test->attach_ops;
+ #endif
+ 
+-	attach = dma_buf_dynamic_attach(dma_buf, dev->dev, attach_ops, &bo->ttm.base);
++	attach = dma_buf_dynamic_attach(dma_buf, dev->dev, attach_ops, obj);
+ 	if (IS_ERR(attach)) {
+-		obj = ERR_CAST(attach);
+-		goto out_err;
++		xe_bo_put(gem_to_xe_bo(obj));
++		return ERR_CAST(attach);
+ 	}
+ 
+ 	get_dma_buf(dma_buf);
+ 	obj->import_attach = attach;
+ 	return obj;
+-
+-out_err:
+-	xe_bo_put(bo);
+-
+-	return obj;
+ }
+ 
+ #if IS_ENABLED(CONFIG_DRM_XE_KUNIT_TEST)
+-- 
+2.43.0
+

--- a/backport/patches/fixes/base/0001-drm-xe-dma-buf-handle-empty-bo-and-UAF-races.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-dma-buf-handle-empty-bo-and-UAF-races.patch
@@ -1,0 +1,117 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Auld <matthew.auld@intel.com>
+Date: Fri, 8 May 2026 11:26:36 +0100
+Subject: drm/xe/dma-buf: handle empty bo and UAF races
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+There look to be some nasty races here when triggering the
+invalidate_mappings hook:
+
+1) We do xe_bo_alloc() followed by the attach, before the actual full bo
+   init step in xe_dma_buf_init_obj(). However the bo is visible on the
+   attachments list after the attach.  This is bad since exporter driver,
+   say amdgpu, can at any time call back into our invalidate_mappings hook,
+   with an empty/bogus bo, leading to potential bugs/crashes.
+
+2) Similar to 1) but here we get a UAF, when the invalidate_mappings
+   hook is triggered. For example, we get as far as xe_bo_init_locked()
+   but this fails in some way. But here the bo will be freed on error, but
+   we still have it attached from dma-buf pov, so if the
+   invalidate_mappings is now triggered then the bo we access is gone and
+   we trigger UAF and more bugs/crashes.
+
+To fix this, move the attach step until after we actually have a fully
+set up buffer object. Note that the bo is not published to userspace
+until later, so not sure what the comment "Don't publish the bo
+until we have a valid attachment", is referring to.
+
+We have at least two different customers reporting hitting a NULL ptr
+deref in evict_flags when importing something from amdgpu, followed by
+triggering the evict flow. Hit rate is also pretty low, which would
+hint at some kind of race, so something like 1) or 2) might explain
+this.
+
+v2:
+  - Shuffle the order of the ops slightly (no functional change)
+  - Improve the comment to better explain the ordering (Matt B)
+
+Assisted-by: Gemini:gemini-3 #debug
+Link: https://gitlab.freedesktop.org/drm/xe/kernel/-/work_items/7903
+Link: https://gitlab.freedesktop.org/drm/xe/kernel/-/work_items/4055
+Fixes: dd08ebf6c352 ("drm/xe: Introduce a new DRM driver for Intel GPUs")
+Signed-off-by: Matthew Auld <matthew.auld@intel.com>
+Cc: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: <stable@vger.kernel.org> # v6.8+
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Acked-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Link: https://patch.msgid.link/20260508102635.149172-3-matthew.auld@intel.com
+(cherry-picked from commit af1f2ad0c59fe4e2f924c526f66e968289d77971 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_dma_buf.c | 31 ++++++++++++++++---------------
+ 1 file changed, 16 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_dma_buf.c b/drivers/gpu/drm/xe/xe_dma_buf.c
+index 855d32ba314d..f7b47e9d1a4c 100644
+--- a/drivers/gpu/drm/xe/xe_dma_buf.c
++++ b/drivers/gpu/drm/xe/xe_dma_buf.c
+@@ -377,15 +377,25 @@ struct drm_gem_object *xe_gem_prime_import(struct drm_device *dev,
+ 		}
+ 	}
+ 
+-	/*
+-	 * Don't publish the bo until we have a valid attachment, and a
+-	 * valid attachment needs the bo address. So pre-create a bo before
+-	 * creating the attachment and publish.
+-	 */
+ 	bo = xe_bo_alloc();
+ 	if (IS_ERR(bo))
+ 		return ERR_CAST(bo);
+ 
++	/*
++	 * xe_dma_buf_init_obj() takes ownership of the raw bo, so do not touch
++	 * on fail, since it will already take care of cleanup. On success we
++	 * still need to drop the ref, if something later fails.
++	 *
++	 * In addition this needs to happen before the attach, since
++	 * it will create a new attachment for this, and add it to the list of
++	 * attachments, at which point it is globally visible, and at any point
++	 * the export side can call into on invalidate_mappings callback, which
++	 * require a working object.
++	 */
++	obj = xe_dma_buf_init_obj(dev, bo, dma_buf);
++	if (IS_ERR(obj))
++		return obj;
++
+ 	attach_ops = &xe_dma_buf_attach_ops;
+ #if IS_ENABLED(CONFIG_DRM_XE_KUNIT_TEST)
+ 	if (test)
+@@ -398,21 +408,12 @@ struct drm_gem_object *xe_gem_prime_import(struct drm_device *dev,
+ 		goto out_err;
+ 	}
+ 
+-	/*
+-	 * xe_dma_buf_init_obj() takes ownership of bo on both success
+-	 * and failure, so we must not touch bo after this call.
+-	 */
+-	obj = xe_dma_buf_init_obj(dev, bo, dma_buf);
+-	if (IS_ERR(obj)) {
+-		dma_buf_detach(dma_buf, attach);
+-		return obj;
+-	}
+ 	get_dma_buf(dma_buf);
+ 	obj->import_attach = attach;
+ 	return obj;
+ 
+ out_err:
+-	xe_bo_free(bo);
++	xe_bo_put(bo);
+ 
+ 	return obj;
+ }
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -371,6 +371,8 @@ backport/patches/fixes/base/0001-drm-xe-uapi-Reject-coh_none-PAT-index-for-CPU_A
 backport/patches/fixes/base/0001-drm-xe-hdcp-Add-NULL-check-for-media_gt-in-intel_hdc.patch
 backport/patches/fixes/base/0001-drm-xe-pf-Fix-EAGAIN-sign-in-pf_migration_consume.patch
 backport/patches/fixes/sriov/0001-drm-xe-pf-Fix-MMIO-access-using-PF-view-instead-of-V.patch
+backport/patches/fixes/base/0001-drm-xe-dma-buf-handle-empty-bo-and-UAF-races.patch
+backport/patches/fixes/base/0001-drm-xe-dma-buf-fix-UAF-with-retry-loop.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
When importing dma-bufs, the BO was attached to the dma-buf before the
object was fully initialized. This exposed partially initialized or even
freed BOs through the invalidate_mappings callback path.

Two race conditions could occur:

The exporter driver may trigger invalidate_mappings immediately after
the attach step, while the BO is still uninitialized, leading to
accesses to an empty or bogus BO.
If BO initialization later fails, the BO is freed while the dma-buf
attachment still exists. A subsequent invalidate_mappings callback may
then access the freed BO, resulting in a UAF.

Fix this by moving the dma-buf attach step until after the BO has been
fully initialized and is safe to expose through dma-buf callbacks.

This is suspected to fix rare NULL pointer dereferences observed during
eviction flows when importing buffers from amdgpu.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>