### PR TITLE
drm/ttm: Fix NULL pointer dereference in ttm_bo_vm_fault_reserved

### DIFF
--- a/patches/0001-drm-ttm-Add-NULL-check-for-bo-resource-in-ttm_bo_vm_.patch
+++ b/patches/0001-drm-ttm-Add-NULL-check-for-bo-resource-in-ttm_bo_vm_.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Akanksha Hotta <akanksha.hotta@intel.com>
+Date: Wed, 12 Aug 2026 11:47:27 +0530
+Subject: drm/ttm: Add NULL check for bo-resource in
+ ttm_bo_vm_fault_reserved()
+
+During xe_madvise, bo->resource is temporarily NULL. If a page fault hits this
+window, we must check bo->resource before using it, otherwise the kernel
+crashes trying to use a NULL address.
+
+Reviewed-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+---
+ drivers/gpu/drm/ttm/ttm_bo_util.c | 3 +++
+ drivers/gpu/drm/ttm/ttm_bo_vm.c   | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/ttm/ttm_bo_util.c b/drivers/gpu/drm/ttm/ttm_bo_util.c
+index 3e3c201..09740ad 100644
+--- a/drivers/gpu/drm/ttm/ttm_bo_util.c
++++ b/drivers/gpu/drm/ttm/ttm_bo_util.c
+@@ -49,6 +49,9 @@ struct ttm_transfer_obj {
+ int ttm_mem_io_reserve(struct ttm_device *bdev,
+ 		       struct ttm_resource *mem)
+ {
++	if (!mem)
++		return 0;
++	
+ 	if (mem->bus.offset || mem->bus.addr)
+ 		return 0;
+ 
+diff --git a/drivers/gpu/drm/ttm/ttm_bo_vm.c b/drivers/gpu/drm/ttm/ttm_bo_vm.c
+index a805104..31d9a6c 100644
+--- a/drivers/gpu/drm/ttm/ttm_bo_vm.c
++++ b/drivers/gpu/drm/ttm/ttm_bo_vm.c
+@@ -204,6 +204,9 @@ vm_fault_t ttm_bo_vm_fault_reserved(struct vm_fault *vmf,
+ 	if (unlikely(ret != 0))
+ 		return ret;
+ 
++	if (unlikely(!bo->resource))
++		return VM_FAULT_SIGBUS;
++
+ 	err = ttm_mem_io_reserve(bo->bdev, bo->resource);
+ 	if (unlikely(err != 0))
+ 		return VM_FAULT_SIGBUS;
+-- 
+2.43.0
+


### PR DESCRIPTION
When xe_madvise changes memory placement of a buffer object, bo->resource can be temporarily NULL during the transition. If a concurrent page fault occurs during this window, ttm_bo_vm_fault_reserved() passes NULL bo->resource directly to ttm_mem_io_reserve(), which dereferences it at offset 0x20, causing a NULL pointer dereference.

```
The crash signature:

  #PF: supervisor read access in kernel mode
  #PF: error_code(0x0000) - not-present page
  RIP: 0010:ttm_mem_io_reserve+0x5/0x50 [ttm]
  CR2: 0000000000000020
  Call Trace:
    __do_fault
    do_fault
    __handle_mm_fault
    handle_mm_fault
    do_user_addr_fault
    exc_page_fault
```

ttm_mem_io_free() already has a NULL check for the mem pointer, whereas ttm_mem_io_reserve() was missing the equivalent protection.

So, by adding a NULL check for bo->resource before calling ttm_mem_io_reserve(), returning VM_FAULT_SIGBUS to userspace which is consistent with the existing error handling pattern already used for ttm_mem_io_reserve() failure on the next line.