### PR TITLE
Fix 5.15 backport warnings

### DIFF
--- a/backport/backport-include/linux/kobject.h
+++ b/backport/backport-include/linux/kobject.h
@@ -1,0 +1,13 @@
+#ifndef __BACKPORT_LINUX_KOBJECT_H
+#define __BACKPORT_LINUX_KOBJECT_H
+
+#include_next <linux/kobject.h>
+
+#define kobject_init(_kobj, _ktype) \
+	kobject_init((_kobj), (struct kobj_type *)(_ktype))
+
+#define kobject_init_and_add(_kobj, _ktype, _parent, _fmt, ...) \
+	kobject_init_and_add((_kobj), (struct kobj_type *)(_ktype), \
+			     (_parent), (_fmt), ##__VA_ARGS__)
+
+#endif /* __BACKPORT_LINUX_KOBJECT_H */


### PR DESCRIPTION
Avoid C90 mixed-declaration warnings when guard(mutex) is used
with 5.15 kernel headers.

Warnings:
-------------------------------------------------------------------------------
ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
-------------------------------------------------------------------------------

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>