### PR TITLE
drm/xe: Fix app hang on pagefault - GDB signal not received

### DIFF
--- a/backport/patches/base/0001-uapi-Move-DRM_XE_VM_BIND_FLAG_DECOMPRESS-from-bit-6-.patch
+++ b/backport/patches/base/0001-uapi-Move-DRM_XE_VM_BIND_FLAG_DECOMPRESS-from-bit-6-.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pravalika Gurram <pravalika.gurram@intel.com>
+Date: Wed, 27 May 2026 15:22:39 +0530
+Subject: uapi: Move DRM_XE_VM_BIND_FLAG_DECOMPRESS from bit 6 to bit 7
+
+Align with NEO UMD which uses bit 7 for DECOMPRESS flag.
+The kernel header incorrectly defined it at bit 6, causing valid
+decompress requests (flags=0x82) to be rejected by SUPPORTED_FLAGS
+validation (0x7F).
+
+After this change, SUPPORTED_FLAGS will be 0xBF and accept valid
+decompression operations, allowing them to proceed through PAT
+validation to GPU execution.
+
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ include/uapi/drm/xe_drm.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index e6412856f..78ea26105 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -1111,7 +1111,7 @@ struct drm_xe_vm_bind_op {
+ #define DRM_XE_VM_BIND_FLAG_DUMPABLE	(1 << 3)
+ #define DRM_XE_VM_BIND_FLAG_CHECK_PXP	(1 << 4)
+ #define DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR	(1 << 5)
+-#define DRM_XE_VM_BIND_FLAG_DECOMPRESS	(1 << 6)
++#define DRM_XE_VM_BIND_FLAG_DECOMPRESS	(1 << 7)
+ 	/** @flags: Bind flags */
+ 	__u32 flags;
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -293,6 +293,7 @@ backport/patches/base/0001-drm-xe-pat-Add-helper-to-query-compression-enable-st.
 backport/patches/base/0001-drm-xe-add-VM_BIND-DECOMPRESS-uapi-flag.patch
 backport/patches/base/0001-drm-xe-add-xe_migrate_resolve-wrapper-and-is_vram_re.patch
 backport/patches/base/0001-drm-xe-implement-VM_BIND-decompression-in-vm_bind_io.patch
+backport/patches/base/0001-uapi-Move-DRM_XE_VM_BIND_FLAG_DECOMPRESS-from-bit-6-.patch
 # features/psr
 backport/patches/features/psr/0001-drm-i915-psr-Set-plane-id-bit-in-crtc_state-async_fl.patch
 backport/patches/features/psr/0001-drm-i915-psr-Perform-full-frame-update-on-async-flip.patch


### PR DESCRIPTION
Application hangs and GDB never receives pagefault signal.
VM_BIND ioctl blocks indefinitely, UMD cannot resume
application or signal debugger.

Root cause : decompression was skipped even
with DECOMPRESS flag set. GPU received stale buffer, triggered engine
reset, hung the kernel.

This is due to drm UAPI DRM_XE_VM_BIND_FLAG_DECOMPRESS  mismatch
Move DECOMPRESS flag from bit 6 to bit 7 in UAPI (UMD mismatch)
with this VM_BIND completes, decompression succeeds, UMD resumes app, GDB
can attach debugger. No more app hang.

Fixes: 45ada4092 ("drm/xe: Add VM_BIND DECOMPRESS support")

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>