### PR TITLE
Backport-only:drm/xe/cri: Bump GuC version to 70.70.0

### DIFF
--- a/backport/patches/base/0001-Backport-only-drm-xe-cri-Bump-GuC-version-to-70.70.0.patch
+++ b/backport/patches/base/0001-Backport-only-drm-xe-cri-Bump-GuC-version-to-70.70.0.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Balasubramani Vivekanandan <balasubramani.vivekanandan@intel.com>
+Date: Mon, 29 Jun 2026 11:51:29 +0530
+Subject: Backport-only:drm/xe/cri: Bump GuC version to 70.70.0
+
+Signed-off-by: Balasubramani Vivekanandan <balasubramani.vivekanandan@intel.com>
+---
+ drivers/gpu/drm/xe/xe_uc_fw.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_uc_fw.c b/drivers/gpu/drm/xe/xe_uc_fw.c
+index 546bac3cc..4d05b06f5 100644
+--- a/drivers/gpu/drm/xe/xe_uc_fw.c
++++ b/drivers/gpu/drm/xe/xe_uc_fw.c
+@@ -115,7 +115,7 @@ struct fw_blobs_by_type {
+ #define XE_GT_TYPE_ANY XE_GT_TYPE_UNINITIALIZED
+ 
+ #define XE_GUC_FIRMWARE_DEFS(fw_def, mmp_ver, major_ver)					\
+-	fw_def(CRESCENTISLAND,	GT_TYPE_ANY,	mmp_ver(xe,	guc,	cri,	70, 68, 0))	\
++	fw_def(CRESCENTISLAND,	GT_TYPE_ANY,	mmp_ver(xe,	guc,	cri,	70, 70, 0))	\
+ 	fw_def(PANTHERLAKE,	GT_TYPE_ANY,	major_ver(xe,	guc,	ptl,	70, 54, 0))	\
+ 	fw_def(BATTLEMAGE,	GT_TYPE_ANY,	major_ver(xe,	guc,	bmg,	70, 54, 0))	\
+ 	fw_def(LUNARLAKE,	GT_TYPE_ANY,	major_ver(xe,	guc,	lnl,	70, 53, 0))	\
+-- 

--- a/series
+++ b/series
@@ -138,6 +138,7 @@ backport/patches/base/0001-drm-xe-mcr-Take-vcs1-vecs1-into-account-for-first-me.
 backport/patches/base/0001-drm-xe-oa-Extend-OAM-unit-hwe-assignment-for-new-dGf.patch
 backport/patches/base/0001-drm-drm_ras-Add-drm_ras-netlink-error-event.patch
 backport/patches/base/0001-drm-xe-xe_ras-Report-correctable-uncorrectable-error.patch
+backport/patches/base/0001-Backport-only-drm-xe-cri-Bump-GuC-version-to-70.70.0.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
This changes is only for early enablement of cri in dkms

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>