### PR TITLE
drm/xe/uc: Apply yield policy to SR-IOV VFs

### DIFF
--- a/backport/patches/fixes/base/0001-drm-xe-uc-Apply-RCS-CCS-yield-policy-to-SR-IOV-VFs.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-uc-Apply-RCS-CCS-yield-policy-to-SR-IOV-VFs.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marcin Bernatowicz <marcin.bernatowicz@linux.intel.com>
+Date: Thu, 9 Jul 2026 09:59:45 +0200
+Subject: drm/xe/uc: Apply RCS/CCS yield policy to SR-IOV VFs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+VFs were missing the call to apply the global scheduling policy.
+Call xe_guc_submit_enable() during vf_uc_load_hw() to ensure VFs
+get the same policy enforcement as PF.
+
+Fixes: 26caeae9fb48 ("drm/xe/guc: Set RCS/CCS yield policy")
+Suggested-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Signed-off-by: Marcin Bernatowicz <marcin.bernatowicz@linux.intel.com>
+Cc: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Cc: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Daniele Ceraolo Spurio <daniele.ceraolospurio@intel.com>
+Link: https://patch.msgid.link/20260709075945.1337660-1-marcin.bernatowicz@linux.intel.com
+Signed-off-by: Michał Winiarski <michal.winiarski@intel.com>
+(cherry picked from commit f09360e857130f7ab7f069e2421e6b4a6e502531)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit d1643db3b037b57f2af7f85c3821d6fe69c492f6 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_uc.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_uc.c b/drivers/gpu/drm/xe/xe_uc.c
+index 75091bde0..65f59f061 100644
+--- a/drivers/gpu/drm/xe/xe_uc.c
++++ b/drivers/gpu/drm/xe/xe_uc.c
+@@ -15,6 +15,7 @@
+ #include "xe_guc_pc.h"
+ #include "xe_guc_rc.h"
+ #include "xe_guc_engine_activity.h"
++#include "xe_guc_submit.h"
+ #include "xe_huc.h"
+ #include "xe_sriov.h"
+ #include "xe_wopcm.h"
+@@ -159,12 +160,14 @@ static int vf_uc_load_hw(struct xe_uc *uc)
+ 	if (err)
+ 		return err;
+ 
+-	uc->guc.submission_state.enabled = true;
+-
+ 	err = xe_guc_opt_in_features_enable(&uc->guc);
+ 	if (err)
+ 		return err;
+ 
++	err = xe_guc_submit_enable(&uc->guc);
++	if (err)
++		return err;
++
+ 	err = xe_gt_record_default_lrcs(uc_to_gt(uc));
+ 	if (err)
+ 		return err;
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -81,6 +81,7 @@ backport/patches/fixes/base/0001-drm-xe-vm-Fix-SVM-leak-on-resv-obj-alloc-failur
 backport/patches/fixes/base/0001-drm-xe-pt-check-no-DMA-huge-pte-cases-before-DMA-seg.patch
 backport/patches/fixes/base/0001-drm-xe-guc-Keep-scheduler-timeline-name-alive.patch
 backport/patches/fixes/base/0001-drm-xe-guc-Hold-device-ref-until-queue-teardown-comp.patch
+backport/patches/fixes/base/0001-drm-xe-uc-Apply-RCS-CCS-yield-policy-to-SR-IOV-VFs.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Call xe_guc_submit_enable() during vf_uc_load_hw() so VFs apply
the same RCS/CCS yield policy as the PF.

Fixes: 26caeae9fb48 ("drm/xe/guc: Set RCS/CCS yield policy")

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>