### PR TITLE
xekmd-backport: add WHITELIST_OA_MERT_MMIO_TRG and Restore BAR fallback fixes

### DIFF
--- a/backport/patches/base/0001-drm-xe-oa-Fix-offset-alignment-for-MERT-WHITELIST_OA.patch
+++ b/backport/patches/base/0001-drm-xe-oa-Fix-offset-alignment-for-MERT-WHITELIST_OA.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Date: Mon, 29 Jun 2026 10:26:34 -0700
+Subject: drm/xe/oa: Fix offset alignment for MERT
+ WHITELIST_OA_MERT_MMIO_TRG
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+'head' argument for WHITELIST_OA_MERT_MMIO_TRG was previously wrong (not
+multiple of 16). Fix this.
+
+Fixes: ec02e49f21bc ("drm/xe/rtp: Whitelist OAMERT MMIO trigger registers")
+Cc: stable@vger.kernel.org
+Reviewed-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>
+Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>
+Link: https://patch.msgid.link/20260629172634.1100983-1-ashutosh.dixit@intel.com
+(cherry picked from commit f6c23e4589bdc69a5d2f79aed5c5bddd5d406cbe)
+Signed-off-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+(cherry picked from commit 959b5016e4646b55fd2fd0438932e4c4e9ce171f linux-next)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/gpu/drm/xe/xe_reg_whitelist.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_reg_whitelist.c b/drivers/gpu/drm/xe/xe_reg_whitelist.c
+index 95c0970d27a1..0a9edf700c02 100644
+--- a/drivers/gpu/drm/xe/xe_reg_whitelist.c
++++ b/drivers/gpu/drm/xe/xe_reg_whitelist.c
+@@ -110,7 +110,7 @@ static const struct xe_rtp_entry_sr register_whitelist[] = {
+ 			      OAM_HEAD_POINTER(XE_OAM_SCMI_1_BASE_ADJ))
+ 
+ #define WHITELIST_OA_MERT_MMIO_TRG \
+-	WHITELIST_OA_MMIO_TRG(OAMERT_MMIO_TRG, OAMERT_STATUS, OAMERT_HEAD_POINTER)
++	WHITELIST_OA_MMIO_TRG(OAMERT_MMIO_TRG, OAMERT_STATUS, OAMERT_TAIL_POINTER)
+ 
+ 	{ XE_RTP_NAME("oag_mmio_trg_rcs"),
+ 	  XE_RTP_RULES(GRAPHICS_VERSION_RANGE(1200, XE_RTP_END_VERSION_UNDEFINED),
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-platform-x86-intel-vsec-Restore-BAR-fallback-for-hea.patch
+++ b/backport/patches/base/0001-platform-x86-intel-vsec-Restore-BAR-fallback-for-hea.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "David E. Box" <david.e.box@linux.intel.com>
+Date: Fri, 29 May 2026 11:31:49 -0700
+Subject: platform/x86/intel/vsec: Restore BAR fallback for header walk
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The base_addr refactor changed intel_vsec_walk_header() to pass
+info->base_addr as the discovery-table base address. For the PCI VSEC
+driver this info comes from driver_data, but exported callers may provide
+their own static headers and leave base_addr unset.
+
+For xe, this made the discovery-table base address zero instead of the BAR
+selected by header->tbir, preventing PMT endpoints from being created.
+
+Restore the previous behavior for the header-walk path by falling back to
+pci_resource_start(pdev, header->tbir) when base_addr is not specified.
+Keep explicit base_addr override behavior unchanged.
+
+This preserves the refactor structure while fixing the functional
+regression in manual-header users.
+
+Fixes: 904b333fc51c ("platform/x86/intel/vsec: Refactor base_addr handling")
+Assisted-by: Claude:claude-sonnet-4-6
+Signed-off-by: David E. Box <david.e.box@linux.intel.com>
+Reviewed-by: Michael J. Ruhl <michael.j.ruhl@intel.com>
+Link: https://patch.msgid.link/20260529183150.129744-1-david.e.box@linux.intel.com
+Reviewed-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+(cherry picked from commit 375bbbbd112af028ee0b45d833a6233c23d19bbf linux-next)
+Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>
+---
+ drivers/platform/x86/intel/vsec.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/platform/x86/intel/vsec.c b/drivers/platform/x86/intel/vsec.c
+index 18e4a892bf0f..439c0c8ac896 100644
+--- a/drivers/platform/x86/intel/vsec.c
++++ b/drivers/platform/x86/intel/vsec.c
+@@ -488,10 +488,25 @@ static int intel_vsec_walk_header(struct device *dev,
+ 				  const struct intel_vsec_platform_info *info)
+ {
+ 	struct intel_vsec_header **header = info->headers;
++	u64 base_addr;
+ 	int ret;
+ 
+ 	for ( ; *header; header++) {
+-		ret = intel_vsec_register_device(dev, *header, info, info->base_addr);
++		if (info->base_addr) {
++			base_addr = info->base_addr;
++		} else {
++			struct pci_dev *pdev;
++
++			if (!dev_is_pci(dev)) {
++				dev_err(dev, "non-PCI device without a base address\n");
++				return -EINVAL;
++			}
++
++			pdev = to_pci_dev(dev);
++			base_addr = pci_resource_start(pdev, (*header)->tbir);
++		}
++
++		ret = intel_vsec_register_device(dev, *header, info, base_addr);
+ 		if (ret)
+ 			return ret;
+ 	}
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -38,6 +38,8 @@ backport/patches/base/0001-drm-xe-oa-Refactor-oa_unit_supports_oa_format.patch
 backport/patches/base/0001-drm-xe-oa-MERTOA-Wa_14026746987.patch
 backport/patches/base/0001-drm-xe-oa-Add-val-arg-to-xe_oa_is_valid_config_reg.patch
 backport/patches/base/0001-drm-xe-oa-MERTOA-Wa_14026779378.patch
+backport/patches/base/0001-drm-xe-oa-Fix-offset-alignment-for-MERT-WHITELIST_OA.patch
+backport/patches/base/0001-platform-x86-intel-vsec-Restore-BAR-fallback-for-hea.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Add fixes which takes care of
'head' argument for WHITELIST_OA_MERT_MMIO_TRG was previously wrong (not
multiple of 16)
Add fix for BAR fallback for header in vsec

Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>