### PR TITLE
fixup! drm/xe: Added patch to fix DRM_XE_VM_BIND_FLAG_DECOMPRESS bit position

### DIFF
--- a/backport/patches/base/0001-drm-xe-Fix-DRM_XE_VM_BIND_FLAG_DECOMPRESS-bit-positi.patch
+++ b/backport/patches/base/0001-drm-xe-Fix-DRM_XE_VM_BIND_FLAG_DECOMPRESS-bit-positi.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pravalika Gurram <pravalika.gurram@intel.com>
+Date: Tue, 9 Jun 2026 13:44:15 +0530
+Subject: drm/xe: Fix DRM_XE_VM_BIND_FLAG_DECOMPRESS bit position
+ alignment
+
+Fix the bit position of DRM_XE_VM_BIND_FLAG_DECOMPRESS from (1 << 6) to
+(1 << 7) to align with drm-tip and resolve UAPI mismatch between UMD and KMD.
+
+Fixes: c6a1b5793 ("drm/xe: add VM_BIND DECOMPRESS uapi flag")
+
+(backported from commit 2270bd7124f4d25497d58c293cd40ea014ddaf01 linux-next)
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ include/uapi/drm/xe_drm.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index 304c17bc8..ee1d334b0 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -1112,7 +1112,7 @@ struct drm_xe_vm_bind_op {
+ #define DRM_XE_VM_BIND_FLAG_DUMPABLE	(1 << 3)
+ #define DRM_XE_VM_BIND_FLAG_CHECK_PXP	(1 << 4)
+ #define DRM_XE_VM_BIND_FLAG_CPU_ADDR_MIRROR	(1 << 5)
+-#define DRM_XE_VM_BIND_FLAG_DECOMPRESS	(1 << 6)
++#define DRM_XE_VM_BIND_FLAG_DECOMPRESS	(1 << 7)
+ 	/** @flags: Bind flags */
+ 	__u32 flags;
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -293,6 +293,7 @@ backport/patches/base/0001-drm-xe-pat-Add-helper-to-query-compression-enable-st.
 backport/patches/base/0001-drm-xe-add-VM_BIND-DECOMPRESS-uapi-flag.patch
 backport/patches/base/0001-drm-xe-add-xe_migrate_resolve-wrapper-and-is_vram_re.patch
 backport/patches/base/0001-drm-xe-implement-VM_BIND-decompression-in-vm_bind_io.patch
+backport/patches/base/0001-drm-xe-Fix-DRM_XE_VM_BIND_FLAG_DECOMPRESS-bit-positi.patch
 # features/psr
 backport/patches/features/psr/0001-drm-i915-psr-Set-plane-id-bit-in-crtc_state-async_fl.patch
 backport/patches/features/psr/0001-drm-i915-psr-Perform-full-frame-update-on-async-flip.patch


### PR DESCRIPTION
drm/xe: Added patch to fix DRM_XE_VM_BIND_FLAG_DECOMPRESS bit position
Added a patch to fix the bit position of DRM_XE_VM_BIND_FLAG_DECOMPRESS from (1 << 6) to
(1 << 7) to align with drm-tip and resolve UAPI mismatch between UMD and KMD.

Fixes: https://github.com/intel-gpu/xekmd-backports/commit/45ada409213b4f1ed87007d9386d7a75580a0575 ("drm/xe: Add VM_BIND DECOMPRESS support")