### PR TITLE
backport: add xe-vfio-pci DKMS module entry

### DIFF
--- a/backport/scripts/backport-mkdrmdkmsconf
+++ b/backport/scripts/backport-mkdrmdkmsconf
@@ -85,4 +85,8 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
 	BUILT_MODULE_NAME[10]="mtd_intel_dg"
 	BUILT_MODULE_LOCATION[10]="src"
 	DEST_MODULE_LOCATION[10]="/updates"
+
+	BUILT_MODULE_NAME[11]="xe-vfio-pci"
+	BUILT_MODULE_LOCATION[11]="src/drivers/vfio/pci/xe"
+	DEST_MODULE_LOCATION[11]="/updates"
 EOF


### PR DESCRIPTION
Add DKMS configuration entries for the xe-vfio-pci module at index [11]
in the backport-mkdrmdkmsconf script for rpm packages.
This ensures the xe-vfio-pci driver is correctly built and installed
via DKMS alongside the other backported DRM/GPU modules.

Signed-off-by: Rachapalli Bandi Jagadeesh <jagadeesh.rachapalli.bandi@intel.com>