### PR TITLE
autotools: fix deb package versioning for xe-dkms releases

### DIFF
--- a/autotools/Makefile
+++ b/autotools/Makefile
@@ -7,17 +7,19 @@ else
 
 # Version extraction from backport versions file
 # Extract value after = and remove quotes, then split by _
-BKPT_VER=$(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '=' -f 2 | tr -d '"' | cut -d '_' -f 3 2>/dev/null || echo 1)
+# Strips git hash suffix (e.g., -7-gb27e38cc6) from the release version field
+BKPT_VER=$(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '=' -f 2 | tr -d '"' | cut -d '_' -f 3 | cut -d '-' -f 1 2>/dev/null || echo 1)
 BP_TAG=$(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '=' -f 2 | tr -d '"' | cut -d '_' -f 2 2>/dev/null || echo 1)
 BP_DATE=$(shell echo $(BKPT_VER) | cut -d "." -f 1 2>/dev/null || echo 1)
 
-# Get kernel version - from KLIB/KLIB_BUILD headers if provided, else from uname -r
+# Get kernel version - from utsrelease.h or uname -r fallback.
+# '^#define UTS_RELEASE ' avoids matching UTS_UBUNTU_RELEASE_ABI lines.
 ifneq ($(origin KLIB), undefined)
   KLIB_BUILD ?= $(KLIB)/build/
-  TARGET_KERN_VER=$(shell cat $(KLIB_BUILD)/include/generated/autoconf.h 2>/dev/null | grep 'CONFIG_BUILD_SALT' | cut -d '"' -f2 2>/dev/null || cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep "UTS_RELEASE" | cut -d '"' -f2 2>/dev/null || uname -r)
+  TARGET_KERN_VER=$(shell cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep '^#define UTS_RELEASE ' | cut -d '"' -f2 || uname -r)
 else ifneq ($(origin KLIB_BUILD), undefined)
   KLIB ?= $(patsubst %/build,%,$(KLIB_BUILD))
-  TARGET_KERN_VER=$(shell cat $(KLIB_BUILD)/include/generated/autoconf.h 2>/dev/null | grep 'CONFIG_BUILD_SALT' | cut -d '"' -f2 2>/dev/null || cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep "UTS_RELEASE" | cut -d '"' -f2 2>/dev/null || uname -r)
+  TARGET_KERN_VER=$(shell cat $(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep '^#define UTS_RELEASE ' | cut -d '"' -f2 || uname -r)
 else
   KLIB := /lib/modules/$(shell uname -r)/
   KLIB_BUILD ?= $(KLIB)/build/
@@ -28,7 +30,7 @@ BACKPORT_DIR = src
 CONFIG_SHELL = /bin/bash
 
 # Extract kernel version components
-FULL_KERN_STR=$(shell echo "$(TARGET_KERN_VER)" | sed 's/\.el[0-9]*_[0-9]*\.x86_64//' | sed 's/\.x86_64//' | tr -d '+')
+FULL_KERN_STR=$(shell echo "$(TARGET_KERN_VER)" | sed 's/\.el[0-9]*_[0-9]*\.x86_64//' | sed 's/\.x86_64//' | sed 's/-[a-zA-Z].*//' | tr -d '+')
 KER_VER=$(subst -,.,$(FULL_KERN_STR))
 DISTRO_SUFFIX=$(shell echo "$(TARGET_KERN_VER)" | grep -oE 'el(9|10)_[0-9]+' | head -1)
 
@@ -48,11 +50,26 @@ XE_PKG_RELEASE=$(RELEASE_VERSION)_1
 XE_RPM_MK_SPEC=$(BACKPORT_DIR)/scripts/backport-mkdrmdkmsspec
 XE_RPM_MK_DKMS=$(BACKPORT_DIR)/scripts/backport-mkdrmdkmsconf
 
+# DEB package version: <KER_VER>-<DEV_TAG>.<BKPT_VER> e.g. intel-xe-dkms_6.12.0.124.8.1-6.17.13.49.260409.4+i1-1_all.deb
+XE_DEB_PKG_VERSION=$(KER_VER)-$(DEV_TAG).$(BKPT_VER)
+XE_DEB_PKG_RELEASE=1
+DEF_VER=$(shell cat debian/changelog.in | head -1 | cut -d '(' -f 2 | cut -d ')' -f 1)
+XE_DKMS_MK_CONTROL=$(BACKPORT_DIR)/scripts/backport-mkdebcontrol
+XE_DKMS_MK_RULES=$(BACKPORT_DIR)/scripts/backport-mkdebrules
+XE_DKMS_MK_DKMS=$(BACKPORT_DIR)/scripts/backport-mkxedebdkms
+XE_DKMS_MK_README=$(BACKPORT_DIR)/scripts/backport-mkdebreadme
+XE_DKMS_MK_COPYRIGHT=$(BACKPORT_DIR)/scripts/backport-mkdebcopyright
+KBUILD_ONLYXEDIRS := src/drivers/gpu src/include src/scripts src/drivers/platform src/drivers/mtd
+KBUILD_XEVFIOPCIDIRS := src/drivers/vfio/pci/xe
+KBUILD_AUTOTOOLS := m4 AUTHORS ChangeLog configure.ac COPYING INSTALL Makefile Makefile.am NEWS README.md compile.sh
+XE_TAR_CONTENT=$(KBUILD_ONLYXEDIRS) $(KBUILD_AUTOTOOLS) $(KBUILD_XEVFIOPCIDIRS) src/Makefile* src/local-symbols src/MAINTAINERS src/local-symbols-autoconf \
+	src/Kconfig src/Kconfig.sources src/Kconfig.package.hacks src/COPYING src/versions src/defconfigs src/backport-include src/kconf src/compat
+
 # Export variables for sub-makes
 export KLIB KLIB_BUILD
 
-.PHONY: all clean xe-dkms-deb-pkg
-all clean xe-dkms-deb-pkg:
+.PHONY: all clean
+all clean:
 	$(MAKE) -C src $@
 
 .PHONY: modules olddefconfig menuconfig savedefconfig
@@ -63,9 +80,11 @@ modules olddefconfig menuconfig savedefconfig:
 show-version:
 	@echo "Target Kernel Version : $(TARGET_KERN_VER)"
 	@echo "Kernel Headers Path   : $(KLIB_BUILD)"
-	@echo "Package Version       : $(XE_PKG_VERSION)"
-	@echo "Package Release       : $(XE_PKG_RELEASE)$(if $(DISTRO_SUFFIX),.$(DISTRO_SUFFIX))"
+	@echo "Package Version (RPM) : $(XE_PKG_VERSION)"
+	@echo "Package Release (RPM) : $(XE_PKG_RELEASE)$(if $(DISTRO_SUFFIX),.$(DISTRO_SUFFIX))"
 	@echo "Expected RPM Name     : $(XE_PKG_NAME)-$(XE_PKG_VERSION)-$(XE_PKG_RELEASE)$(if $(DISTRO_SUFFIX),.$(DISTRO_SUFFIX)).x86_64.rpm"
+	@echo "Package Version (DEB) : $(XE_DEB_PKG_VERSION)"
+	@echo "Expected DEB Name     : $(XE_PKG_NAME)_$(XE_DEB_PKG_VERSION)+i$(XE_DEB_PKG_RELEASE)-1_all.deb"
 
 .PHONY: xe-dkms-rpm-pkg
 xe-dkms-rpm-pkg: clean
@@ -84,5 +103,35 @@ xe-dkms-rpm-pkg: clean
 	$(CONFIG_SHELL) $(XE_RPM_MK_DKMS) -n $(XE_PKG_NAME) -v $(XE_PKG_VERSION) -r $(XE_PKG_RELEASE) > rpm/$(XE_PKG_NAME).dkms.conf
 	cp -r src m4 debian Makefile* configure* aclocal.m4 AUTHORS ChangeLog COPYING INSTALL NEWS README compile.sh ~/rpmbuild/SOURCES/ 2>/dev/null || true
 	+rpmbuild -bb --define "_sourcedir $(PWD)" rpm/$(XE_PKG_NAME).spec
+
+.PHONY: xe-dkms-deb-pkg
+xe-dkms-deb-pkg: clean
+	@echo "========================================"
+	@echo "Building DKMS DEB package"
+	@echo "Target Kernel: $(TARGET_KERN_VER)"
+	@echo "Package version: $(XE_DEB_PKG_VERSION)-$(XE_DEB_PKG_RELEASE)"
+	@echo "========================================"
+	$(CONFIG_SHELL) $(XE_DKMS_MK_CONTROL) -n $(XE_PKG_NAME) -v $(XE_DEB_PKG_VERSION) -r $(XE_DEB_PKG_RELEASE) -z dkms > debian/control
+	$(CONFIG_SHELL) $(XE_DKMS_MK_RULES) -n $(XE_PKG_NAME) -v $(XE_DEB_PKG_VERSION) -r $(XE_DEB_PKG_RELEASE) -z dkms > debian/rules
+	cp debian/changelog.in debian/changelog
+	sed -i 's/pkg-name/$(XE_PKG_NAME)/g' debian/changelog
+	sed -i 's/$(DEF_VER)/$(XE_DEB_PKG_VERSION)/g' debian/changelog
+	for i in $(XE_TAR_CONTENT); do \
+		z=$$(expr index $$i "="); \
+		if [ $$z = 0 ]; then \
+			x=$$(expr index $$i "/"); \
+			if [ $$x != 0 ]; then \
+				y=`dirname $$i`; \
+				echo "$$i /usr/src/@BACKPORT_PACKAGE_NAME@-@BACKPORT_PACKAGE_VERSION@/$$y"; \
+			else \
+				echo "$$i /usr/src/@BACKPORT_PACKAGE_NAME@-@BACKPORT_PACKAGE_VERSION@"; \
+			fi \
+		fi \
+	done > debian/$(XE_PKG_NAME).install.in
+	$(CONFIG_SHELL) $(XE_DKMS_MK_DKMS) -n $(XE_PKG_NAME) -v $(XE_DEB_PKG_VERSION) -r $(XE_DEB_PKG_RELEASE) > debian/$(XE_PKG_NAME).dkms.in
+	$(CONFIG_SHELL) $(XE_DKMS_MK_README) -n $(XE_PKG_NAME) -v $(XE_DEB_PKG_VERSION) -r $(XE_DEB_PKG_RELEASE) > debian/README.Debian
+	$(CONFIG_SHELL) $(XE_DKMS_MK_COPYRIGHT) -n $(XE_PKG_NAME) -v $(XE_DEB_PKG_VERSION) -r $(XE_DEB_PKG_RELEASE) > debian/copyright
+	+dch -l "+i${XE_DEB_PKG_RELEASE}-" -m "build ${XE_DEB_PKG_RELEASE}"
+	+dpkg-buildpackage -j`nproc --all` -us -uc -b -rfakeroot
 
 endif # End of user/packaging mode

--- a/autotools/Makefile.am
+++ b/autotools/Makefile.am
@@ -25,17 +25,16 @@ KLIB_BUILD ?= /lib/modules/@DOLLAR_SIGN@(shell uname -r)/build
 
 RELEASE=1
 
-# Extract kernel version from running kernel or KLIB_BUILD
-# Try CONFIG_BUILD_SALT first (has full version like 6.12.0-124.49.1.el10_1.x86_64)
-# Fall back to UTS_RELEASE if not found, then uname -r
-TARGET_KERN_VER=@DOLLAR_SIGN@(shell cat @DOLLAR_SIGN@(KLIB_BUILD)/include/generated/autoconf.h 2>/dev/null | grep 'CONFIG_BUILD_SALT' | cut -d '"' -f2 2>/dev/null || cat @DOLLAR_SIGN@(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep UTS_RELEASE | cut -d '"' -f2 || uname -r)
-FULL_KERN_STR=@DOLLAR_SIGN@(shell echo "@DOLLAR_SIGN@(TARGET_KERN_VER)" | sed 's/\.el[0-9]*_[0-9]*\.x86_64//' | sed 's/\.x86_64//' | tr -d '+')
+# Extract kernel version from utsrelease.h
+# Uses precise '^#define UTS_RELEASE ' pattern to avoid matching UTS_UBUNTU_RELEASE_ABI.
+# Falls back to uname -r if headers are not available.
+TARGET_KERN_VER=@DOLLAR_SIGN@(shell cat @DOLLAR_SIGN@(KLIB_BUILD)/include/generated/utsrelease.h 2>/dev/null | grep '^#define UTS_RELEASE ' | cut -d '"' -f2 || uname -r)
+FULL_KERN_STR=@DOLLAR_SIGN@(shell echo "@DOLLAR_SIGN@(TARGET_KERN_VER)" | sed 's/\.el[0-9]*_[0-9]*\.x86_64//' | sed 's/\.x86_64//' | sed 's/-[a-zA-Z].*//' | tr -d '+')
 KER_VER=@DOLLAR_SIGN@(subst -,.,@DOLLAR_SIGN@(FULL_KERN_STR))
 
 # BKPT_VER consist of backported release version.
 # Expected input: 'BACKPORTS_RELEASE_TAG="xeb_v6.17.13.49_260409.4"'
-# Extract value after ="...", then get field 3 after splitting by _: 260409.4
-BKPT_VER=@DOLLAR_SIGN@(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '=' -f 2 | tr -d '"' | cut -d '_' -f 3 2>/dev/null || echo 1)
+BKPT_VER=@DOLLAR_SIGN@(shell cat src/versions | grep BACKPORTS_RELEASE_TAG | cut -d '=' -f 2 | tr -d '"' | cut -d '_' -f 3 | cut -d '-' -f 1 2>/dev/null || echo 1)
 
 # DEV_TAG is extracted from BASE_KERNEL_TAG.
 # Expected format: "xe-v6.17.13.49" -> extracts "v6.17.13.49" and removes 'v' prefix
@@ -60,8 +59,8 @@ DISTRO_SUFFIX=@DOLLAR_SIGN@(shell cat $(KLIB_BUILD)/include/generated/utsrelease
 XE_PKG_NAME_BASENAME=intel-xe-dkms
 XE_PKG_NAME=$(XE_PKG_NAME_BASENAME)
 
-# Debian version format: 0.<BKPT_VER> e.g. intel-xe-dkms_0.260409.5+i1-1_all.deb
-XE_PKG_VERSION=0.$(BKPT_VER)
+# Debian version format: <KER_VER>-<RELEASE_VERSION> e.g. intel-xe-dkms_6.12.0.124.8.1-6.17.13.49.260409.4+i1-1_all.deb
+XE_PKG_VERSION=$(KER_VER)-$(RELEASE_VERSION)
 XE_PKG_RELEASE=$(RELEASE)
 
 # RPM version format: <kernel-ver>-<dev_tag>.<bkpt_ver>.<release> e.g. intel-xe-dkms-6.12.0.124.8.1-6.17.13.54.260409.5.1.el10_1.x86_64.rpm

--- a/autotools/README.md
+++ b/autotools/README.md
@@ -57,10 +57,11 @@ Example:
 	$./compile.sh configure
 	$ make xe-dkms-deb-pkg
 
-Generated package name :
-	intel-xe-dkms_1.250811.7.0+i1-1_all.deb
+Generated package name:
+	intel-xe-dkms_<kernel-version>-<release-version>+i1-1_all.deb
+	Example: intel-xe-dkms_6.12.0.124.8.1-6.17.13.49.260409.4+i1-1_all.deb
 ```
-Above command will create Debian package in parent folder. **intel-xe-dkms_<**release version**>.<**kernel-version**>.deb**
+Above command will create Debian package in parent folder. **intel-xe-dkms_\<kernel-version\>-\<release-version\>+i1-1_all.deb**
 
 ```
 Example:


### PR DESCRIPTION
The xe-dkms deb package previously used only the backport release version in its name (e.g., intel-xe-dkms_0.260306.0.0+i1-1_all.deb), omitting the target kernel version. So, the fixes by aligning the deb package versioning are as follows:

Makefile.am:
- change XE_PKG_VERSION from 0.<BKPT_VER> to <KER_VER>-<RELEASE_VERSION>
- resulting deb name: intel-xe-dkms_<kernel-ver>-<dev_tag>.<bkpt_ver>+i1-1_all.deb

Makefile:
- add xe_deb_pkg_ver=$(KER_VER)-$(DEV_TAG).$(BKPT_VER) and supporting variables.
- replace broken xe-dkms-deb-pkg delegation to src/ with a full target implementation matching the Makefile.am logic

Resultant package: intel-xe-dkms_6.6.135-6.17.13.54.260409.3+i1-1_all.deb