### PR TITLE
TODO: disable xe_i2c compilation based on designware_i2c header

### DIFF
--- a/autotools/m4/xe.m4
+++ b/autotools/m4/xe.m4
@@ -216,6 +216,8 @@ dnl # Macros to check for header availability
 	AC_KERNEL_CHECK_HEADERS([linux/unaligned.h])
 	dnl # v5.19-6a99099fe1d6 drm/display: Move HDCP helpers into display-helper module
 	AC_KERNEL_CHECK_HEADERS([drm/display/drm_hdcp.h])
+	dnl # Check for designware i2c header
+	AC_KERNEL_CHECK_HEADERS([linux/designware_i2c.h])
 
 	AC_KERNEL_WAIT
 ])

--- a/patches/0001-disable-xe_i2c-compilation-based-on-designware_i2c-h.patch
+++ b/patches/0001-disable-xe_i2c-compilation-based-on-designware_i2c-h.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pravalika Gurram <pravalika.gurram@intel.com>
+Date: Thu, 20 Aug 2026 17:24:52 +0530
+Subject: TODO: disable xe_i2c compilation based on designware_i2c header
+
+disable xe_i2c from the build until backport compatibility is added
+
+Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/Makefile |  2 ++
+ drivers/gpu/drm/xe/xe_i2c.h | 10 ++++++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/Makefile b/drivers/gpu/drm/xe/Makefile
+index 72b1480..1b135e0 100644
+--- a/drivers/gpu/drm/xe/Makefile
++++ b/drivers/gpu/drm/xe/Makefile
+@@ -154,7 +154,9 @@ xe-y += xe_bb.o \
+ 	xe_wait_user_fence.o \
+ 	xe_wopcm.o
+ 
++ifneq ($(wildcard $(KLIB_BUILD)/include/linux/designware_i2c.h),)
+ xe-$(CONFIG_I2C)	+= xe_i2c.o
++endif
+ xe-$(CONFIG_PRELIM_DRM_XE_EUDEBUG) += prelim/xe_eudebug.o \
+ 	prelim/xe_debug_metadata.o
+ xe-$(CONFIG_DRM_GPUSVM) += xe_svm.o
+diff --git a/drivers/gpu/drm/xe/xe_i2c.h b/drivers/gpu/drm/xe/xe_i2c.h
+index 425d816..7fd40c8 100644
+--- a/drivers/gpu/drm/xe/xe_i2c.h
++++ b/drivers/gpu/drm/xe/xe_i2c.h
+@@ -48,6 +48,7 @@ struct xe_i2c {
+ };
+ 
+ #if IS_ENABLED(CONFIG_I2C)
++#ifdef HAVE_LINUX_DESIGNWARE_I2C_H
+ int xe_i2c_probe(struct xe_device *xe);
+ bool xe_i2c_present(struct xe_device *xe);
+ void xe_i2c_irq_handler(struct xe_device *xe, u32 master_ctl);
+@@ -64,5 +65,14 @@ static inline void xe_i2c_irq_reset(struct xe_device *xe) { }
+ static inline void xe_i2c_pm_suspend(struct xe_device *xe) { }
+ static inline void xe_i2c_pm_resume(struct xe_device *xe, bool d3cold) { }
+ #endif
++#else
++static inline int xe_i2c_probe(struct xe_device *xe) { return 0; }
++static inline bool xe_i2c_present(struct xe_device *xe) { return false; }
++static inline void xe_i2c_irq_handler(struct xe_device *xe, u32 master_ctl) { }
++static inline void xe_i2c_irq_postinstall(struct xe_device *xe) { }
++static inline void xe_i2c_irq_reset(struct xe_device *xe) { }
++static inline void xe_i2c_pm_suspend(struct xe_device *xe) { }
++static inline void xe_i2c_pm_resume(struct xe_device *xe, bool d3cold) { }
++#endif
+ 
+ #endif
+-- 
+2.43.0
+


### PR DESCRIPTION
The xe_i2c will be enabled once we have designware support in kernel,
which is not available in all kernel versions. Conditionally disable xe_i2c
compilation at the Makefile level using a wildcard check for the
header, and guard the function declarations in xe_i2c.h.

This will be enabled once full i2c backport support is added.

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>