### PR TITLE
list_lru: use caller nid in list_lru_add() shim

### DIFF
--- a/backport/backport-include/linux/list_lru.h
+++ b/backport/backport-include/linux/list_lru.h
@@ -4,10 +4,30 @@
 #define __BACKPORT_LIST_LRU_H__
 
 #include <linux/version.h>
+#include <linux/list.h>
+#include <linux/spinlock.h>
 #include_next <linux/list_lru.h>
 
 #ifdef BPM_LIST_LRU_ADD_4ARGS_NOT_PRESENT
-#define list_lru_add(lru, item, nid, memcg) list_lru_add(lru, item)
+static inline bool
+backport_list_lru_add(struct list_lru *lru, struct list_head *item, int nid,
+		      struct mem_cgroup *memcg)
+{
+	struct list_lru_node *nlru = &lru->node[nid];
+
+	spin_lock(&nlru->lock);
+	if (list_empty(item)) {
+		list_add_tail(item, &nlru->lru.list);
+		nlru->lru.nr_items++;
+		nlru->nr_items++;
+		spin_unlock(&nlru->lock);
+		return true;
+	}
+	spin_unlock(&nlru->lock);
+	return false;
+}
+#define list_lru_add(lru, item, nid, memcg) \
+	backport_list_lru_add(lru, item, nid, memcg)
 #elif defined(BPM_LIST_LRU_ADD_OBJ_NOT_PRESENT)
 #define list_lru_add(lru, item, nid, memcg) list_lru_add_obj(lru, item)
 #endif


### PR DESCRIPTION
The backported list_lru_add() api dropped @nid and fell back to the
2-arg list_lru_add(), which recomputes nid via page_to_nid(virt_to_page(item)).
TTM passes &page->lru (a vmemmap address), so virt_to_page() returns a bogus page
and page_to_nid() oopses in ttm_pool_free().

Provide an inline wrapper that honours the caller-supplied @nid instead
of recomputing it, with proper node locking and nr_items accounting.

Call Trace:
------------------------------------------------------------------------------
BUG: unable to handle page fault for address: fffffcc8fb1063c0
RIP: 0010:list_lru_add+0x4a/0x1a0
Call Trace:
ttm_pool_unmap_and_free+0x14d/0x1c0 [ttm]
ttm_pool_free_range+0x78/0xb0 [ttm]
ttm_pool_free+0x2f/0x70 [ttm]
------------------------------------------------------------------------------

Signed-off-by: Rachapalli Bandi Jagadeesh <jagadeesh.rachapalli.bandi@intel.com>