### PR TITLE
docs: fix branch name in README table to use versioned tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note:
 
 | Branch Name | Kernel Version | Status |
 |-------------|----------------|--------|
-| kernel-backport/main | 7.0 | Active |
+| kernel-backport/v7.0 | 7.0 | Active |
 | kernel-backport/v6.17 | 6.17 | Active |
 | kernel-backport/v6.14 | 6.14 | Frozen |
 | kernel-backport/v6.11 | 6.11 | Frozen |


### PR DESCRIPTION
Update the branch name in the supported branches table from
`kernel-backport/main` to `kernel-backport/v7.0` to accurately
reflect the correct versioned branch naming convention.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>