### PR TITLE
drm/gpu: Add gpu_buddy_allocated_addr_to_block helper and KUnit test

### DIFF
--- a/backport/patches/base/0001-drm-buddy-Integrate-lockdep-annotations-for-gpu-budd.patch
+++ b/backport/patches/base/0001-drm-buddy-Integrate-lockdep-annotations-for-gpu-budd.patch
@@ -1,0 +1,187 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Fri, 8 May 2026 12:25:45 +0530
+Subject: drm/buddy: Integrate lockdep annotations for gpu buddy
+ manager
+
+gpu_buddy APIs are expected to be called with the driver-provided lock
+held, but there is no runtime enforcement of this contract. Add lockdep
+annotations to catch locking violations early.
+
+Introduce gpu_buddy_driver_set_lock() for the driver to register the
+lock that protects the buddy manager. Add gpu_buddy_driver_lock_held()
+assertions to all exported gpu_buddy and drm_buddy APIs that
+access/modify the manager state. The lock_dep_map field is only compiled
+in when CONFIG_LOCKDEP is enabled, adding zero overhead to production
+builds.
+
+Wire up xe_ttm_vram_mgr to register its mutex with the buddy manager
+after initialization.
+
+Assisted-by: Copilot:claude-opus-4.6
+Suggested-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Signed-off-by: Arunpravin Paneer Selvam <Arunpravin.PaneerSelvam@amd.com>
+Link: https://patch.msgid.link/20260508065544.4049240-2-tejas.upadhyay@intel.com
+(cherry-picked from commit 35b535db69589ea0025ec3f06df08f2e3faad26f linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/buddy.c                  | 11 ++++++++
+ drivers/gpu/drm/drm_buddy.c          |  1 +
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.c |  1 +
+ include/linux/gpu_buddy.h            | 41 ++++++++++++++++++++++++++++
+ 4 files changed, 54 insertions(+)
+
+diff --git a/drivers/gpu/buddy.c b/drivers/gpu/buddy.c
+index 0acfcbcbb..315f860f4 100644
+--- a/drivers/gpu/buddy.c
++++ b/drivers/gpu/buddy.c
+@@ -437,6 +437,9 @@ int gpu_buddy_init(struct gpu_buddy *mm, u64 size, u64 chunk_size)
+ 		root_count++;
+ 	} while (size);
+ 
++#ifdef CONFIG_LOCKDEP
++	mm->lock_dep_map = NULL;
++#endif
+ 	return 0;
+ 
+ out_free_roots:
+@@ -538,6 +541,7 @@ void gpu_buddy_reset_clear(struct gpu_buddy *mm, bool is_clear)
+ 	unsigned int order;
+ 	int i;
+ 
++	gpu_buddy_driver_lock_held(mm);
+ 	size = mm->size;
+ 	for (i = 0; i < mm->n_roots; ++i) {
+ 		order = ilog2(size) - ilog2(mm->chunk_size);
+@@ -580,6 +584,7 @@ EXPORT_SYMBOL(gpu_buddy_reset_clear);
+ void gpu_buddy_free_block(struct gpu_buddy *mm,
+ 			  struct gpu_buddy_block *block)
+ {
++	gpu_buddy_driver_lock_held(mm);
+ 	BUG_ON(!gpu_buddy_block_is_allocated(block));
+ 	mm->avail += gpu_buddy_block_size(mm, block);
+ 	if (gpu_buddy_block_is_clear(block))
+@@ -686,6 +691,7 @@ void gpu_buddy_free_list(struct gpu_buddy *mm,
+ {
+ 	bool mark_clear = flags & GPU_BUDDY_CLEARED;
+ 
++	gpu_buddy_driver_lock_held(mm);
+ 	__gpu_buddy_free_list(mm, objects, mark_clear, !mark_clear);
+ }
+ EXPORT_SYMBOL(gpu_buddy_free_list);
+@@ -1225,6 +1231,8 @@ int gpu_buddy_block_trim(struct gpu_buddy *mm,
+ 	u64 new_start;
+ 	int err;
+ 
++	gpu_buddy_driver_lock_held(mm);
++
+ 	if (!list_is_singular(blocks))
+ 		return -EINVAL;
+ 
+@@ -1340,6 +1348,8 @@ int gpu_buddy_alloc_blocks(struct gpu_buddy *mm,
+ 	unsigned long pages;
+ 	int err;
+ 
++	gpu_buddy_driver_lock_held(mm);
++
+ 	if (size < mm->chunk_size)
+ 		return -EINVAL;
+ 
+@@ -1528,6 +1538,7 @@ void gpu_buddy_print(struct gpu_buddy *mm)
+ {
+ 	int order;
+ 
++	gpu_buddy_driver_lock_held(mm);
+ 	pr_info("chunk_size: %lluKiB, total: %lluMiB, free: %lluMiB, clear_free: %lluMiB\n",
+ 		mm->chunk_size >> 10, mm->size >> 20, mm->avail >> 20, mm->clear_avail >> 20);
+ 
+diff --git a/drivers/gpu/drm/drm_buddy.c b/drivers/gpu/drm/drm_buddy.c
+index 841f3de5f..faa025498 100644
+--- a/drivers/gpu/drm/drm_buddy.c
++++ b/drivers/gpu/drm/drm_buddy.c
+@@ -42,6 +42,7 @@ void drm_buddy_print(struct gpu_buddy *mm, struct drm_printer *p)
+ {
+ 	int order;
+ 
++	gpu_buddy_driver_lock_held(mm);
+ 	drm_printf(p, "chunk_size: %lluKiB, total: %lluMiB, free: %lluMiB, clear_free: %lluMiB\n",
+ 		   mm->chunk_size >> 10, mm->size >> 20, mm->avail >> 20, mm->clear_avail >> 20);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 5fd0d5506..7ebc4d278 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -322,6 +322,7 @@ int __xe_ttm_vram_mgr_init(struct xe_device *xe, struct xe_ttm_vram_mgr *mgr,
+ 	if (err)
+ 		return err;
+ 
++	gpu_buddy_driver_set_lock(&mgr->mm, &mgr->lock);
+ 	ttm_set_driver_manager(&xe->ttm, mem_type, &mgr->manager);
+ 	ttm_resource_manager_set_used(&mgr->manager, true);
+ 
+diff --git a/include/linux/gpu_buddy.h b/include/linux/gpu_buddy.h
+index 1019e9be3..e7e22fa05 100644
+--- a/include/linux/gpu_buddy.h
++++ b/include/linux/gpu_buddy.h
+@@ -154,6 +154,7 @@ struct gpu_buddy_block {
+  * @avail: Total free space currently available for allocation in bytes.
+  * @clear_avail: Free space available in the clear tree (zeroed memory) in bytes.
+  *               This is a subset of @avail.
++ * @lock_dep_map: Annotates gpu_buddy API with a driver provided lock.
+  */
+ struct gpu_buddy {
+ /* private: */
+@@ -179,8 +180,48 @@ struct gpu_buddy {
+ 	u64 size;
+ 	u64 avail;
+ 	u64 clear_avail;
++#ifdef CONFIG_LOCKDEP
++	struct lockdep_map *lock_dep_map;
++#endif
+ };
+ 
++#ifdef CONFIG_LOCKDEP
++/**
++ * gpu_buddy_driver_set_lock() - Set the lock protecting accesses to GPU BUDDY
++ * @mm: Pointer to GPU buddy structure.
++ * @lock: the lock used to protect the gpu buddy. The locking primitive
++ * must contain a dep_map field.
++ *
++ * Call this to annotate gpu_buddy APIs which access/modify gpu_buddy manager
++ */
++#define gpu_buddy_driver_set_lock(mm, lock) \
++	do { \
++		struct gpu_buddy *__mm = (mm); \
++		if (!WARN(__mm->lock_dep_map, "GPU BUDDY MM lock should be set only once.")) \
++			__mm->lock_dep_map = &(lock)->dep_map; \
++	} while (0)
++#else
++#define gpu_buddy_driver_set_lock(mm, lock) do { (void)(mm); (void)(lock); } while (0)
++#endif
++
++#ifdef CONFIG_LOCKDEP
++/**
++ * gpu_buddy_driver_lock_held() - Assert GPU BUDDY manager lock is held
++ * @mm: Pointer to the GPU BUDDY structure.
++ *
++ * Ensure driver lock is held.
++ */
++static inline void gpu_buddy_driver_lock_held(struct gpu_buddy *mm)
++{
++	if (mm->lock_dep_map)
++		lockdep_assert(lock_is_held_type(mm->lock_dep_map, 0));
++}
++#else
++static inline void gpu_buddy_driver_lock_held(struct gpu_buddy *mm)
++{
++}
++#endif
++
+ static inline u64
+ gpu_buddy_block_offset(const struct gpu_buddy_block *block)
+ {
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-gpu-Add-gpu_buddy_allocated_addr_to_block-helper.patch
+++ b/backport/patches/base/0001-drm-gpu-Add-gpu_buddy_allocated_addr_to_block-helper.patch
@@ -1,0 +1,108 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Thu, 6 Aug 2026 11:06:25 +0530
+Subject: drm/gpu: Add gpu_buddy_allocated_addr_to_block helper
+
+Add helper with primary purpose is to efficiently trace a specific
+physical memory address back to its corresponding TTM buffer object.
+
+v3:
+- use mm->chunk_size minimum allocation granularity (Arun)
+v2:
+- %s/gpu_buddy_addr_to_block/gpu_buddy_allocated_addr_to_block(MattA)
+- remove clear->avail and split nodes check(MattA)
+- Adapt lockdep(MattB)
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Cc: Arunpravin Paneer Selvam <arunpravin.paneerselvam@amd.com>
+Cc: dri-devel@lists.freedesktop.org
+Reviewed-by: Arunpravin Paneer Selvam <Arunpravin.PaneerSelvam@amd.com>
+Signed-off-by: Arunpravin Paneer Selvam <Arunpravin.PaneerSelvam@amd.com>
+Link: https://patch.msgid.link/20260806053624.3215216-5-tejas.upadhyay@intel.com
+(cherry-picked from commit 151ebbc20aa2365fa854a77432043b16606b5cfe drm-tip-eudebug)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/buddy.c       | 53 +++++++++++++++++++++++++++++++++++++++
+ include/linux/gpu_buddy.h |  2 ++
+ 2 files changed, 55 insertions(+)
+
+diff --git a/drivers/gpu/buddy.c b/drivers/gpu/buddy.c
+index 52686672e..0acfcbcbb 100644
+--- a/drivers/gpu/buddy.c
++++ b/drivers/gpu/buddy.c
+@@ -589,6 +589,59 @@ void gpu_buddy_free_block(struct gpu_buddy *mm,
+ }
+ EXPORT_SYMBOL(gpu_buddy_free_block);
+ 
++/**
++ * gpu_buddy_allocated_addr_to_block - given relative address find the allocated block
++ *
++ * @mm: GPU buddy manager
++ * @addr: Relative address
++ *
++ * Returns:
++ * gpu_buddy_block on success, NULL or error code on failure
++ */
++struct gpu_buddy_block *gpu_buddy_allocated_addr_to_block(struct gpu_buddy *mm, u64 addr)
++{
++	struct gpu_buddy_block *block;
++	LIST_HEAD(dfs);
++	u64 end;
++	int i;
++
++	gpu_buddy_driver_lock_held(mm);
++
++	end = addr + mm->chunk_size - 1;
++	for (i = 0; i < mm->n_roots; ++i)
++		list_add_tail(&mm->roots[i]->tmp_link, &dfs);
++
++	do {
++		u64 block_start;
++		u64 block_end;
++
++		block = list_first_entry_or_null(&dfs,
++						 struct gpu_buddy_block,
++						 tmp_link);
++		if (!block)
++			break;
++
++		list_del(&block->tmp_link);
++
++		block_start = gpu_buddy_block_offset(block);
++		block_end = block_start + gpu_buddy_block_size(mm, block) - 1;
++
++		if (!overlaps(addr, end, block_start, block_end))
++			continue;
++
++		if (gpu_buddy_block_is_allocated(block))
++			return block;
++		else if (gpu_buddy_block_is_free(block))
++			return NULL;
++
++		list_add(&block->right->tmp_link, &dfs);
++		list_add(&block->left->tmp_link, &dfs);
++	} while (1);
++
++	return ERR_PTR(-ENXIO);
++}
++EXPORT_SYMBOL(gpu_buddy_allocated_addr_to_block);
++
+ static void __gpu_buddy_free_list(struct gpu_buddy *mm,
+ 				  struct list_head *objects,
+ 				  bool mark_clear,
+diff --git a/include/linux/gpu_buddy.h b/include/linux/gpu_buddy.h
+index 5fa917ba5..1019e9be3 100644
+--- a/include/linux/gpu_buddy.h
++++ b/include/linux/gpu_buddy.h
+@@ -231,6 +231,8 @@ void gpu_buddy_reset_clear(struct gpu_buddy *mm, bool is_clear);
+ 
+ void gpu_buddy_free_block(struct gpu_buddy *mm, struct gpu_buddy_block *block);
+ 
++struct gpu_buddy_block *gpu_buddy_allocated_addr_to_block(struct gpu_buddy *mm, u64 addr);
++
+ void gpu_buddy_free_list(struct gpu_buddy *mm,
+ 			 struct list_head *objects,
+ 			 unsigned int flags);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-gpu-tests-gpu_buddy-Add-KUnit-test-for-gpu_buddy_all.patch
+++ b/backport/patches/base/0001-gpu-tests-gpu_buddy-Add-KUnit-test-for-gpu_buddy_all.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Thu, 6 Aug 2026 11:06:26 +0530
+Subject: gpu/tests/gpu_buddy: Add KUnit test for
+ gpu_buddy_allocated_addr_to_block
+
+Add a new KUnit test gpu_test_buddy_addr_to_block() that validates the
+gpu_buddy_allocated_addr_to_block() helper which traces a address back
+to its allocated buddy block.
+
+The test covers:
+- Exact address matching returns the correct allocated block
+- An unallocated address inside the manager should return NULL
+- An address outside the manager should return -ENXIO
+
+v4(MattA):
+- Add test for unaligned address
+v3(Sashiko):
+- remove unused target_addr variable
+v2(Sashiko):
+- Drop the mutex and lockdep annotation; standalone KUnit tests do
+  not register a driver lock.
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Signed-off-by: Arunpravin Paneer Selvam <Arunpravin.PaneerSelvam@amd.com>
+Link: https://patch.msgid.link/20260806053624.3215216-6-tejas.upadhyay@intel.com
+(cherry-picked from commit 3de014f7debc7162ae26db2f6151af1ba5456dc0 drm-tip-eudebug)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/tests/gpu_buddy_test.c | 45 ++++++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
+
+diff --git a/drivers/gpu/tests/gpu_buddy_test.c b/drivers/gpu/tests/gpu_buddy_test.c
+index 7df5c2ae8..04e425eb8 100644
+--- a/drivers/gpu/tests/gpu_buddy_test.c
++++ b/drivers/gpu/tests/gpu_buddy_test.c
+@@ -1381,6 +1381,50 @@ static void gpu_test_buddy_alloc_exceeds_max_order(struct kunit *test)
+ 	gpu_buddy_fini(&mm);
+ }
+ 
++static void gpu_test_buddy_addr_to_block(struct kunit *test)
++{
++	struct gpu_buddy_block *allocated_block, *found_block;
++	LIST_HEAD(allocated_list);
++	const u64 test_size = SZ_4M + SZ_2M;
++	const u64 alloc_start = SZ_4M;
++	const u64 alloc_size = SZ_4K;
++	const u64 chunk_size = SZ_4K;
++	struct gpu_buddy mm;
++
++	KUNIT_ASSERT_FALSE_MSG(test, gpu_buddy_init(&mm, test_size, chunk_size),
++			       "buddy_init failed\n");
++
++	KUNIT_ASSERT_FALSE_MSG(test, gpu_buddy_alloc_blocks(&mm, alloc_start,
++							    alloc_start + alloc_size,
++							    alloc_size, chunk_size,
++							    &allocated_list, 0),
++			       "buddy_alloc failed\n");
++
++	allocated_block = list_first_entry(&allocated_list, struct gpu_buddy_block, link);
++	KUNIT_EXPECT_EQ(test, gpu_buddy_block_offset(allocated_block), alloc_start);
++	KUNIT_EXPECT_EQ(test, gpu_buddy_block_size(&mm, allocated_block), alloc_size);
++
++	found_block = gpu_buddy_allocated_addr_to_block(&mm, alloc_start);
++	KUNIT_EXPECT_PTR_EQ(test, found_block, allocated_block);
++
++	/* Unaligned address inside the allocated block (should resolve to the same block) */
++	found_block = gpu_buddy_allocated_addr_to_block(&mm, alloc_start + 16);
++	KUNIT_EXPECT_PTR_EQ(test, found_block, allocated_block);
++
++	/* An unallocated address inside the manager should return NULL. */
++	found_block = gpu_buddy_allocated_addr_to_block(&mm,
++							alloc_start - chunk_size);
++	KUNIT_EXPECT_NULL(test, found_block);
++
++	/* An address outside the manager should return -ENXIO. */
++	found_block = gpu_buddy_allocated_addr_to_block(&mm, test_size);
++	KUNIT_EXPECT_EQ(test, PTR_ERR(found_block), -ENXIO);
++
++	/* 3. Standard inline cleanup flow */
++	gpu_buddy_free_list(&mm, &allocated_list, 0);
++	gpu_buddy_fini(&mm);
++}
++
+ static int gpu_buddy_suite_init(struct kunit_suite *suite)
+ {
+ 	while (!random_seed)
+@@ -1405,6 +1449,7 @@ static struct kunit_case gpu_buddy_tests[] = {
+ 	KUNIT_CASE(gpu_test_buddy_alloc_exceeds_max_order),
+ 	KUNIT_CASE(gpu_test_buddy_offset_aligned_allocation),
+ 	KUNIT_CASE(gpu_test_buddy_subtree_offset_alignment_stress),
++	KUNIT_CASE(gpu_test_buddy_addr_to_block),
+ 	{}
+ };
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -40,6 +40,9 @@ backport/patches/base/0001-drm-xe-oa-Add-val-arg-to-xe_oa_is_valid_config_reg.pa
 backport/patches/base/0001-drm-xe-oa-MERTOA-Wa_14026779378.patch
 backport/patches/base/0001-drm-xe-oa-Fix-offset-alignment-for-MERT-WHITELIST_OA.patch
 backport/patches/base/0001-platform-x86-intel-vsec-Restore-BAR-fallback-for-hea.patch
+backport/patches/base/0001-drm-gpu-Add-gpu_buddy_allocated_addr_to_block-helper.patch
+backport/patches/base/0001-gpu-tests-gpu_buddy-Add-KUnit-test-for-gpu_buddy_all.patch
+backport/patches/base/0001-drm-buddy-Integrate-lockdep-annotations-for-gpu-budd.patch
 # fixes
 backport/patches/fixes/base/0001-drm-xe-Fix-PTE-index-in-xe_vm_populate_pgtable-for-c.patch
 backport/patches/fixes/base/0001-drm-xe-remove-duplicate-kunit-test-bug.h-include.patch


### PR DESCRIPTION
Add gpu_buddy_allocated_addr_to_block() to trace a physical address
back to its allocated GPU buddy block.

Add a KUnit test covering:
- Exact address matching
- Unallocated address within the manager
- Address outside the manager
- Unaligned address handling

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>