### PR TITLE
linux/slab: Fix kvrealloc() compatibility wrapper

### DIFF
--- a/backport/backport-include/linux/slab.h
+++ b/backport/backport-include/linux/slab.h
@@ -9,7 +9,7 @@
 #ifndef BPM_KVREALLOC_NOPROF_PRESENT
 
 #define __bp_kvrealloc_3(_p, _newsize, _flags) \
-	kvrealloc(_p, 0, _newsize, _flags)
+	kvrealloc(_p, ksize(_p), _newsize, _flags)
 #define __bp_kvrealloc_4(_p, _oldsize, _newsize, _flags) \
 	kvrealloc(_p, _oldsize, _newsize, _flags)
 #define __bp_kvrealloc_pick(_1, _2, _3, _4, _pick, ...) _pick


### PR DESCRIPTION
The kvrealloc() API mismatch is now handled directly by drm_exec,
which selects the appropriate kvrealloc() prototype based on
BPM_KVREALLOC_OLDSIZE_PARAM_PRESENT and provides the correct old
allocation size for older kernels.

Remove the backport kvrealloc() wrapper from linux/slab.h, as it is
no longer required and can hide incorrect API usage.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>