### PR TITLE
drm/xe: dma-buf Add VRAM pin limit for backports when dmem_cgroup is not present

### DIFF
--- a/backport/backport-include/drm/drm_drv.h
+++ b/backport/backport-include/drm/drm_drv.h
@@ -9,22 +9,6 @@
 #define DRIVER_DATE             "20201103"
 #endif
 
-#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
-#include <linux/cgroup_dmem.h>
-#include <drm/drm_managed.h>
-#include <linux/slab.h>
-
-static inline struct dmem_cgroup_region *drmm_cgroup_register_region(
-	struct drm_device *dev, const char *region_name, u64 size)
-{
-	/* 
-	 * Return NULL to indicate cgroup functionality is not available.
-	 * This disables cgroup memory tracking but allows the driver to work.
-	 */
-	return NULL;
-}
-#endif /* BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT */
-
 #ifdef BPM_DRM_DEV_WEDGED_EVENT_NOT_PRESENT
 int drm_dev_wedged_event(struct drm_device *dev, unsigned long method,
 			struct drm_wedge_task_info *info);

--- a/patches/0001-drm-xe-Add-pin_vram_percent-modparam.patch
+++ b/patches/0001-drm-xe-Add-pin_vram_percent-modparam.patch
@@ -1,0 +1,118 @@
+From f583ff029733e5ce706ef6fac884a3aeb2a91056 Mon Sep 17 00:00:00 2001
+From: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Date: Mon, 3 Aug 2026 10:37:57 +0530
+Subject: drm/xe: Add pin_vram_percent modparam
+
+Add a module parameter that caps the percentage of each VRAM region
+which may be pinned via dma-buf. A value of 0 disables the limit.
+Derive the per-region dma-buf pin limit from pin_vram_percent during
+VRAM manager initialization.
+
+Reviewed-by: Tejas Upadhyay tejas.upadhyay@intel.com
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+---
+ src/drivers/gpu/drm/xe/xe_defaults.h     |  1 +
+ src/drivers/gpu/drm/xe/xe_module.c       |  7 +++++++
+ src/drivers/gpu/drm/xe/xe_module.h       |  3 +++
+ src/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c | 14 ++++++++++++++
+ 4 files changed, 25 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_defaults.h b/drivers/gpu/drm/xe/xe_defaults.h
+index 1dca9041e..0f69db0f3 100644
+--- a/drivers/gpu/drm/xe/xe_defaults.h
++++ b/drivers/gpu/drm/xe/xe_defaults.h
+@@ -22,5 +22,6 @@
+ #define XE_DEFAULT_WEDGED_MODE			XE_WEDGED_MODE_UPON_CRITICAL_ERROR
+ #define XE_DEFAULT_WEDGED_MODE_STR		"upon-critical-error"
+ #define XE_DEFAULT_SVM_NOTIFIER_SIZE		512
++#define XE_DEFAULT_PIN_VRAM_PERCENT		50
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_module.c b/drivers/gpu/drm/xe/xe_module.c
+index 919ef9e7b..cc58ddddd 100644
+--- a/drivers/gpu/drm/xe/xe_module.c
++++ b/drivers/gpu/drm/xe/xe_module.c
+@@ -31,6 +31,9 @@ struct xe_modparam xe_modparam = {
+ #endif
+ 	.wedged_mode =		XE_DEFAULT_WEDGED_MODE,
+ 	.svm_notifier_size =	XE_DEFAULT_SVM_NOTIFIER_SIZE,
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	.pin_vram_percent =	XE_DEFAULT_PIN_VRAM_PERCENT,
++#endif
+ 	/* the rest are 0 by default */
+ };
+ 
+@@ -38,6 +41,10 @@ module_param_named(svm_notifier_size, xe_modparam.svm_notifier_size, uint, 0600)
+ MODULE_PARM_DESC(svm_notifier_size, "Set the svm notifier size in MiB, must be power of 2 "
+ 		 "[default=" __stringify(XE_DEFAULT_SVM_NOTIFIER_SIZE) "]");
+ 
++module_param_named(pin_vram_percent, xe_modparam.pin_vram_percent, uint, 0400);
++MODULE_PARM_DESC(pin_vram_percent, "Max percent of VRAM pinnable via dma-buf per region (0=unlimited) "
++                "[default=" __stringify(XE_DEFAULT_PIN_VRAM_PERCENT) "]");
++
+ module_param_named_unsafe(force_execlist, xe_modparam.force_execlist, bool, 0444);
+ MODULE_PARM_DESC(force_execlist, "Force Execlist submission");
+ 
+diff --git a/drivers/gpu/drm/xe/xe_module.h b/drivers/gpu/drm/xe/xe_module.h
+index e8e54f701..afc4fbde4 100644
+--- a/drivers/gpu/drm/xe/xe_module.h
++++ b/drivers/gpu/drm/xe/xe_module.h
+@@ -25,6 +25,9 @@ struct xe_modparam {
+ #endif
+ 	unsigned int wedged_mode;
+ 	u32 svm_notifier_size;
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	unsigned int pin_vram_percent;
++#endif
+ };
+ 
+ extern struct xe_modparam xe_modparam;
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 5d22dafec..6e42d289a 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -8,11 +8,18 @@
+ #include <drm/drm_drv.h>
+ #include <drm/drm_buddy.h>
+ 
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++#include <linux/math64.h>
++#endif
++
+ #include <drm/ttm/ttm_placement.h>
+ #include <drm/ttm/ttm_range_manager.h>
+ 
+ #include "xe_bo.h"
+ #include "xe_device.h"
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++#include "xe_module.h"
++#endif
+ #include "xe_res_cursor.h"
+ #include "xe_ttm_vram_mgr.h"
+ #include "xe_vram_types.h"
+@@ -320,15 +327,22 @@ int __xe_ttm_vram_mgr_init(struct xe_device *xe, struct xe_ttm_vram_mgr *mgr,
+ 	struct ttm_resource_manager *man = &mgr->manager;
+ 	int err;
+ 
++#ifndef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
+ 	if (mem_type != XE_PL_STOLEN) {
+ 		const char *name = mem_type == XE_PL_VRAM0 ? "vram0" : "vram1";
+ 		man->cg = drmm_cgroup_register_region(&xe->drm, name, size);
+ 		if (IS_ERR(man->cg))
+ 			return PTR_ERR(man->cg);
+ 	}
++#endif
+ 
+ 	man->func = &xe_ttm_vram_mgr_func;
+ 	mgr->mem_type = mem_type;
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	if (xe_modparam.pin_vram_percent)
++		mgr->pin.dmabuf_limit =
++			mul_u64_u32_div(size, xe_modparam.pin_vram_percent, 100);
++#endif
+ 	mutex_init(&mgr->lock);
+ 	mgr->default_page_size = default_page_size;
+ 	mgr->visible_size = io_size;
+-- 
+2.43.0
+

--- a/patches/0001-drm-xe-bo-account-dma-buf-pinned-vram.patch
+++ b/patches/0001-drm-xe-bo-account-dma-buf-pinned-vram.patch
@@ -1,0 +1,145 @@
+From 3414215380329cb1551782476cbbaf5e8ba96ca0 Mon Sep 17 00:00:00 2001
+From: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Date: Mon, 3 Aug 2026 10:39:35 +0530
+Subject: drm/xe/bo: account dma-buf pinned vram
+
+Track dma-buf pinned VRAM in the per-region counters on external
+pin and unpin.
+
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+---
+ src/drivers/gpu/drm/xe/xe_bo.c       | 57 ++++++++++++++++++++++++++--
+ src/drivers/gpu/drm/xe/xe_bo_types.h | 10 +++++
+ 2 files changed, 64 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
+index 8e9bc422f..bef139ed4 100644
+--- a/drivers/gpu/drm/xe/xe_bo.c
++++ b/drivers/gpu/drm/xe/xe_bo.c
+@@ -38,6 +38,9 @@
+ #include "xe_tile.h"
+ #include "xe_trace_bo.h"
+ #include "xe_ttm_stolen_mgr.h"
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++#include "xe_ttm_vram_mgr.h"
++#endif
+ #include "xe_vm.h"
+ #include "xe_vram_types.h"
+ 
+@@ -3119,6 +3122,17 @@ uint64_t vram_region_gpu_offset(struct ttm_resource *res)
+ 	return 0;
+ }
+ 
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++static struct xe_ttm_vram_mgr *xe_bo_pin_vram_mgr(struct xe_bo *bo)
++{
++	struct ttm_resource *res = bo->ttm.resource;
++
++	if (!res || !mem_type_is_vram(res->mem_type))
++		return NULL;
++
++	return to_xe_ttm_vram_mgr(ttm_manager_type(bo->ttm.bdev, res->mem_type));
++}
++#endif
+ /**
+  * xe_bo_pin_external - pin an external BO
+  * @bo: buffer object to be pinned
+@@ -3134,6 +3148,10 @@ uint64_t vram_region_gpu_offset(struct ttm_resource *res)
+ int xe_bo_pin_external(struct xe_bo *bo, bool in_place, struct drm_exec *exec)
+ {
+ 	struct xe_device *xe = xe_bo_device(bo);
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	struct xe_ttm_vram_mgr *mgr;
++	u64 size = xe_bo_size(bo);
++#endif
+ 	int err;
+ 
+ 	xe_assert(xe, !bo->vm);
+@@ -3145,12 +3163,29 @@ int xe_bo_pin_external(struct xe_bo *bo, bool in_place, struct drm_exec *exec)
+ 			if (err)
+ 				return err;
+ 		}
++	}
+ 
+-		spin_lock(&xe->pinned.lock);
+-		list_add_tail(&bo->pinned_link, &xe->pinned.late.external);
+-		spin_unlock(&xe->pinned.lock);
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	mgr = xe_bo_pin_vram_mgr(bo);
++	spin_lock(&xe->pinned.lock);
++
++	if (bo->dmabuf_pin_count++ == 0) {
++		if (mgr) {
++			mgr->pin.dmabuf_used += size;
++			mgr->pin.total_used += size;
++		}
+ 	}
+ 
++	if (!xe_bo_is_pinned(bo))
++		list_add_tail(&bo->pinned_link, &xe->pinned.late.external);
++
++	spin_unlock(&xe->pinned.lock);
++#else
++	spin_lock(&xe->pinned.lock);
++	list_add_tail(&bo->pinned_link, &xe->pinned.late.external);
++	spin_unlock(&xe->pinned.lock);
++#endif
++	
+ 	ttm_bo_pin(&bo->ttm);
+ 	if (bo->ttm.ttm && ttm_tt_is_populated(bo->ttm.ttm))
+ 		xe_ttm_tt_account_subtract(xe, bo->ttm.ttm);
+@@ -3235,14 +3270,30 @@ int xe_bo_pin(struct xe_bo *bo, struct drm_exec *exec)
+ void xe_bo_unpin_external(struct xe_bo *bo)
+ {
+ 	struct xe_device *xe = xe_bo_device(bo);
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	struct xe_ttm_vram_mgr *mgr = xe_bo_pin_vram_mgr(bo);
++	u64 size = xe_bo_size(bo);
++#endif
+ 
+ 	xe_assert(xe, !bo->vm);
+ 	xe_assert(xe, xe_bo_is_pinned(bo));
+ 	xe_assert(xe, xe_bo_is_user(bo));
+ 
+ 	spin_lock(&xe->pinned.lock);
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	/* display may hold a concurrent pin; use dmabuf_pin_count not ttm pin_count */
++	if (--bo->dmabuf_pin_count == 0) {
++		if (mgr) {
++			mgr->pin.dmabuf_used -= size;
++			mgr->pin.total_used -= size;
++		}
++		if (!list_empty(&bo->pinned_link))
++			list_del_init(&bo->pinned_link);
++	}
++#else
+ 	if (bo->ttm.pin_count == 1 && !list_empty(&bo->pinned_link))
+ 		list_del_init(&bo->pinned_link);
++#endif
+ 	spin_unlock(&xe->pinned.lock);
+ 
+ 	ttm_bo_unpin(&bo->ttm);
+diff --git a/drivers/gpu/drm/xe/xe_bo_types.h b/drivers/gpu/drm/xe/xe_bo_types.h
+index b1cdd7acc..87d90abed 100644
+--- a/drivers/gpu/drm/xe/xe_bo_types.h
++++ b/drivers/gpu/drm/xe/xe_bo_types.h
+@@ -90,6 +90,16 @@ struct xe_bo {
+ 	/** @ccs_cleared: true means that CCS region of BO is already cleared */
+ 	bool ccs_cleared;
+ 
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	/**
++	 * @dmabuf_pin_count: number of active dma-buf pins. 0->1 charges the
++	 * VRAM limit and adds to the restore list; N->0 uncharges and removes.
++	 * Independent of ttm pin_count, which also counts display pins that
++	 * bypass xe_bo_pin_external.
++	 */
++	u32 dmabuf_pin_count;
++#endif
++
+ 	/** @bb_ccs: BB instructions of CCS read/write. Valid only for VF */
+ 	struct xe_mem_pool_node *bb_ccs[XE_SRIOV_VF_CCS_CTX_COUNT];
+ 
+-- 
+2.43.0
+

--- a/patches/0001-drm-xe-bo-account-kernel-pinned-vram.patch
+++ b/patches/0001-drm-xe-bo-account-kernel-pinned-vram.patch
@@ -1,0 +1,60 @@
+From 551b4d8c826e9863abb2e9ab595b5bb996dc2ae8 Mon Sep 17 00:00:00 2001
+From: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Date: Mon, 3 Aug 2026 10:39:57 +0530
+Subject: drm/xe/bo: account kernel pinned vram
+
+Track kernel pinned VRAM in the per-region total counter on pin
+and unpin.
+
+Reviewed-by: Tejas Upadhyay tejas.upadhyay@intel.com
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+---
+ src/drivers/gpu/drm/xe/xe_bo.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
+index bef139ed4..ec698b93d 100644
+--- a/drivers/gpu/drm/xe/xe_bo.c
++++ b/drivers/gpu/drm/xe/xe_bo.c
+@@ -3236,7 +3236,15 @@ int xe_bo_pin(struct xe_bo *bo, struct drm_exec *exec)
+ 		return err;
+ 
+ 	if (mem_type_is_vram(place->mem_type) || bo->flags & XE_BO_FLAG_GGTT) {
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++		struct xe_ttm_vram_mgr *mgr = xe_bo_pin_vram_mgr(bo);
++#endif
++
+ 		spin_lock(&xe->pinned.lock);
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++		if (mgr)
++			mgr->pin.total_used += xe_bo_size(bo);
++#endif
+ 		if (bo->flags & XE_BO_FLAG_PINNED_LATE_RESTORE)
+ 			list_add_tail(&bo->pinned_link, &xe->pinned.late.kernel_bo_present);
+ 		else
+@@ -3259,6 +3267,7 @@ int xe_bo_pin(struct xe_bo *bo, struct drm_exec *exec)
+ 
+ /**
+  * xe_bo_unpin_external - unpin an external BO
++#endif
+  * @bo: buffer object to be unpinned
+  *
+  * Unpin an external (not tied to a VM, can be exported via dma-buf / prime FD)
+@@ -3316,7 +3325,14 @@ void xe_bo_unpin(struct xe_bo *bo)
+ 	xe_assert(xe, xe_bo_is_pinned(bo));
+ 
+ 	if (mem_type_is_vram(place->mem_type) || bo->flags & XE_BO_FLAG_GGTT) {
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++		struct xe_ttm_vram_mgr *mgr = xe_bo_pin_vram_mgr(bo);
++#endif
+ 		spin_lock(&xe->pinned.lock);
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++		if (mgr)
++			mgr->pin.total_used -= xe_bo_size(bo);
++#endif
+ 		xe_assert(xe, !list_empty(&bo->pinned_link));
+ 		list_del_init(&bo->pinned_link);
+ 		spin_unlock(&xe->pinned.lock);
+-- 
+2.43.0
+

--- a/patches/0001-drm-xe-bo-enforce-dma-buf-pin-limit.patch
+++ b/patches/0001-drm-xe-bo-enforce-dma-buf-pin-limit.patch
@@ -1,0 +1,55 @@
+From c813ba6556fd37aaafb2db96ab4a9778dd505d18 Mon Sep 17 00:00:00 2001
+From: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Date: Mon, 3 Aug 2026 10:40:13 +0530
+Subject: drm/xe/bo: enforce dma-buf pin limit
+
+Reject external VRAM pins that would exceed the per-region dma-buf
+limit with -ENOSPC.
+
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+---
+ src/drivers/gpu/drm/xe/xe_bo.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
+index ec698b93d..889a0f46e 100644
+--- a/drivers/gpu/drm/xe/xe_bo.c
++++ b/drivers/gpu/drm/xe/xe_bo.c
+@@ -31,6 +31,9 @@
+ #include "xe_pat.h"
+ #include "xe_pm.h"
+ #include "xe_preempt_fence.h"
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++#include "xe_printk.h"
++#endif
+ #include "xe_pxp.h"
+ #include "xe_res_cursor.h"
+ #include "xe_shrinker.h"
+@@ -3170,6 +3173,24 @@ int xe_bo_pin_external(struct xe_bo *bo, bool in_place, struct drm_exec *exec)
+ 	spin_lock(&xe->pinned.lock);
+ 
+ 	if (bo->dmabuf_pin_count++ == 0) {
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++		if (mgr && mgr->pin.dmabuf_limit &&
++		    mgr->pin.dmabuf_used + size > mgr->pin.dmabuf_limit) {
++			u64 used = mgr->pin.dmabuf_used;
++			u64 limit = mgr->pin.dmabuf_limit;
++
++			bo->dmabuf_pin_count--;
++			spin_unlock(&xe->pinned.lock);
++			xe_err_ratelimited(xe,
++					   "dma-buf VRAM pin limit reached (used %lluM, limit %lluM), rejecting with -ENOSPC\n",
++					   used >> 20, limit >> 20);
++			/*
++			 * No SMEM fallback: non-P2P callers migrate to TT before
++			 * reaching here; a VRAM mgr means VRAM is genuinely required.
++			 */
++			return -ENOSPC;
++		}
++#endif
+ 		if (mgr) {
+ 			mgr->pin.dmabuf_used += size;
+ 			mgr->pin.total_used += size;
+-- 
+2.43.0
+

--- a/patches/0001-drm-xe-dma-buf-propagate-pin-error.patch
+++ b/patches/0001-drm-xe-dma-buf-propagate-pin-error.patch
@@ -1,0 +1,37 @@
+From 65fb8284564a5d6db8c4884cad903119d85dce3f Mon Sep 17 00:00:00 2001
+From: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Date: Mon, 3 Aug 2026 10:37:19 +0530
+Subject: drm/xe/dma-buf: propagate pin error
+
+Return the error from xe_bo_pin_external() instead of asserting
+success, so callers observe failures such as -ENOSPC from the pin limit.
+
+Reviewed-by: Tejas Upadhyay tejas.upadhyay@intel.com
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+---
+ src/drivers/gpu/drm/xe/xe_dma_buf.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_dma_buf.c b/drivers/gpu/drm/xe/xe_dma_buf.c
+index de6999f89..15a2290b4 100644
+--- a/drivers/gpu/drm/xe/xe_dma_buf.c
++++ b/drivers/gpu/drm/xe/xe_dma_buf.c
+@@ -80,10 +80,15 @@ static int xe_dma_buf_pin(struct dma_buf_attachment *attach)
+ 		}
+ 	}
+ 
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	return xe_bo_pin_external(bo, !allow_vram, exec);
++#else
+ 	ret = xe_bo_pin_external(bo, !allow_vram, exec);
+ 	xe_assert(xe, !ret);
+ 
+ 	return 0;
++#endif
++
+ }
+ 
+ static void xe_dma_buf_unpin(struct dma_buf_attachment *attach)
+-- 
+2.43.0
+

--- a/patches/0001-drm-xe-tests-add-VRAM-pin-limit-KUnit-tests.patch
+++ b/patches/0001-drm-xe-tests-add-VRAM-pin-limit-KUnit-tests.patch
@@ -1,0 +1,404 @@
+From b773c1cb7af742d66e3ae52f08ecefc0445b1b18 Mon Sep 17 00:00:00 2001
+From: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Date: Mon, 3 Aug 2026 11:49:33 +0530
+Subject: drm/xe/tests: add VRAM pin limit KUnit tests
+
+Test under-limit success, over-limit rejection, counter recovery after
+unpin, and the limit=0 unlimited case in xe_bo tests. Add an end-to-end
+dma-buf pin limit test in xe_dma_buf tests.
+
+Reviewed-by: Tejas Upadhyay tejas.upadhyay@intel.com
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+---
+ src/drivers/gpu/drm/xe/tests/xe_bo.c      | 242 ++++++++++++++++++++++
+ src/drivers/gpu/drm/xe/tests/xe_dma_buf.c | 101 +++++++++
+ 2 files changed, 343 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/tests/xe_bo.c b/drivers/gpu/drm/xe/tests/xe_bo.c
+index 58343b215..a2789a548 100644
+--- a/drivers/gpu/drm/xe/tests/xe_bo.c
++++ b/drivers/gpu/drm/xe/tests/xe_bo.c
+@@ -17,7 +17,13 @@
+ #include "tests/xe_pci_test.h"
+ #include "tests/xe_test.h"
+ 
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++#include "xe_bo.h"
++#endif
+ #include "xe_bo_evict.h"
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++#include "xe_ttm_vram_mgr.h"
++#endif
+ #include "xe_gt.h"
+ #include "xe_pci.h"
+ #include "xe_pm.h"
+@@ -828,9 +834,245 @@ static void xe_bo_shrink_kunit(struct kunit *test)
+ 	shrink_test_run_device(xe);
+ }
+ 
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++/* Returns NULL if the device has no VRAM (skips the test). */
++static struct xe_ttm_vram_mgr *pin_limit_get_mgr(struct xe_device *xe,
++						  struct kunit *test)
++{
++	struct ttm_resource_manager *man = ttm_manager_type(&xe->ttm, XE_PL_VRAM0);
++
++	if (!man) {
++		kunit_skip(test, "no VRAM\n");
++		return NULL;
++	}
++	return to_xe_ttm_vram_mgr(man);
++}
++
++static struct xe_bo *pin_limit_bo_create(struct xe_device *xe,
++					 struct kunit *test, u64 size)
++{
++	struct xe_bo *bo = xe_bo_create_user(xe, NULL, size,
++					     DRM_XE_GEM_CPU_CACHING_WC,
++					     XE_BO_FLAG_VRAM0, NULL);
++	if (IS_ERR(bo))
++		KUNIT_FAIL(test, "bo create err=%pe\n", bo);
++	return bo;
++}
++
++static void xe_bo_pin_limit_under_kunit(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	struct xe_ttm_vram_mgr *mgr;
++	struct drm_exec *exec = XE_VALIDATION_OPT_OUT;
++	struct xe_bo *bo;
++	u64 orig_limit;
++	int err;
++
++	guard(xe_pm_runtime)(xe);
++
++	mgr = pin_limit_get_mgr(xe, test);
++	if (!mgr)
++		return;
++
++	bo = pin_limit_bo_create(xe, test, SZ_64K);
++	if (IS_ERR(bo))
++		return;
++
++	spin_lock(&xe->pinned.lock);
++	orig_limit = mgr->pin.dmabuf_limit;
++	/* limit = current usage + exactly one BO */
++	mgr->pin.dmabuf_limit = mgr->pin.dmabuf_used + SZ_64K;
++	spin_unlock(&xe->pinned.lock);
++
++	xe_bo_lock(bo, false);
++	err = xe_bo_pin_external(bo, false, exec);
++	xe_bo_unlock(bo);
++	KUNIT_EXPECT_EQ(test, err, 0);
++
++	xe_bo_lock(bo, false);
++	xe_bo_unpin_external(bo);
++	xe_bo_unlock(bo);
++
++	spin_lock(&xe->pinned.lock);
++	/* dmabuf_used must be back to what it was before the pin */
++	KUNIT_EXPECT_EQ(test, mgr->pin.dmabuf_used,
++			mgr->pin.dmabuf_limit - SZ_64K);
++	mgr->pin.dmabuf_limit = orig_limit;
++	spin_unlock(&xe->pinned.lock);
++
++	xe_bo_put(bo);
++}
++
++static void xe_bo_pin_limit_reject_kunit(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	struct xe_ttm_vram_mgr *mgr;
++	struct drm_exec *exec = XE_VALIDATION_OPT_OUT;
++	struct xe_bo *bo;
++	u64 orig_limit;
++	int err;
++
++	guard(xe_pm_runtime)(xe);
++
++	mgr = pin_limit_get_mgr(xe, test);
++	if (!mgr)
++		return;
++
++	bo = pin_limit_bo_create(xe, test, SZ_64K);
++	if (IS_ERR(bo))
++		return;
++
++	spin_lock(&xe->pinned.lock);
++	orig_limit = mgr->pin.dmabuf_limit;
++	/* limit = current usage + less than one BO, forcing rejection */
++	mgr->pin.dmabuf_limit = mgr->pin.dmabuf_used + SZ_4K;
++	spin_unlock(&xe->pinned.lock);
++
++	xe_bo_lock(bo, false);
++	err = xe_bo_pin_external(bo, false, exec);
++	xe_bo_unlock(bo);
++	KUNIT_EXPECT_EQ(test, err, -ENOSPC);
++
++	spin_lock(&xe->pinned.lock);
++	/* dmabuf_used must be unchanged — no partial charge on rejection */
++	KUNIT_EXPECT_EQ(test, mgr->pin.dmabuf_used,
++			mgr->pin.dmabuf_limit - SZ_4K);
++	mgr->pin.dmabuf_limit = orig_limit;
++	spin_unlock(&xe->pinned.lock);
++
++	xe_bo_put(bo);
++}
++
++static void xe_bo_pin_limit_unpin_restores_kunit(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	struct xe_ttm_vram_mgr *mgr;
++	struct drm_exec *exec = XE_VALIDATION_OPT_OUT;
++	struct xe_bo *bo_a, *bo_b;
++	u64 orig_limit;
++	int err;
++
++	guard(xe_pm_runtime)(xe);
++
++	mgr = pin_limit_get_mgr(xe, test);
++	if (!mgr)
++		return;
++
++	bo_a = pin_limit_bo_create(xe, test, SZ_64K);
++	if (IS_ERR(bo_a))
++		return;
++
++	bo_b = pin_limit_bo_create(xe, test, SZ_64K);
++	if (IS_ERR(bo_b)) {
++		xe_bo_put(bo_a);
++		return;
++	}
++
++	spin_lock(&xe->pinned.lock);
++	orig_limit = mgr->pin.dmabuf_limit;
++	/* limit = current usage + exactly one BO */
++	mgr->pin.dmabuf_limit = mgr->pin.dmabuf_used + SZ_64K;
++	spin_unlock(&xe->pinned.lock);
++
++	xe_bo_lock(bo_a, false);
++	err = xe_bo_pin_external(bo_a, false, exec);
++	xe_bo_unlock(bo_a);
++	KUNIT_EXPECT_EQ(test, err, 0);
++	if (err)
++		goto out;
++
++	/* Second pin must be rejected while first is held. */
++	xe_bo_lock(bo_b, false);
++	err = xe_bo_pin_external(bo_b, false, exec);
++	xe_bo_unlock(bo_b);
++	KUNIT_EXPECT_EQ(test, err, -ENOSPC);
++
++	xe_bo_lock(bo_a, false);
++	xe_bo_unpin_external(bo_a);
++	xe_bo_unlock(bo_a);
++
++	/* After unpin, the second BO must fit. */
++	xe_bo_lock(bo_b, false);
++	err = xe_bo_pin_external(bo_b, false, exec);
++	xe_bo_unlock(bo_b);
++	KUNIT_EXPECT_EQ(test, err, 0);
++
++	xe_bo_lock(bo_b, false);
++	xe_bo_unpin_external(bo_b);
++	xe_bo_unlock(bo_b);
++
++out:
++	spin_lock(&xe->pinned.lock);
++	mgr->pin.dmabuf_limit = orig_limit;
++	spin_unlock(&xe->pinned.lock);
++
++	xe_bo_put(bo_b);
++	xe_bo_put(bo_a);
++}
++
++static void xe_bo_pin_limit_zero_unlimited_kunit(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	struct xe_ttm_vram_mgr *mgr;
++	struct drm_exec *exec = XE_VALIDATION_OPT_OUT;
++	struct xe_bo *bo;
++	u64 orig_limit;
++	int err;
++
++	guard(xe_pm_runtime)(xe);
++
++	mgr = pin_limit_get_mgr(xe, test);
++	if (!mgr)
++		return;
++
++	/* BO is 2x SZ_64K so it would fail if limit were SZ_64K */
++	bo = pin_limit_bo_create(xe, test, 2 * SZ_64K);
++	if (IS_ERR(bo))
++		return;
++
++	spin_lock(&xe->pinned.lock);
++	orig_limit = mgr->pin.dmabuf_limit;
++	/* limit = current usage + one BO; 2*SZ_64K BO will be rejected */
++	mgr->pin.dmabuf_limit = mgr->pin.dmabuf_used + SZ_64K;
++	spin_unlock(&xe->pinned.lock);
++
++	/* Confirm this size is rejected when a limit is set. */
++	xe_bo_lock(bo, false);
++	err = xe_bo_pin_external(bo, false, exec);
++	xe_bo_unlock(bo);
++	KUNIT_EXPECT_EQ(test, err, -ENOSPC);
++
++	spin_lock(&xe->pinned.lock);
++	mgr->pin.dmabuf_limit = 0; /* now disable limit */
++	spin_unlock(&xe->pinned.lock);
++
++	/* Same BO must succeed once limit is cleared. */
++	xe_bo_lock(bo, false);
++	err = xe_bo_pin_external(bo, false, exec);
++	xe_bo_unlock(bo);
++	KUNIT_EXPECT_EQ(test, err, 0);
++
++	xe_bo_lock(bo, false);
++	xe_bo_unpin_external(bo);
++	xe_bo_unlock(bo);
++
++	spin_lock(&xe->pinned.lock);
++	mgr->pin.dmabuf_limit = orig_limit;
++	spin_unlock(&xe->pinned.lock);
++
++	xe_bo_put(bo);
++}
++#endif
++
+ static struct kunit_case xe_bo_tests[] = {
+ 	KUNIT_CASE_PARAM(xe_ccs_migrate_kunit, xe_pci_live_device_gen_param),
+ 	KUNIT_CASE_PARAM(xe_bo_evict_kunit, xe_pci_live_device_gen_param),
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	KUNIT_CASE_PARAM(xe_bo_pin_limit_under_kunit, xe_pci_live_device_gen_param),
++	KUNIT_CASE_PARAM(xe_bo_pin_limit_reject_kunit, xe_pci_live_device_gen_param),
++	KUNIT_CASE_PARAM(xe_bo_pin_limit_unpin_restores_kunit, xe_pci_live_device_gen_param),
++	KUNIT_CASE_PARAM(xe_bo_pin_limit_zero_unlimited_kunit, xe_pci_live_device_gen_param),
++#endif
+ 	{}
+ };
+ 
+diff --git a/drivers/gpu/drm/xe/tests/xe_dma_buf.c b/drivers/gpu/drm/xe/tests/xe_dma_buf.c
+index 0be8440b3..5f87cf09b 100644
+--- a/drivers/gpu/drm/xe/tests/xe_dma_buf.c
++++ b/drivers/gpu/drm/xe/tests/xe_dma_buf.c
+@@ -13,6 +13,9 @@
+ 
+ #include "xe_pci.h"
+ #include "xe_pm.h"
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++#include "xe_ttm_vram_mgr.h"
++#endif
+ 
+ static bool p2p_enabled(struct dma_buf_test_params *params)
+ {
+@@ -285,8 +288,106 @@ static void xe_dma_buf_kunit(struct kunit *test)
+ 	dma_buf_run_device(xe);
+ }
+ 
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++static void xe_dma_buf_pin_limit_kunit(struct kunit *test)
++{
++	struct xe_device *xe = test->priv;
++	struct ttm_resource_manager *man;
++	struct xe_ttm_vram_mgr *mgr;
++	/* dynamic importer + force_different_devices required for dma_buf_pin */
++	struct dma_buf_test_params p = {
++		.base.id = XE_TEST_LIVE_DMA_BUF,
++		.mem_mask = XE_BO_FLAG_VRAM0,
++		.attach_ops = &xe_dma_buf_attach_ops,
++		.force_different_devices = true,
++	};
++	struct drm_gem_object *import;
++	struct dma_buf_attachment *attach;
++	struct dma_buf *dmabuf;
++	struct xe_bo *bo;
++	u64 orig_limit;
++	int err;
++
++	guard(xe_pm_runtime)(xe);
++
++	man = ttm_manager_type(&xe->ttm, XE_PL_VRAM0);
++	if (!man) {
++		kunit_skip(test, "no VRAM\n");
++		return;
++	}
++	mgr = to_xe_ttm_vram_mgr(man);
++
++	test->priv = &p;
++	bo = xe_bo_create_user(xe, NULL, SZ_64K,
++			DRM_XE_GEM_CPU_CACHING_WC,
++			XE_BO_FLAG_VRAM0, NULL);
++	if (IS_ERR(bo)) {
++		KUNIT_FAIL(test, "bo create err=%pe\n", bo);
++		return;
++	}
++
++	dmabuf = xe_gem_prime_export(&bo->ttm.base, 0);
++	if (IS_ERR(dmabuf)) {
++		KUNIT_FAIL(test, "export err=%pe\n", dmabuf);
++		goto put_bo;
++	}
++	bo->ttm.base.dma_buf = dmabuf;
++
++	import = xe_gem_prime_import(&xe->drm, dmabuf);
++	if (IS_ERR(import)) {
++		KUNIT_FAIL(test, "import err=%pe\n", import);
++		goto put_dmabuf;
++	}
++
++	attach = list_first_entry_or_null(&dmabuf->attachments,
++			typeof(*attach), node);
++	if (!attach) {
++		KUNIT_FAIL(test, "no attachment\n");
++		goto put_import;
++	}
++
++	/* dma_buf_pin requires dmabuf->resv to be held */
++	xe_bo_lock(bo, false);
++	/* Force reject: limit = current used + less than one BO */
++	spin_lock(&xe->pinned.lock);
++	orig_limit = mgr->pin.dmabuf_limit;
++	mgr->pin.dmabuf_limit = mgr->pin.dmabuf_used + SZ_4K;
++	spin_unlock(&xe->pinned.lock);
++
++	err = dma_buf_pin(attach);
++	KUNIT_EXPECT_EQ(test, err, -ENOSPC);
++
++	/* Lift limit: pin must succeed */
++	spin_lock(&xe->pinned.lock);
++	mgr->pin.dmabuf_limit = 0;
++	spin_unlock(&xe->pinned.lock);
++
++	err = dma_buf_pin(attach);
++	KUNIT_EXPECT_EQ(test, err, 0);
++	if (!err)
++		dma_buf_unpin(attach);
++
++	xe_bo_unlock(bo);
++
++	spin_lock(&xe->pinned.lock);
++	mgr->pin.dmabuf_limit = orig_limit;
++	spin_unlock(&xe->pinned.lock);
++
++put_import:
++	drm_gem_object_put(import);
++put_dmabuf:
++	bo->ttm.base.dma_buf = NULL;
++	dma_buf_put(dmabuf);
++put_bo:
++	xe_bo_put(bo);
++}
++#endif
++
+ static struct kunit_case xe_dma_buf_tests[] = {
+ 	KUNIT_CASE_PARAM(xe_dma_buf_kunit, xe_pci_live_device_gen_param),
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	KUNIT_CASE_PARAM(xe_dma_buf_pin_limit_kunit, xe_pci_live_device_gen_param),
++#endif
+ 	{}
+ };
+ 
+-- 
+2.43.0
+

--- a/patches/0001-drm-xe-vram-add-pinned-vram-counters.patch
+++ b/patches/0001-drm-xe-vram-add-pinned-vram-counters.patch
@@ -1,0 +1,39 @@
+From 34c945b828b7ef025e468d715c5e3423f264f3c8 Mon Sep 17 00:00:00 2001
+From: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Date: Mon, 3 Aug 2026 10:38:13 +0530
+Subject: drm/xe/vram: add pinned vram counters
+
+Add per-region counters tracking dma-buf and total pinned VRAM bytes
+along with the enforced dma-buf pin limit.
+
+Reviewed-by: Tejas Upadhyay tejas.upadhyay@intel.com
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+---
+ src/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h b/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
+index 9106da056..6e38001ec 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
+@@ -29,6 +29,17 @@ struct xe_ttm_vram_mgr {
+ 	struct mutex lock;
+ 	/** @mem_type: The TTM memory type */
+ 	u32 mem_type;
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	/** @pin: pinned VRAM accounting in bytes, protected by xe->pinned.lock */
++	struct {
++		/** @pin.dmabuf_limit: max bytes pinnable via dma-buf, 0 = unlimited */
++		u64 dmabuf_limit;
++		/** @pin.dmabuf_used: bytes currently pinned via dma-buf */
++		u64 dmabuf_used;
++		/** @pin.total_used: bytes currently pinned via any path */
++		u64 total_used;
++	} pin;
++#endif
+ };
+ 
+ /**
+-- 
+2.43.0
+

--- a/patches/0001-drm-xe-vram-show-pinned-vram-in-debug.patch
+++ b/patches/0001-drm-xe-vram-show-pinned-vram-in-debug.patch
@@ -1,0 +1,58 @@
+From 9adf8d7f4ca55cffdbe2cc58a023d2dae6c98cb0 Mon Sep 17 00:00:00 2001
+From: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Date: Mon, 3 Aug 2026 10:40:35 +0530
+Subject: drm/xe/vram: show pinned vram in debug
+
+Expose the pinned VRAM counters and the dma-buf limit in the VRAM
+manager debug output.
+
+Reviewed-by: Tejas Upadhyay tejas.upadhyay@intel.com
+Signed-off-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+---
+ src/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 6e42d289a..723b99a7d 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -214,8 +214,21 @@ static void xe_ttm_vram_mgr_del(struct ttm_resource_manager *man,
+ static void xe_ttm_vram_mgr_debug(struct ttm_resource_manager *man,
+ 				  struct drm_printer *printer)
+ {
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	struct xe_device *xe = ttm_to_xe_device(man->bdev);
++#endif
+ 	struct xe_ttm_vram_mgr *mgr = to_xe_ttm_vram_mgr(man);
+ 	struct gpu_buddy *mm = &mgr->mm;
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	u64 dmabuf_used, dmabuf_limit, total_used;
++
++	/* snapshot pin counters under their own lock before sleeping on mgr->lock */
++	spin_lock(&xe->pinned.lock);
++	dmabuf_used  = mgr->pin.dmabuf_used;
++	dmabuf_limit = mgr->pin.dmabuf_limit;
++	total_used   = mgr->pin.total_used;
++	spin_unlock(&xe->pinned.lock);
++#endif
+ 
+ 	mutex_lock(&mgr->lock);
+ 	drm_printf(printer, "default_page_size: %lluKiB\n",
+@@ -224,6 +237,14 @@ static void xe_ttm_vram_mgr_debug(struct ttm_resource_manager *man,
+ 		   (u64)mgr->visible_avail >> 20);
+ 	drm_printf(printer, "visible_size: %lluMiB\n",
+ 		   (u64)mgr->visible_size >> 20);
++#ifdef BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT
++	drm_printf(printer, "pin_dmabuf_used: %lluMiB\n",
++		   dmabuf_used >> 20);
++	drm_printf(printer, "pin_dmabuf_limit: %lluMiB\n",
++		   dmabuf_limit >> 20);
++	drm_printf(printer, "pin_total_used: %lluMiB\n",
++		   total_used >> 20);
++#endif
+ 
+ 	drm_buddy_print(mm, printer);
+ 	mutex_unlock(&mgr->lock);
+-- 
+2.43.0
+


### PR DESCRIPTION
Remove the dummy drmm_cgroup_register_region() stub from the backport
header and replace it with a driver-level VRAM pin accounting and
enforcement mechanism for kernels where dmem_cgroup is not available.

The dmem_cgroup subsystem, introduced in
newer kernels, provides per-cgroup limits on device memory usage such
as GPU VRAM. On older backport target kernels this subsystem is absent
(BPM_DRMM_CGROUP_REGISTER_REGION_NOT_PRESENT), so no VRAM pinning
limits were enforced — external dma-buf consumers could pin an
unbounded amount of VRAM, potentially starving the GPU driver and
local workloads.

The VRAM pin percentage is configurable via the module parameter:
  xe.pin_vram_percent=<0-100>  (default: 50)
A value of 0 disables the limit (unlimited pinning).

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>