### PR TITLE
drm/xe/pf: Improve EQ/PT provisioning

### DIFF
--- a/backport/patches/base/0001-drm-xe-guc-Update-POLICY_SCHED_IF_IDLE-documentation.patch
+++ b/backport/patches/base/0001-drm-xe-guc-Update-POLICY_SCHED_IF_IDLE-documentation.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:14 +0200
+Subject: drm/xe/guc: Update POLICY_SCHED_IF_IDLE documentation
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Starting from the GuC firmware version 70.12.0 the meaning of the
+POLICY_SCHED_IF_IDLE has changed, which now acts as a bulk update
+of the VF_CFG_SCHED_PRIORITY configurations of all VFs.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-2-michal.wajdeczko@intel.com
+(cherry-picked from commit 3fb4d2c10702695f33eee9f00a94d2d5e91a5755 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/abi/guc_klvs_abi.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+index e33bd622a..7106fad7b 100644
+--- a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+@@ -192,6 +192,13 @@ enum  {
+  * `GuC KLV`_ keys available for use with PF2GUC_UPDATE_VGT_POLICY.
+  *
+  * _`GUC_KLV_VGT_POLICY_SCHED_IF_IDLE` : 0x8001
++ *      [From 70.12.0]
++ *      This config allows to update scheduling priority of PF and all VFs at once.
++ *      Setting this policy to 0 updates all VFs scheduling priorities to LOW, and
++ *      setting this policy to 1 updates all VFs scheduling priorities to NORMAL.
++ *      Those changes will take effect on the next VF-Switch event.
++ *
++ *      [Before 70.12.0]
+  *      This config sets whether strict scheduling is enabled whereby any VF
+  *      that doesn’t have work to submit is still allocated a fixed execution
+  *      time-slice to ensure active VFs execution is always consistent even
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Allow-to-change-sched_if_idle-policy-under.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Allow-to-change-sched_if_idle-policy-under.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:22 +0200
+Subject: drm/xe/pf: Allow to change sched_if_idle policy under lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In upcoming patch we will need to update sched_if_idle policy when
+we already hold the provisioning mutex. Split existing function
+into two variants to allow that.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-10-michal.wajdeczko@intel.com
+(cherry-picked from commit 55d1945636583f2b88034e50458013f1a9165ee0 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c | 23 +++++++++++++++++++---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h |  1 +
+ 2 files changed, 21 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+index 6c1036743..d1d494d00 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+@@ -193,7 +193,7 @@ static void pf_sanitize_sched_if_idle(struct xe_gt *gt)
+ }
+ 
+ /**
+- * xe_gt_sriov_pf_policy_set_sched_if_idle - Control the 'sched_if_idle' policy.
++ * xe_gt_sriov_pf_policy_set_sched_if_idle_locked() - Control the 'sched_if_idle' policy.
+  * @gt: the &xe_gt where to apply the policy
+  * @enable: the value of the 'sched_if_idle' policy
+  *
+@@ -201,12 +201,12 @@ static void pf_sanitize_sched_if_idle(struct xe_gt *gt)
+  *
+  * Return: 0 on success or a negative error code on failure.
+  */
+-int xe_gt_sriov_pf_policy_set_sched_if_idle(struct xe_gt *gt, bool enable)
++int xe_gt_sriov_pf_policy_set_sched_if_idle_locked(struct xe_gt *gt, bool enable)
+ {
+ 	u32 priority;
+ 	int err;
+ 
+-	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
++	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
+ 	err = pf_provision_sched_if_idle(gt, enable);
+ 	if (err)
+@@ -224,6 +224,23 @@ int xe_gt_sriov_pf_policy_set_sched_if_idle(struct xe_gt *gt, bool enable)
+ 	return 0;
+ }
+ 
++/**
++ * xe_gt_sriov_pf_policy_set_sched_if_idle() - Control the 'sched_if_idle' policy.
++ * @gt: the &xe_gt where to apply the policy
++ * @enable: the value of the 'sched_if_idle' policy
++ *
++ * This function can only be called on PF.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_gt_sriov_pf_policy_set_sched_if_idle(struct xe_gt *gt, bool enable)
++{
++	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
++	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
++
++	return xe_gt_sriov_pf_policy_set_sched_if_idle_locked(gt, enable);
++}
++
+ /**
+  * xe_gt_sriov_pf_policy_get_sched_if_idle_locked() - Retrieve value of 'sched_if_idle' policy.
+  * @gt: the &xe_gt where to read the policy from
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
+index 8c4c5b710..071097fea 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
+@@ -14,6 +14,7 @@ struct drm_printer;
+ struct xe_gt;
+ 
+ int xe_gt_sriov_pf_policy_set_sched_if_idle(struct xe_gt *gt, bool enable);
++int xe_gt_sriov_pf_policy_set_sched_if_idle_locked(struct xe_gt *gt, bool enable);
+ bool xe_gt_sriov_pf_policy_get_sched_if_idle(struct xe_gt *gt);
+ bool xe_gt_sriov_pf_policy_get_sched_if_idle_locked(struct xe_gt *gt);
+ int xe_gt_sriov_pf_policy_set_reset_engine(struct xe_gt *gt, bool enable);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Check-EQ-PT-PRIO-when-testing-VF-config.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Check-EQ-PT-PRIO-when-testing-VF-config.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:21 +0200
+Subject: drm/xe/pf: Check EQ/PT/PRIO when testing VF config
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In addition to the hard resources (like GGTT, CTXs, DBs) we should
+also check if VF was already configured (by sysfs or debugfs) with
+optional parameters like execution quantum (EQ), preemption timeout
+(PT) or scheduling priority (PRIO) as otherwise we might miss to
+send to the GuC updated latest values after a resume or GT reset.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-9-michal.wajdeczko@intel.com
+(cherry-picked from commit 0701bf6fce0aa6f0f2122c9a324bd954d3d91b0b linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 32 ++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 703a954d7..abc6b5e22 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -2090,6 +2090,17 @@ static u32 pf_get_exec_quantum(struct xe_gt *gt, unsigned int vfid)
+ 	return config->exec_quantum[0];
+ }
+ 
++static bool pf_non_default_exec_quantum(struct xe_gt *gt, unsigned int vfid)
++{
++	struct xe_gt_sriov_config *config = pf_pick_vf_config(gt, vfid);
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(config->exec_quantum); i++)
++		if (config->exec_quantum[i])
++			return true;
++	return false;
++}
++
+ /**
+  * xe_gt_sriov_pf_config_set_exec_quantum_locked() - Configure PF/VF execution quantum.
+  * @gt: the &xe_gt
+@@ -2305,6 +2316,17 @@ static u32 pf_get_preempt_timeout(struct xe_gt *gt, unsigned int vfid)
+ 	return config->preempt_timeout[0];
+ }
+ 
++static bool pf_non_default_preempt_timeout(struct xe_gt *gt, unsigned int vfid)
++{
++	struct xe_gt_sriov_config *config = pf_pick_vf_config(gt, vfid);
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(config->preempt_timeout); i++)
++		if (config->preempt_timeout[i])
++			return true;
++	return false;
++}
++
+ /**
+  * xe_gt_sriov_pf_config_set_preempt_timeout_locked() - Configure PF/VF preemption timeout.
+  * @gt: the &xe_gt
+@@ -2603,6 +2625,13 @@ static void pf_reset_config_sched(struct xe_gt *gt, struct xe_gt_sriov_config *c
+ 	}
+ }
+ 
++static bool pf_non_default_sched(struct xe_gt *gt, unsigned int vfid)
++{
++	return pf_non_default_exec_quantum(gt, vfid) ||
++	       pf_non_default_preempt_timeout(gt, vfid) ||
++	       custom_sched_priority(gt, pf_get_sched_priority(gt, vfid));
++}
++
+ static int pf_provision_threshold(struct xe_gt *gt, unsigned int vfid,
+ 				  enum xe_guc_klv_threshold_index index, u32 value)
+ {
+@@ -2879,6 +2908,9 @@ static int pf_validate_vf_config(struct xe_gt *gt, unsigned int vfid)
+ 		valid_all = valid_all && valid_lmem;
+ 	}
+ 
++	/* also check optional EQ/PT/PRIO */
++	valid_any = valid_any || pf_non_default_sched(gt, vfid);
++
+ 	return valid_all ? 0 : valid_any ? -ENOKEY : -ENODATA;
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Don-t-reprovision-policies-if-already-defa.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Don-t-reprovision-policies-if-already-defa.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:19 +0200
+Subject: drm/xe/pf: Don't reprovision policies if already default
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+There is no need to send policy updates to the GuC if policies
+were not changed from the default settings (usually zero value).
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-7-michal.wajdeczko@intel.com
+(cherry-picked from commit 689937c71cbbec927ba2c04f86fd1e59de5097f3 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+index c88c4e6a9..55b54a519 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+@@ -178,6 +178,9 @@ static int pf_reprovision_sched_if_idle(struct xe_gt *gt)
+ 	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
++	if (!gt->sriov.pf.policy.guc.sched_if_idle)
++		return 0;
++
+ 	return pf_provision_sched_if_idle(gt, gt->sriov.pf.policy.guc.sched_if_idle);
+ }
+ 
+@@ -256,6 +259,9 @@ static int pf_reprovision_reset_engine(struct xe_gt *gt)
+ 	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
++	if (!gt->sriov.pf.policy.guc.reset_engine)
++		return 0;
++
+ 	return pf_provision_reset_engine(gt, gt->sriov.pf.policy.guc.reset_engine);
+ }
+ 
+@@ -322,6 +328,9 @@ static int pf_reprovision_sample_period(struct xe_gt *gt)
+ 	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
++	if (!gt->sriov.pf.policy.guc.sample_period)
++		return 0;
++
+ 	return pf_provision_sample_period(gt, gt->sriov.pf.policy.guc.sample_period);
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Encode-scheduling-priority-KLV-if-needed.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Encode-scheduling-priority-KLV-if-needed.patch
@@ -1,0 +1,116 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:20 +0200
+Subject: drm/xe/pf: Encode scheduling priority KLV if needed
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+After a reset we missed to reprovision VFs scheduling priority config.
+But as of today, the GuC firmware allows to change scheduling priority
+using config SCHED_PRIORITY KLV only for the PF and configuration of
+all VFs relies on the previously applied value of the SCHED_IF_IDLE
+policy. Use this policy value to check and decide whether we need to
+encode VF priority KLV while reprovisioning this VF.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-8-michal.wajdeczko@intel.com
+(cherry-picked from commit 43533f75c4577885da1f2e6fddeb88ccf61005f0 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 12 +++++++++++
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c | 25 ++++++++++++++++------
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h |  1 +
+ 3 files changed, 31 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index c74745642..703a954d7 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -285,6 +285,13 @@ static u32 encode_config_ggtt(u32 *cfg, const struct xe_gt_sriov_config *config,
+ 	return encode_ggtt(cfg, xe_ggtt_node_addr(node), xe_ggtt_node_size(node), details);
+ }
+ 
++static bool custom_sched_priority(struct xe_gt *gt, u32 priority)
++{
++	return xe_gt_sriov_pf_policy_get_sched_if_idle_locked(gt) ?
++		priority != GUC_SCHED_PRIORITY_NORMAL :
++		priority != GUC_SCHED_PRIORITY_LOW;
++}
++
+ static u32 encode_config_sched(struct xe_gt *gt, u32 *cfg, u32 n,
+ 			       const struct xe_gt_sriov_config *config)
+ {
+@@ -313,6 +320,11 @@ static u32 encode_config_sched(struct xe_gt *gt, u32 *cfg, u32 n,
+ 		cfg[n++] = config->preempt_timeout[0];
+ 	}
+ 
++	if (custom_sched_priority(gt, config->sched_priority)) {
++		cfg[n++] = PREP_GUC_KLV_TAG(VF_CFG_SCHED_PRIORITY);
++		cfg[n++] = config->sched_priority;
++	}
++
+ 	return n;
+ }
+ 
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+index 55b54a519..6c1036743 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+@@ -224,6 +224,22 @@ int xe_gt_sriov_pf_policy_set_sched_if_idle(struct xe_gt *gt, bool enable)
+ 	return 0;
+ }
+ 
++/**
++ * xe_gt_sriov_pf_policy_get_sched_if_idle_locked() - Retrieve value of 'sched_if_idle' policy.
++ * @gt: the &xe_gt where to read the policy from
++ *
++ * This function can only be called on PF.
++ *
++ * Return: last value of 'sched_if_idle' policy applied.
++ */
++bool xe_gt_sriov_pf_policy_get_sched_if_idle_locked(struct xe_gt *gt)
++{
++	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
++	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
++
++	return gt->sriov.pf.policy.guc.sched_if_idle;
++}
++
+ /**
+  * xe_gt_sriov_pf_policy_get_sched_if_idle - Retrieve value of 'sched_if_idle' policy.
+  * @gt: the &xe_gt where to read the policy from
+@@ -234,15 +250,10 @@ int xe_gt_sriov_pf_policy_set_sched_if_idle(struct xe_gt *gt, bool enable)
+  */
+ bool xe_gt_sriov_pf_policy_get_sched_if_idle(struct xe_gt *gt)
+ {
+-	bool enable;
+-
+ 	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
++	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
+ 
+-	mutex_lock(xe_gt_sriov_pf_master_mutex(gt));
+-	enable = gt->sriov.pf.policy.guc.sched_if_idle;
+-	mutex_unlock(xe_gt_sriov_pf_master_mutex(gt));
+-
+-	return enable;
++	return xe_gt_sriov_pf_policy_get_sched_if_idle_locked(gt);
+ }
+ 
+ static int pf_provision_reset_engine(struct xe_gt *gt, bool enable)
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
+index bd73aa58f..8c4c5b710 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
+@@ -15,6 +15,7 @@ struct xe_gt;
+ 
+ int xe_gt_sriov_pf_policy_set_sched_if_idle(struct xe_gt *gt, bool enable);
+ bool xe_gt_sriov_pf_policy_get_sched_if_idle(struct xe_gt *gt);
++bool xe_gt_sriov_pf_policy_get_sched_if_idle_locked(struct xe_gt *gt);
+ int xe_gt_sriov_pf_policy_set_reset_engine(struct xe_gt *gt, bool enable);
+ bool xe_gt_sriov_pf_policy_get_reset_engine(struct xe_gt *gt);
+ int xe_gt_sriov_pf_policy_set_sample_period(struct xe_gt *gt, u32 value);
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Extract-helper-to-show-which-VFs-are-provi.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Extract-helper-to-show-which-VFs-are-provi.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:24 +0200
+Subject: drm/xe/pf: Extract helper to show which VFs are provisioned
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In upcoming patches we will want to show which VFs were already
+provisioned with resources other than LMEM(VRAM). Convert code
+from the LMEM reporting function into a more generic helper that
+can handle both u32 and u64 resources and can report also PF.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-12-michal.wajdeczko@intel.com
+(cherry-picked from commit 67a5fb1f9ada7c3d8b7f571be86554968084a4b9 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 30 +++++++++++++++++-----
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index abc6b5e22..2eda63b69 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -1934,29 +1934,45 @@ static u64 pf_profile_fair_lmem(struct xe_gt *gt, unsigned int num_vfs)
+ 	return ALIGN_DOWN(fair, alignment);
+ }
+ 
+-static void __pf_show_provisioning_lmem(struct xe_gt *gt, unsigned int first_vf,
+-					unsigned int num_vfs, bool provisioned)
++static void __pf_show_provisioned(struct xe_gt *gt, unsigned int first_vf,
++				  unsigned int num_vfs, bool provisioned,
++				  u32 (*get32)(struct xe_gt *, unsigned int),
++				  u64 (*get64)(struct xe_gt *, unsigned int),
++				  const char *what)
+ {
+ 	unsigned int allvfs = 1 + xe_gt_sriov_pf_get_totalvfs(gt); /* PF plus VFs */
+ 	unsigned long *bitmap __free(bitmap) = bitmap_zalloc(allvfs, GFP_KERNEL);
+ 	unsigned int weight;
+ 	unsigned int n;
++	bool pf;
++
++	xe_gt_assert(gt, get32 || get64);
+ 
+ 	if (!bitmap)
+ 		return;
+ 
+ 	for (n = first_vf; n < first_vf + num_vfs; n++) {
+-		if (!!pf_get_vf_config_lmem(gt, VFID(n)) == provisioned)
++		if ((get32 && (!!get32(gt, VFID(n)) == provisioned)) ||
++		    (get64 && (!!get64(gt, VFID(n)) == provisioned)))
+ 			bitmap_set(bitmap, n, 1);
+ 	}
+ 
++	pf = test_and_clear_bit(0, bitmap);
+ 	weight = bitmap_weight(bitmap, allvfs);
+-	if (!weight)
++	if (!pf && !weight)
+ 		return;
+ 
+-	xe_gt_sriov_info(gt, "VF%s%*pbl %s provisioned with VRAM\n",
+-			 weight > 1 ? "s " : "", allvfs, bitmap,
+-			 provisioned ? "already" : "not");
++	xe_gt_sriov_info(gt, "%s%s%s%s%*pbl %s provisioned with %s\n",
++			 pf ? "PF" : "", pf && weight ? " and " : "",
++			 weight ? "VF" : "", weight > 1 ? "s " : "",
++			 allvfs, bitmap, provisioned ? "already" : "not", what);
++}
++
++static void __pf_show_provisioning_lmem(struct xe_gt *gt, unsigned int first_vf,
++					unsigned int num_vfs, bool provisioned)
++{
++	__pf_show_provisioned(gt, first_vf, num_vfs, provisioned,
++			      NULL, pf_get_vf_config_lmem, "VRAM");
+ }
+ 
+ static void pf_show_all_provisioned_lmem(struct xe_gt *gt)
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Extract-helpers-for-bulk-EQ-PT-provisionin.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Extract-helpers-for-bulk-EQ-PT-provisionin.patch
@@ -1,0 +1,139 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:25 +0200
+Subject: drm/xe/pf: Extract helpers for bulk EQ/PT provisioning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We already have functions to bulk provision execution quantum and
+preemption timeout, but they are applying changes to all possible
+VFs, while in upcoming patch we would like to provision only subset
+of available VFs.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-13-michal.wajdeczko@intel.com
+(cherry-picked from commit 4f91e3a5b79f3962acff8038dfb89394496faa7d linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 66 +++++++++++++---------
+ 1 file changed, 40 insertions(+), 26 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 2eda63b69..d02c96d30 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -2193,34 +2193,41 @@ u32 xe_gt_sriov_pf_config_get_exec_quantum(struct xe_gt *gt, unsigned int vfid)
+ 	return pf_get_exec_quantum(gt, vfid);
+ }
+ 
+-/**
+- * xe_gt_sriov_pf_config_bulk_set_exec_quantum_locked() - Configure EQ for PF and VFs.
+- * @gt: the &xe_gt to configure
+- * @exec_quantum: requested execution quantum in milliseconds (0 is infinity)
+- *
+- * This function can only be called on PF with the master mutex hold.
+- *
+- * Return: 0 on success or a negative error code on failure.
+- */
+-int xe_gt_sriov_pf_config_bulk_set_exec_quantum_locked(struct xe_gt *gt, u32 exec_quantum)
++static int pf_bulk_set_exec_quantum(struct xe_gt *gt, u32 exec_quantum,
++				    unsigned int first_vf, unsigned int num_vfs)
+ {
+-	unsigned int totalvfs = xe_gt_sriov_pf_get_totalvfs(gt);
+ 	unsigned int n;
+ 	int err = 0;
+ 
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
+-	for (n = 0; n <= totalvfs; n++) {
++	for (n = first_vf; n < first_vf + num_vfs; n++) {
+ 		err = pf_provision_exec_quantum(gt, VFID(n), exec_quantum);
+ 		if (err)
+ 			break;
+ 	}
+ 
+-	return pf_config_bulk_set_u32_done(gt, 0, 1 + totalvfs, exec_quantum,
++	return pf_config_bulk_set_u32_done(gt, first_vf, num_vfs, exec_quantum,
+ 					   pf_get_exec_quantum, "execution quantum",
+ 					   exec_quantum_unit, n, err);
+ }
+ 
++/**
++ * xe_gt_sriov_pf_config_bulk_set_exec_quantum_locked() - Configure EQ for PF and VFs.
++ * @gt: the &xe_gt to configure
++ * @exec_quantum: requested execution quantum in milliseconds (0 is infinity)
++ *
++ * This function can only be called on PF with the master mutex hold.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_gt_sriov_pf_config_bulk_set_exec_quantum_locked(struct xe_gt *gt, u32 exec_quantum)
++{
++	unsigned int totalvfs = xe_gt_sriov_pf_get_totalvfs(gt);
++
++	return pf_bulk_set_exec_quantum(gt, exec_quantum, PFID, 1 + totalvfs);
++}
++
+ static int pf_provision_groups_exec_quantums(struct xe_gt *gt, unsigned int vfid,
+ 					     const u32 *exec_quantums, u32 count)
+ {
+@@ -2418,34 +2425,41 @@ u32 xe_gt_sriov_pf_config_get_preempt_timeout(struct xe_gt *gt, unsigned int vfi
+ 	return pf_get_preempt_timeout(gt, vfid);
+ }
+ 
+-/**
+- * xe_gt_sriov_pf_config_bulk_set_preempt_timeout_locked() - Configure PT for PF and VFs.
+- * @gt: the &xe_gt to configure
+- * @preempt_timeout: requested preemption timeout in microseconds (0 is infinity)
+- *
+- * This function can only be called on PF with the master mutex hold.
+- *
+- * Return: 0 on success or a negative error code on failure.
+- */
+-int xe_gt_sriov_pf_config_bulk_set_preempt_timeout_locked(struct xe_gt *gt, u32 preempt_timeout)
++static int pf_bulk_set_preempt_timeout(struct xe_gt *gt, u32 preempt_timeout,
++				       unsigned int first_vf, unsigned int num_vfs)
+ {
+-	unsigned int totalvfs = xe_gt_sriov_pf_get_totalvfs(gt);
+ 	unsigned int n;
+ 	int err = 0;
+ 
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
+-	for (n = 0; n <= totalvfs; n++) {
++	for (n = first_vf; n < first_vf + num_vfs; n++) {
+ 		err = pf_provision_preempt_timeout(gt, VFID(n), preempt_timeout);
+ 		if (err)
+ 			break;
+ 	}
+ 
+-	return pf_config_bulk_set_u32_done(gt, 0, 1 + totalvfs, preempt_timeout,
++	return pf_config_bulk_set_u32_done(gt, first_vf, num_vfs, preempt_timeout,
+ 					   pf_get_preempt_timeout, "preemption timeout",
+ 					   preempt_timeout_unit, n, err);
+ }
+ 
++/**
++ * xe_gt_sriov_pf_config_bulk_set_preempt_timeout_locked() - Configure PT for PF and VFs.
++ * @gt: the &xe_gt to configure
++ * @preempt_timeout: requested preemption timeout in microseconds (0 is infinity)
++ *
++ * This function can only be called on PF with the master mutex hold.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_gt_sriov_pf_config_bulk_set_preempt_timeout_locked(struct xe_gt *gt, u32 preempt_timeout)
++{
++	unsigned int totalvfs = xe_gt_sriov_pf_get_totalvfs(gt);
++
++	return pf_bulk_set_preempt_timeout(gt, preempt_timeout, PFID, 1 + totalvfs);
++}
++
+ static int pf_provision_groups_preempt_timeouts(struct xe_gt *gt, unsigned int vfid,
+ 						const u32 *preempt_timeouts, u32 count)
+ {
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Fix-pf_get_sched_priority-function-signatu.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Fix-pf_get_sched_priority-function-signatu.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:15 +0200
+Subject: drm/xe/pf: Fix pf_get_sched_priority() function signature
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The pf_get_sched_priority() function returns scheduling priority
+that we defined as u32 so while it works we shouldn't return int.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-3-michal.wajdeczko@intel.com
+(cherry-picked from commit a438423409692833e3b0f56a1d8440ac1761e594 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 2f376b5fb..658e9b048 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -2500,7 +2500,7 @@ static int pf_provision_sched_priority(struct xe_gt *gt, unsigned int vfid, u32
+ 	return 0;
+ }
+ 
+-static int pf_get_sched_priority(struct xe_gt *gt, unsigned int vfid)
++static u32 pf_get_sched_priority(struct xe_gt *gt, unsigned int vfid)
+ {
+ 	struct xe_gt_sriov_config *config = pf_pick_vf_config(gt, vfid);
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Force-new-VFs-prorities-only-once.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Force-new-VFs-prorities-only-once.patch
@@ -1,0 +1,161 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:16 +0200
+Subject: drm/xe/pf: Force new VFs prorities only once
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We should force change of VFs scheduling priorities only after
+initial change of the SCHED_IF_IDLE policy. Doing that also during
+any later policy reprovisioning will overwrite changes done on the
+individual per-VF scheduling priorities (currently only for PF).
+
+While around also move priority change code to the _config component
+to maintain a proper isolation. Also document our expectation about
+the GuC version where the new meaning of the policy KLV is present.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-4-michal.wajdeczko@intel.com
+(cherry-picked from commit fbbf73a81b845ea6fd40688a63570298298d03c1 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 29 ++++++++++++++
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h |  1 +
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c | 44 ++++++++++------------
+ 3 files changed, 49 insertions(+), 25 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index 658e9b048..c74745642 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -2550,6 +2550,35 @@ u32 xe_gt_sriov_pf_config_get_sched_priority(struct xe_gt *gt, unsigned int vfid
+ 	return priority;
+ }
+ 
++/**
++ * xe_gt_sriov_pf_config_force_sched_priority_locked() - Force update scheduling priority.
++ * @gt: the &xe_gt
++ * @priority: new scheduling priority to set
++ *
++ * This function allows to update cached values of the scheduling priorities of all
++ * VFs (and PF) as result of applying the `GUC_KLV_VGT_POLICY_SCHED_IF_IDLE`_ policy.
++ *
++ * This function can only be called on PF.
++ */
++void xe_gt_sriov_pf_config_force_sched_priority_locked(struct xe_gt *gt, u32 priority)
++{
++	unsigned int total_vfs = 1 + xe_gt_sriov_pf_get_totalvfs(gt);
++	struct xe_gt_sriov_config *config;
++	unsigned int n;
++
++	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
++	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
++
++	for (n = 0; n < total_vfs; n++) {
++		config = pf_pick_vf_config(gt, VFID(n));
++		config->sched_priority = priority;
++	}
++
++	pf_config_bulk_set_u32_done(gt, PFID, 1 + total_vfs, priority,
++				    pf_get_sched_priority, "scheduling priority",
++				    sched_priority_unit, n, 0);
++}
++
+ static void pf_reset_config_sched(struct xe_gt *gt, struct xe_gt_sriov_config *config)
+ {
+ 	int i;
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
+index 4a004ecd6..e9314f0a9 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
+@@ -71,6 +71,7 @@ int xe_gt_sriov_pf_config_set_groups_preempt_timeouts(struct xe_gt *gt, unsigned
+ 
+ u32 xe_gt_sriov_pf_config_get_sched_priority(struct xe_gt *gt, unsigned int vfid);
+ int xe_gt_sriov_pf_config_set_sched_priority(struct xe_gt *gt, unsigned int vfid, u32 priority);
++void xe_gt_sriov_pf_config_force_sched_priority_locked(struct xe_gt *gt, u32 priority);
+ 
+ u32 xe_gt_sriov_pf_config_get_threshold(struct xe_gt *gt, unsigned int vfid,
+ 					enum xe_guc_klv_threshold_index index);
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+index 848e24926..6ab02e96e 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+@@ -8,6 +8,7 @@
+ #include "abi/guc_actions_sriov_abi.h"
+ 
+ #include "xe_gt.h"
++#include "xe_gt_sriov_pf_config.h"
+ #include "xe_gt_sriov_pf_helpers.h"
+ #include "xe_gt_sriov_pf_policy.h"
+ #include "xe_gt_sriov_printk.h"
+@@ -153,33 +154,14 @@ static int pf_update_policy_u32(struct xe_gt *gt, u16 key, u32 *policy, u32 valu
+ 	return 0;
+ }
+ 
+-static void pf_bulk_reset_sched_priority(struct xe_gt *gt, u32 priority)
+-{
+-	unsigned int total_vfs = 1 + xe_gt_sriov_pf_get_totalvfs(gt);
+-	unsigned int n;
+-
+-	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+-	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+-
+-	for (n = 0; n < total_vfs; n++)
+-		gt->sriov.pf.vfs[n].config.sched_priority = priority;
+-}
+-
+ static int pf_provision_sched_if_idle(struct xe_gt *gt, bool enable)
+ {
+-	int err;
+-
+ 	xe_gt_assert(gt, IS_SRIOV_PF(gt_to_xe(gt)));
+ 	lockdep_assert_held(xe_gt_sriov_pf_master_mutex(gt));
+ 
+-	err = pf_update_policy_bool(gt, GUC_KLV_VGT_POLICY_SCHED_IF_IDLE_KEY,
+-				    &gt->sriov.pf.policy.guc.sched_if_idle,
+-				    enable);
+-
+-	if (!err)
+-		pf_bulk_reset_sched_priority(gt, enable ? GUC_SCHED_PRIORITY_NORMAL :
+-					     GUC_SCHED_PRIORITY_LOW);
+-	return err;
++	return pf_update_policy_bool(gt, GUC_KLV_VGT_POLICY_SCHED_IF_IDLE_KEY,
++				     &gt->sriov.pf.policy.guc.sched_if_idle,
++				     enable);
+ }
+ 
+ static int pf_reprovision_sched_if_idle(struct xe_gt *gt)
+@@ -209,13 +191,25 @@ static void pf_sanitize_sched_if_idle(struct xe_gt *gt)
+  */
+ int xe_gt_sriov_pf_policy_set_sched_if_idle(struct xe_gt *gt, bool enable)
+ {
++	u32 priority;
+ 	int err;
+ 
+-	mutex_lock(xe_gt_sriov_pf_master_mutex(gt));
++	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
++
+ 	err = pf_provision_sched_if_idle(gt, enable);
+-	mutex_unlock(xe_gt_sriov_pf_master_mutex(gt));
++	if (err)
++		return err;
+ 
+-	return err;
++	/*
++	 * As of GuC 70.12 a change of this policy impacts individual configs
++	 * of all VFs. See `GUC_KLV_VGT_POLICY_SCHED_IF_IDLE`_ for details.
++	 */
++	xe_gt_assert(gt, GUC_FIRMWARE_VER_AT_LEAST(&gt->uc.guc, 70, 12));
++
++	priority = enable ? GUC_SCHED_PRIORITY_NORMAL : GUC_SCHED_PRIORITY_LOW;
++	xe_gt_sriov_pf_config_force_sched_priority_locked(gt, priority);
++
++	return 0;
+ }
+ 
+ /**
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Perform-fair-scheduling-auto-provisioning.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Perform-fair-scheduling-auto-provisioning.patch
@@ -1,0 +1,161 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:26 +0200
+Subject: drm/xe/pf: Perform fair scheduling auto-provisioning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Default VF scheduling configuration is the same as for the PF and
+includes unlimited execution quantum (EQ) and unlimited preemption
+timeout (PT). While this setup gives the most flexibility it does
+not protect the PF or VFs from other VF that could constantly submit
+workloads without any gaps that would let GuC do a VF-switch.
+
+To avoid that, do some trivial auto-provisioning and configure PF
+and all VFs with 16ms EQ and PT. This setup should allow GuC to
+perform a full round-robin with up to 63 VFs within 2s, which in
+turn should match expectations from most of the VMs using VFs.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com> #v1
+Reviewed-by: Michał Winiarski <michal.winiarski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-14-michal.wajdeczko@intel.com
+(cherry-picked from commit afc480ff55c5244f3a1941096f232b57c354cc68 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c | 91 ++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h |  1 +
+ drivers/gpu/drm/xe/xe_sriov_pf_provision.c |  2 +
+ 3 files changed, 94 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+index d02c96d30..e112aa148 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.c
+@@ -2662,6 +2662,97 @@ static bool pf_non_default_sched(struct xe_gt *gt, unsigned int vfid)
+ 	       custom_sched_priority(gt, pf_get_sched_priority(gt, vfid));
+ }
+ 
++static void __pf_show_provisioned_sched(struct xe_gt *gt, unsigned int first_vf,
++					unsigned int num_vfs, bool provisioned)
++{
++	__pf_show_provisioned(gt, first_vf, num_vfs, provisioned,
++			      pf_get_exec_quantum, NULL, "EQ");
++	__pf_show_provisioned(gt, first_vf, num_vfs, provisioned,
++			      pf_get_preempt_timeout, NULL, "PT");
++
++	/* we only care about non-default priorities */
++	if (provisioned)
++		__pf_show_provisioned(gt, first_vf, num_vfs, true,
++				      pf_get_sched_priority, NULL, "PRIORITY");
++}
++
++static void pf_show_all_provisioned_sched(struct xe_gt *gt)
++{
++	__pf_show_provisioned_sched(gt, PFID, 1 + xe_gt_sriov_pf_get_totalvfs(gt), true);
++}
++
++static void pf_show_unprovisioned_sched(struct xe_gt *gt, unsigned int num_vfs)
++{
++	__pf_show_provisioned_sched(gt, PFID, 1 + num_vfs, false);
++}
++
++static bool pf_needs_provision_sched(struct xe_gt *gt, unsigned int num_vfs)
++{
++	unsigned int vfid;
++
++	for (vfid = PFID; vfid <= PFID + num_vfs; vfid++) {
++		if (pf_non_default_sched(gt, vfid)) {
++			pf_show_all_provisioned_sched(gt);
++			pf_show_unprovisioned_sched(gt, num_vfs);
++			return false;
++		}
++	}
++
++	if (xe_gt_sriov_pf_policy_get_sched_if_idle_locked(gt)) {
++		pf_show_all_provisioned_sched(gt);
++		pf_show_unprovisioned_sched(gt, num_vfs);
++		return false;
++	}
++
++	pf_show_all_provisioned_sched(gt);
++	return true;
++}
++
++/* With 16ms EQ/PT GuC should be able to handle up to 63 VFs within 2s */
++#define XE_FAIR_EXEC_QUANTUM_MS		16
++#define XE_FAIR_PREEMPT_TIMEOUT_US	16000
++#define XE_FAIR_SCHED_PRIORITY		GUC_SCHED_PRIORITY_LOW
++#define XE_ADMIN_PF_SCHED_PRIORITY	GUC_SCHED_PRIORITY_HIGH
++
++/**
++ * xe_gt_sriov_pf_config_set_fair_sched() - Provision PF and VFs with fair scheduling.
++ * @gt: the &xe_gt
++ * @num_vfs: number of VFs to provision (can't be 0)
++ *
++ * This function can only be called on PF.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_gt_sriov_pf_config_set_fair_sched(struct xe_gt *gt, unsigned int num_vfs)
++{
++	int result = 0;
++	int err;
++
++	xe_gt_assert(gt, num_vfs);
++	xe_gt_assert(gt, XE_FAIR_EXEC_QUANTUM_MS);
++	xe_gt_assert(gt, XE_FAIR_PREEMPT_TIMEOUT_US);
++
++	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
++
++	if (!pf_needs_provision_sched(gt, num_vfs))
++		return 0;
++
++	err = pf_bulk_set_exec_quantum(gt, XE_FAIR_EXEC_QUANTUM_MS, PFID, 1 + num_vfs);
++	result = result ?: err;
++	err = pf_bulk_set_preempt_timeout(gt, XE_FAIR_PREEMPT_TIMEOUT_US, PFID, 1 + num_vfs);
++	result = result ?: err;
++
++	xe_gt_assert(gt, XE_FAIR_SCHED_PRIORITY == GUC_SCHED_PRIORITY_LOW);
++	xe_gt_assert(gt, !xe_gt_sriov_pf_policy_get_sched_if_idle_locked(gt));
++
++	if (xe_sriov_pf_admin_only(gt_to_xe(gt))) {
++		err = pf_provision_sched_priority(gt, PFID, XE_ADMIN_PF_SCHED_PRIORITY);
++		result = result ?: err;
++	}
++
++	return result;
++}
++
+ static int pf_provision_threshold(struct xe_gt *gt, unsigned int vfid,
+ 				  enum xe_guc_klv_threshold_index index, u32 value)
+ {
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
+index e9314f0a9..2ec62c12a 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_config.h
+@@ -78,6 +78,7 @@ u32 xe_gt_sriov_pf_config_get_threshold(struct xe_gt *gt, unsigned int vfid,
+ int xe_gt_sriov_pf_config_set_threshold(struct xe_gt *gt, unsigned int vfid,
+ 					enum xe_guc_klv_threshold_index index, u32 value);
+ 
++int xe_gt_sriov_pf_config_set_fair_sched(struct xe_gt *gt, unsigned int num_vfs);
+ int xe_gt_sriov_pf_config_set_fair(struct xe_gt *gt, unsigned int vfid, unsigned int num_vfs);
+ int xe_gt_sriov_pf_config_sanitize(struct xe_gt *gt, unsigned int vfid, long timeout);
+ int xe_gt_sriov_pf_config_release(struct xe_gt *gt, unsigned int vfid, bool force);
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_provision.c b/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
+index e11874d68..0ec7ea83f 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
+@@ -41,6 +41,8 @@ static int pf_provision_vfs(struct xe_device *xe, unsigned int num_vfs)
+ 	int err;
+ 
+ 	for_each_gt(gt, xe, id) {
++		err = xe_gt_sriov_pf_config_set_fair_sched(gt, num_vfs);
++		result = result ?: err;
+ 		err = xe_gt_sriov_pf_config_set_fair(gt, VFID(1), num_vfs);
+ 		result = result ?: err;
+ 	}
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Print-applied-policy-KLVs.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Print-applied-policy-KLVs.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:17 +0200
+Subject: drm/xe/pf: Print applied policy KLVs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Under CONFIG_DRM_XE_DEBUG_SRIOV print all policy KLVs sent to the
+GuC for better diagnostics.  This is similar what we are already
+doing with VF configuration KLVs.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-5-michal.wajdeczko@intel.com
+(cherry-picked from commit 980bb387fb08163d0692f25892d8b3e34542349c linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+index 6ab02e96e..c88c4e6a9 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+@@ -68,6 +68,15 @@ static int pf_push_policy_buf_klvs(struct xe_gt *gt, u32 num_klvs,
+ 		return err;
+ 	}
+ 
++	if (IS_ENABLED(CONFIG_DRM_XE_DEBUG_SRIOV)) {
++		struct drm_printer p = xe_gt_dbg_printer(gt);
++		void *klvs = xe_guc_buf_cpu_ptr(buf);
++
++		xe_gt_sriov_dbg(gt, "pushed policy update with %u KLV%s:\n",
++				num_klvs, str_plural(num_klvs));
++		xe_guc_klv_print(klvs, num_dwords, &p);
++	}
++
+ 	return 0;
+ }
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Reprovision-policy-settings-after-GT-reset.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Reprovision-policy-settings-after-GT-reset.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:18 +0200
+Subject: drm/xe/pf: Reprovision policy settings after GT reset
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In addition to the reprovisioning of individual VFs configurations,
+we should also reprovision GuC global policy settings. Note that we
+already had a draft function for that but we missed to call it once
+we started handling GT reset. Reuse it now but don't take extra RPM
+as this is now a caller responsibility and drop unused parameter.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-6-michal.wajdeczko@intel.com
+(cherry-picked from commit b23883a0874fbca9ada07b75509c6126fb5f3575 linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_gt_sriov_pf.c        |  1 +
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c | 14 +++-----------
+ drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h |  2 +-
+ 3 files changed, 5 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf.c
+index fb5c9101e..786805684 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf.c
+@@ -219,6 +219,7 @@ static void pf_restart(struct xe_gt *gt)
+ 
+ 	xe_gt_assert(gt, !xe_pm_runtime_suspended(xe));
+ 
++	xe_gt_sriov_pf_policy_restart(gt);
+ 	xe_gt_sriov_pf_config_restart(gt);
+ 	xe_gt_sriov_pf_control_restart(gt);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+index d1d494d00..e8458d637 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.c
+@@ -17,7 +17,6 @@
+ #include "xe_guc_ct.h"
+ #include "xe_guc_klv_helpers.h"
+ #include "xe_guc_submit.h"
+-#include "xe_pm.h"
+ 
+ /*
+  * Return: number of KLVs that were successfully parsed and saved,
+@@ -729,30 +728,23 @@ void xe_gt_sriov_pf_policy_sanitize(struct xe_gt *gt)
+ }
+ 
+ /**
+- * xe_gt_sriov_pf_policy_reprovision - Reprovision (and optionally reset) policy settings.
++ * xe_gt_sriov_pf_policy_restart() - Reprovision policy settings.
+  * @gt: the &xe_gt
+- * @reset: if true will reprovision using default values instead of latest
+  *
+  * This function can only be called on PF.
+  *
+  * Return: 0 on success or a negative error code on failure.
+  */
+-int xe_gt_sriov_pf_policy_reprovision(struct xe_gt *gt, bool reset)
++int xe_gt_sriov_pf_policy_restart(struct xe_gt *gt)
+ {
+ 	int err = 0;
+ 
+-	xe_pm_runtime_get_noresume(gt_to_xe(gt));
++	guard(mutex)(xe_gt_sriov_pf_master_mutex(gt));
+ 
+-	mutex_lock(xe_gt_sriov_pf_master_mutex(gt));
+-	if (reset)
+-		pf_sanitize_guc_policies(gt);
+ 	err |= pf_reprovision_sched_if_idle(gt);
+ 	err |= pf_reprovision_reset_engine(gt);
+ 	err |= pf_reprovision_sample_period(gt);
+ 	err |= pf_reprovision_sched_groups(gt);
+-	mutex_unlock(xe_gt_sriov_pf_master_mutex(gt));
+-
+-	xe_pm_runtime_put(gt_to_xe(gt));
+ 
+ 	return err ? -ENXIO : 0;
+ }
+diff --git a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
+index 071097fea..d667d6689 100644
+--- a/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
++++ b/drivers/gpu/drm/xe/xe_gt_sriov_pf_policy.h
+@@ -31,7 +31,7 @@ bool xe_gt_sriov_pf_policy_sched_groups_enabled(struct xe_gt *gt);
+ 
+ void xe_gt_sriov_pf_policy_init(struct xe_gt *gt);
+ void xe_gt_sriov_pf_policy_sanitize(struct xe_gt *gt);
+-int xe_gt_sriov_pf_policy_reprovision(struct xe_gt *gt, bool reset);
++int xe_gt_sriov_pf_policy_restart(struct xe_gt *gt);
+ int xe_gt_sriov_pf_policy_print(struct xe_gt *gt, struct drm_printer *p);
+ 
+ #endif
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-pf-Reprovision-scheduling-to-default-when-no-.patch
+++ b/backport/patches/base/0001-drm-xe-pf-Reprovision-scheduling-to-default-when-no-.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Date: Thu, 2 Apr 2026 21:17:23 +0200
+Subject: drm/xe/pf: Reprovision scheduling to default when no VFs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Once we have disabled VFs there is no point in keeping potentially
+limited PF scheduling provisioning as we want to complete a cleanup
+of the VFs resources and return to the pure native mode, the same
+as before VFs were enabled, as soon as possible.
+
+Signed-off-by: Michal Wajdeczko <michal.wajdeczko@intel.com>
+Reviewed-by: Piotr Piórkowski <piotr.piorkowski@intel.com>
+Link: https://patch.msgid.link/20260402191726.4932-11-michal.wajdeczko@intel.com
+(cherry-picked from commit 24ac010a97b6e6a65dc32ee2af1cdbe4a44daf7e linux-next)
+Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci_sriov.c          |  2 ++
+ drivers/gpu/drm/xe/xe_sriov_pf_provision.c | 39 ++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_sriov_pf_provision.h |  1 +
+ 3 files changed, 42 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci_sriov.c b/drivers/gpu/drm/xe/xe_pci_sriov.c
+index 3fd22034f..35e6b53e1 100644
+--- a/drivers/gpu/drm/xe/xe_pci_sriov.c
++++ b/drivers/gpu/drm/xe/xe_pci_sriov.c
+@@ -191,6 +191,8 @@ static int pf_disable_vfs(struct xe_device *xe)
+ 
+ 	pci_disable_sriov(pdev);
+ 
++	xe_sriov_pf_reprovision_default(xe);
++
+ 	pf_reset_vfs(xe, num_vfs);
+ 
+ 	xe_sriov_pf_unprovision_vfs(xe, num_vfs);
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_provision.c b/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
+index abe3677d3..e11874d68 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_provision.c
+@@ -103,6 +103,45 @@ int xe_sriov_pf_unprovision_vfs(struct xe_device *xe, unsigned int num_vfs)
+ 	return 0;
+ }
+ 
++static int pf_reprovision_default(struct xe_device *xe)
++{
++	struct xe_gt *gt;
++	unsigned int id;
++	int result = 0;
++	int err;
++
++	guard(mutex)(xe_sriov_pf_master_mutex(xe));
++
++	for_each_gt(gt, xe, id) {
++		err = xe_gt_sriov_pf_policy_set_sched_if_idle_locked(gt, false);
++		result = result ?: err;
++		err = xe_gt_sriov_pf_config_set_exec_quantum_locked(gt, PFID, 0);
++		result = result ?: err;
++		err = xe_gt_sriov_pf_config_set_preempt_timeout_locked(gt, PFID, 0);
++		result = result ?: err;
++	}
++
++	return result;
++}
++
++/**
++ * xe_sriov_pf_reprovision_default() - Reprovision default PF in auto-mode.
++ * @xe: the PF &xe_device
++ *
++ * This function can only be called on PF.
++ *
++ * Return: 0 on success or a negative error code on failure.
++ */
++int xe_sriov_pf_reprovision_default(struct xe_device *xe)
++{
++	xe_assert(xe, IS_SRIOV_PF(xe));
++
++	if (!pf_auto_provisioning_mode(xe))
++		return 0;
++
++	return pf_reprovision_default(xe);
++}
++
+ /**
+  * xe_sriov_pf_provision_set_mode() - Change VFs provision mode.
+  * @xe: the PF &xe_device
+diff --git a/drivers/gpu/drm/xe/xe_sriov_pf_provision.h b/drivers/gpu/drm/xe/xe_sriov_pf_provision.h
+index f26f49539..b15e4d7ad 100644
+--- a/drivers/gpu/drm/xe/xe_sriov_pf_provision.h
++++ b/drivers/gpu/drm/xe/xe_sriov_pf_provision.h
+@@ -30,6 +30,7 @@ int xe_sriov_pf_provision_query_vf_vram(struct xe_device *xe, unsigned int vfid,
+ 
+ int xe_sriov_pf_provision_vfs(struct xe_device *xe, unsigned int num_vfs);
+ int xe_sriov_pf_unprovision_vfs(struct xe_device *xe, unsigned int num_vfs);
++int xe_sriov_pf_reprovision_default(struct xe_device *xe);
+ 
+ int xe_sriov_pf_provision_set_mode(struct xe_device *xe, enum xe_sriov_provisioning_mode mode);
+ 
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -40,6 +40,19 @@ backport/patches/base/0001-drm-xe-oa-Add-val-arg-to-xe_oa_is_valid_config_reg.pa
 backport/patches/base/0001-drm-xe-oa-MERTOA-Wa_14026779378.patch
 backport/patches/base/0001-drm-xe-oa-Fix-offset-alignment-for-MERT-WHITELIST_OA.patch
 backport/patches/base/0001-platform-x86-intel-vsec-Restore-BAR-fallback-for-hea.patch
+backport/patches/base/0001-drm-xe-guc-Update-POLICY_SCHED_IF_IDLE-documentation.patch
+backport/patches/base/0001-drm-xe-pf-Fix-pf_get_sched_priority-function-signatu.patch
+backport/patches/base/0001-drm-xe-pf-Force-new-VFs-prorities-only-once.patch
+backport/patches/base/0001-drm-xe-pf-Print-applied-policy-KLVs.patch
+backport/patches/base/0001-drm-xe-pf-Reprovision-policy-settings-after-GT-reset.patch
+backport/patches/base/0001-drm-xe-pf-Don-t-reprovision-policies-if-already-defa.patch
+backport/patches/base/0001-drm-xe-pf-Encode-scheduling-priority-KLV-if-needed.patch
+backport/patches/base/0001-drm-xe-pf-Check-EQ-PT-PRIO-when-testing-VF-config.patch
+backport/patches/base/0001-drm-xe-pf-Allow-to-change-sched_if_idle-policy-under.patch
+backport/patches/base/0001-drm-xe-pf-Reprovision-scheduling-to-default-when-no-.patch
+backport/patches/base/0001-drm-xe-pf-Extract-helper-to-show-which-VFs-are-provi.patch
+backport/patches/base/0001-drm-xe-pf-Extract-helpers-for-bulk-EQ-PT-provisionin.patch
+backport/patches/base/0001-drm-xe-pf-Perform-fair-scheduling-auto-provisioning.patch
 # fixes
 backport/patches/fixes/base/0001-drm-xe-Fix-PTE-index-in-xe_vm_populate_pgtable-for-c.patch
 backport/patches/fixes/base/0001-drm-xe-remove-duplicate-kunit-test-bug.h-include.patch


### PR DESCRIPTION
Improve PF and VF scheduling policy provisioning to provide fair
scheduling by default.

Auto-provision EQ/PT to 16ms when VFs are enabled, while handling
policy reprovisioning across GT resets and VF configuration changes.
Also fix scheduling priority handling and avoid unnecessary policy
updates when the default configuration is already applied.

This ensures a VF cannot continuously submit workloads without
allowing GuC to switch between VFs.

Signed-off-by: Bommu Krishnaiah <krishnaiah.bommu@intel.com>