### PR TITLE
drm/xe: Add memory page offlining support

### DIFF
--- a/backport/patches/base/0001-drm-xe-Add-fault-inject-based-VRAM-page-offline-injection.patch
+++ b/backport/patches/base/0001-drm-xe-Add-fault-inject-based-VRAM-page-offline-injection.patch
@@ -1,0 +1,228 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe: Add fault-inject based VRAM page offline injection
+
+Add a fault-inject based debugfs interface for testing VRAM page
+offlining. This replaces the previous standalone debugfs approach
+with the standard kernel fault-inject infrastructure.
+
+Two debugfs entries are created under the xe debugfs root for
+CRI platforms:
+- inject_mempage_offline/: Standard fault-inject knobs (probability,
+  times, interval, etc.) created by fault_create_debugfs_attr().
+  Without CONFIG_FAULT_INJECTION_DEBUG_FS, the stub returns
+  ERR_PTR(-ENODEV) and no knobs are created, making the trigger
+  effectively a no-op.
+- inject_mempage_offline_trigger: Write a PFN value to inject a
+  specific page, or write "0" to auto-pick the last unallocated
+  VRAM page
+
+The trigger accepts:
+- "0"      : auto-pick last unallocated page
+- "0xPFN"  : inject fault at a specific PFN address
+
+Usage:
+  echo 100 > inject_mempage_offline/probability
+  echo 1 > inject_mempage_offline/times
+  echo 0 > inject_mempage_offline_trigger
+
+  probability: likelihood of should_fail() returning true (0-100)
+  times: number of times injection is allowed (-1 for unlimited)
+
+v4(Himal):
+- Use xe_fault_mempage_offline() instead of IS_ENABLED() +
+  direct should_fail(). CONFIG_FAULT_INJECTION_DEBUG_FS is now
+  an implicit requirement for the trigger to function.
+v3(Himal):
+- Use FAULT_ACTION
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe: Add fault-inject based VRAM page offline injection)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_debugfs.c      | 47 +++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_debugfs.h      |  2 ++
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.c | 52 ++++++++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.h |  1 +
+ 4 files changed, 102 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_debugfs.c b/drivers/gpu/drm/xe/xe_debugfs.c
+index e19eafffbb08..003abf4af2e3 100644
+--- a/drivers/gpu/drm/xe/xe_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_debugfs.c
+@@ -45,12 +45,18 @@
+ DECLARE_FAULT_ATTR(gt_reset_failure);
+ DECLARE_FAULT_ATTR(inject_csc_hw_error);
+ DECLARE_FAULT_ATTR(wedge_cold_reset);
++DECLARE_FAULT_ATTR(inject_mempage_offline);
+ 
+ static bool csc_hw_error_available(struct xe_device *xe)
+ {
+ 	return !IS_SRIOV_VF(xe) && xe->info.platform == XE_BATTLEMAGE;
+ }
+ 
++static bool is_crescent_island_pf(struct xe_device *xe)
++{
++	return !IS_SRIOV_VF(xe) && xe->info.platform == XE_CRESCENTISLAND;
++}
++
+ /*
+  * Fault injection table.  Each entry registers a debugfs attribute; add a
+  * matching FAULT_ACTION() below for every entry added here.
+@@ -67,6 +73,9 @@ static struct {
+ 	  .is_visible = csc_hw_error_available },
+ 	{ .name = "wedge_cold_reset",
+ 	  .attr = &wedge_cold_reset },
++	{ .name = "inject_mempage_offline",
++	  .attr = &inject_mempage_offline,
++	  .is_visible = is_crescent_island_pf },
+ };
+ 
+ /*
+@@ -82,6 +91,39 @@ bool xe_fault_##name(void)				\
+ FAULT_ACTION(gt_reset, gt_reset_failure)
+ FAULT_ACTION(csc_hw_error, inject_csc_hw_error)
+ FAULT_ACTION(wedge_cold_reset, wedge_cold_reset)
++FAULT_ACTION(mempage_offline, inject_mempage_offline)
++
++static ssize_t inject_mempage_offline_trigger(struct file *f,
++					      const char __user *ubuf,
++					      size_t size, loff_t *pos)
++{
++	struct xe_device *xe = file_inode(f)->i_private;
++	struct xe_tile *tile = xe_device_get_root_tile(xe);
++	struct xe_vram_region *vr = tile->mem.vram;
++	u64 pfn;
++	int ret;
++
++	if (!vr)
++		return -ENODEV;
++
++	ret = kstrtou64_from_user(ubuf, size, 0, &pfn);
++	if (ret)
++		return ret;
++
++	if (!xe_fault_mempage_offline())
++		return size;
++
++	if (pfn == 0)
++		return xe_ttm_vram_inject_fault(xe) ?: size;
++
++	/* User provided PFN - convert to DPA and inject */
++	return xe_ttm_vram_handle_addr_fault(xe, pfn << PAGE_SHIFT) ?: size;
++}
++
++static const struct file_operations inject_mempage_offline_fops = {
++	.owner = THIS_MODULE,
++	.write = inject_mempage_offline_trigger,
++};
+ 
+ static void xe_fault_inject_debugfs_register(struct xe_device *xe,
+ 					     struct dentry *root)
+@@ -96,6 +138,11 @@ static void xe_fault_inject_debugfs_register(struct xe_device *xe,
+ 		fault_create_debugfs_attr(xe_fault_inject_entry[i].name, root,
+ 					  xe_fault_inject_entry[i].attr);
+ 	}
++
++	if (is_crescent_island_pf(xe)) {
++		debugfs_create_file("inject_mempage_offline_trigger", 0200,
++				    root, xe, &inject_mempage_offline_fops);
++	}
+ }
+ 
+ static void read_residency_counter(struct xe_device *xe, u32 offset, const char *name,
+diff --git a/drivers/gpu/drm/xe/xe_debugfs.h b/drivers/gpu/drm/xe/xe_debugfs.h
+index 0dcd28fd7dc0..88d91c78036b 100644
+--- a/drivers/gpu/drm/xe/xe_debugfs.h
++++ b/drivers/gpu/drm/xe/xe_debugfs.h
+@@ -14,11 +14,13 @@ struct xe_device;
+ bool xe_fault_gt_reset(void);
+ bool xe_fault_csc_hw_error(void);
+ bool xe_fault_wedge_cold_reset(void);
++bool xe_fault_mempage_offline(void);
+ void xe_debugfs_register(struct xe_device *xe);
+ #else
+ static inline bool xe_fault_gt_reset(void) { return false; }
+ static inline bool xe_fault_csc_hw_error(void) { return false; }
+ static inline bool xe_fault_wedge_cold_reset(void) { return false; }
++static inline bool xe_fault_mempage_offline(void) { return false; }
+ static inline void xe_debugfs_register(struct xe_device *xe) { }
+ #endif
+ 
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 8f583f1631bf..c54ad017725f 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -895,6 +895,58 @@ int xe_ttm_vram_handle_addr_fault(struct xe_device *xe, u64 addr)
+ }
+ EXPORT_SYMBOL(xe_ttm_vram_handle_addr_fault);
+ 
++/**
++ * xe_ttm_vram_inject_fault - Inject a VRAM page fault for testing
++ * @xe: xe device instance
++ *
++ * Picks the last unallocated VRAM page and reports it as faulted
++ * via xe_ttm_vram_handle_addr_fault(). Used by the fault-inject
++ * debugfs interface for testing page offlining.
++ *
++ * Return: 0 on success, negative error code on failure.
++ */
++int xe_ttm_vram_inject_fault(struct xe_device *xe)
++{
++	struct xe_tile *tile = xe_device_get_root_tile(xe);
++	struct xe_vram_region *vr = tile->mem.vram;
++	struct xe_ttm_vram_mgr *vram_mgr = &vr->ttm;
++	struct gpu_buddy *mm = &vram_mgr->mm;
++	u64 addr;
++
++	if (vr->actual_physical_size < SZ_4K)
++		return -ENOSPC;
++
++	addr = vr->actual_physical_size - SZ_4K;
++	while (addr < vr->actual_physical_size) {
++		struct gpu_buddy_block *block;
++		bool found = false;
++
++		scoped_guard(mutex, &vram_mgr->lock) {
++			block = gpu_buddy_allocated_addr_to_block(mm, addr);
++			if (!block)
++				found = true;
++		}
++
++		/*
++		 * Intentional race window: xe_ttm_vram_handle_addr_fault()
++		 * re-acquires vram_mgr->lock internally, so we cannot hold
++		 * it here. A concurrent allocation claiming this page between
++		 * the two calls is an acceptable false negative for this
++		 * test-only path.
++		 */
++		if (found)
++			return xe_ttm_vram_handle_addr_fault(xe, addr + vr->dpa_base);
++
++		cond_resched();
++		if (addr == 0)
++			break;
++		addr -= SZ_4K;
++	}
++
++	return -ENOSPC;
++}
++EXPORT_SYMBOL(xe_ttm_vram_inject_fault);
++
+ static int vram_bad_pages_show(struct seq_file *m, void *unused)
+ {
+ 	struct xe_device *xe = m->private;
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
+index f354c26c4257..8878e36292b2 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
+@@ -33,6 +33,7 @@ void xe_ttm_vram_get_used(struct ttm_resource_manager *man,
+ 			  u64 *used, u64 *used_visible);
+ 
+ int xe_ttm_vram_handle_addr_fault(struct xe_device *xe, u64 addr);
++int xe_ttm_vram_inject_fault(struct xe_device *xe);
+ void xe_ttm_vram_debugfs_init(struct xe_device *xe, struct dentry *root);
+ static inline struct xe_ttm_vram_mgr_resource *
+ to_xe_ttm_vram_mgr_resource(struct ttm_resource *res)

--- a/backport/patches/base/0001-drm-xe-Expose-bad-VRAM-pages-via-debugfs.patch
+++ b/backport/patches/base/0001-drm-xe-Expose-bad-VRAM-pages-via-debugfs.patch
@@ -1,0 +1,165 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe: Expose bad VRAM pages via debugfs
+
+Add a debugfs file "vram_bad_pages" that shows offlined and queued
+VRAM pages across all tiles. Each entry displays the page frame number,
+GPU page size, and status flag (R=reserved, P=pending, F=failed).
+
+example,
+cat /sys/kernel/debug/dri/0/vram_bad_pages
+
+max_pages: 10000
+0x0000000000000000 : 0x0000000000001000 : R
+0x0000000000001234 : 0x0000000000001000 : P
+0x0000000000080000 : 0x0000000000001000 : R   ← tile 1 addr (includes tile offset)
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe: Expose bad VRAM pages via debugfs)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_debugfs.c            |  4 ++
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.c       | 66 ++++++++++++++++++++++
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.h       |  2 +
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h |  2 +
+ 4 files changed, 74 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_debugfs.c b/drivers/gpu/drm/xe/xe_debugfs.c
+index 28135f84e286..e19eafffbb08 100644
+--- a/drivers/gpu/drm/xe/xe_debugfs.c
++++ b/drivers/gpu/drm/xe/xe_debugfs.c
+@@ -32,6 +32,7 @@
+ #include "xe_sriov_vf.h"
+ #include "xe_step.h"
+ #include "xe_tile_debugfs.h"
++#include "xe_ttm_vram_mgr.h"
+ #include "xe_vsec.h"
+ #include "xe_wa.h"
+ 
+@@ -773,6 +774,9 @@ void xe_debugfs_register(struct xe_device *xe)
+ 	if (man)
+ 		ttm_resource_manager_create_debugfs(man, root, "stolen_mm");
+ 
++	if (xe->info.platform == XE_CRESCENTISLAND)
++		xe_ttm_vram_debugfs_init(xe, root);
++
+ 	for_each_tile(tile, xe, tile_id)
+ 		xe_tile_debugfs_register(tile);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 24d134754265..af9e1fa868d7 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -5,6 +5,8 @@
+  */
+ 
++#include <linux/debugfs.h>
++
+ #include <drm/drm_managed.h>
+ #include <drm/drm_drv.h>
+ #include <drm/drm_buddy.h>
+ 
+@@ -874,3 +875,68 @@ int xe_ttm_vram_handle_addr_fault(struct xe_device *xe, u64 addr)
+ 	return xe_ttm_vram_reserve_page_at_addr(xe, addr - vr->dpa_base, vram_mgr, mm);
+ }
+ EXPORT_SYMBOL(xe_ttm_vram_handle_addr_fault);
++
++static int vram_bad_pages_show(struct seq_file *m, void *unused)
++{
++	struct xe_device *xe = m->private;
++	struct xe_ttm_vram_offline_resource *pos;
++	struct ttm_resource_manager *man;
++	struct gpu_buddy_block *block;
++	struct xe_ttm_vram_mgr *mgr;
++	struct xe_tile *tile;
++	u8 id;
++
++	man = ttm_manager_type(&xe->ttm, XE_PL_VRAM0);
++	if (man)
++		seq_printf(m, "max_pages: %d\n",
++			   to_xe_ttm_vram_mgr(man)->max_pages);
++
++	for_each_tile(tile, xe, id) {
++		struct xe_vram_region *vr = tile->mem.vram;
++
++		man = ttm_manager_type(&xe->ttm, XE_PL_VRAM0 + id);
++		if (!man || !vr)
++			continue;
++		mgr = to_xe_ttm_vram_mgr(man);
++
++		rcu_read_lock();
++
++		list_for_each_entry_rcu(pos, &mgr->offlined_pages, offlined_link) {
++			block = list_first_entry_or_null(&pos->blocks,
++							 struct gpu_buddy_block, link);
++			if (!block)
++				continue;
++
++			seq_printf(m, "0x%016llx : 0x%016llx : R\n",
++				   (gpu_buddy_block_offset(block) + vr->dpa_base) >> PAGE_SHIFT,
++				   gpu_buddy_block_size(&mgr->mm, block));
++		}
++
++		list_for_each_entry_rcu(pos, &mgr->queued_pages, queued_link) {
++			u64 pfn, blk_size;
++
++			block = list_first_entry_or_null(&pos->blocks,
++							 struct gpu_buddy_block, link);
++			if (block) {
++				pfn = (gpu_buddy_block_offset(block) + vr->dpa_base) >> PAGE_SHIFT;
++				blk_size = gpu_buddy_block_size(&mgr->mm, block);
++			} else {
++				pfn = (pos->addr + vr->dpa_base) >> PAGE_SHIFT;
++				blk_size = PAGE_SIZE;
++			}
++
++			seq_printf(m, "0x%016llx : 0x%016llx : %c\n",
++				   pfn, blk_size, pos->status ? 'F' : 'P');
++		}
++
++		rcu_read_unlock();
++	}
++
++	return 0;
++}
++DEFINE_SHOW_ATTRIBUTE(vram_bad_pages);
++
++void xe_ttm_vram_debugfs_init(struct xe_device *xe, struct dentry *root)
++{
++	debugfs_create_file("vram_bad_pages", 0444, root, xe, &vram_bad_pages_fops);
++}
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
+index d5392beff30c..f354c26c4257 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
+@@ -9,6 +9,7 @@
+ #include "xe_ttm_vram_mgr_types.h"
+ 
+ enum dma_data_direction;
++struct dentry;
+ struct xe_device;
+ struct xe_tile;
+ struct xe_vram_region;
+@@ -32,6 +33,7 @@ void xe_ttm_vram_get_used(struct ttm_resource_manager *man,
+ 			  u64 *used, u64 *used_visible);
+ 
+ int xe_ttm_vram_handle_addr_fault(struct xe_device *xe, u64 addr);
++void xe_ttm_vram_debugfs_init(struct xe_device *xe, struct dentry *root);
+ static inline struct xe_ttm_vram_mgr_resource *
+ to_xe_ttm_vram_mgr_resource(struct ttm_resource *res)
+ {
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h b/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
+index dc97b0ad0e51..efcf3e1d4e80 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
+@@ -37,6 +37,8 @@ struct xe_ttm_vram_mgr {
+ 	struct mutex lock;
+ 	/** @mem_type: The TTM memory type */
+ 	u32 mem_type;
++	/** @max_pages: max pages that can be in offline queue retrieved from FW */
++	u16 max_pages;
+ };
+ 
+ /**

--- a/backport/patches/base/0001-drm-xe-Extend-BO-purge-to-handle-vram-pages-as-well.patch
+++ b/backport/patches/base/0001-drm-xe-Extend-BO-purge-to-handle-vram-pages-as-well.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe: Extend BO purge to handle vram pages as well
+
+Recent driver update introduce support for purgeable buffer
+objects (BOs), extending the API to include VRAM pages to
+better manage memory pressure and enable memory offlining.
+
+Reviewed-by: Arvind Yadav <arvind.yadav@intel.com>
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Link:[V21] https://lore.kernel.org/all/20260519122817.45770-17-tejas.upadhyay@intel.com/
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_bo.c | 5 +----
+ drivers/gpu/drm/xe/xe_bo.h | 1 +
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
+index dde309821237..52f81e972ada 100644
+--- a/drivers/gpu/drm/xe/xe_bo.c
++++ b/drivers/gpu/drm/xe/xe_bo.c
+@@ -921,7 +921,7 @@ void xe_bo_set_purgeable_state(struct xe_bo *bo,
+  *
+  * Return: 0 on success, negative error code on failure
+  */
+-static int xe_ttm_bo_purge(struct ttm_buffer_object *ttm_bo, struct ttm_operation_ctx *ctx)
++int xe_ttm_bo_purge(struct ttm_buffer_object *ttm_bo, struct ttm_operation_ctx *ctx)
+ {
+ 	struct xe_bo *bo = ttm_to_xe_bo(ttm_bo);
+ 	struct ttm_placement place = {};
+@@ -929,9 +929,6 @@ static int xe_ttm_bo_purge(struct ttm_buffer_object *ttm_bo, struct ttm_operatio
+ 
+ 	xe_bo_assert_held(bo);
+ 
+-	if (!ttm_bo->ttm)
+-		return 0;
+-
+ 	if (!xe_bo_madv_is_dontneed(bo))
+ 		return 0;
+ 
+diff --git a/drivers/gpu/drm/xe/xe_bo.h b/drivers/gpu/drm/xe/xe_bo.h
+index e8081af5bfc1..90b15fff36c7 100644
+--- a/drivers/gpu/drm/xe/xe_bo.h
++++ b/drivers/gpu/drm/xe/xe_bo.h
+@@ -600,6 +600,7 @@ struct xe_bo_shrink_flags {
+ long xe_bo_shrink(struct ttm_operation_ctx *ctx, struct ttm_buffer_object *bo,
+ 		  const struct xe_bo_shrink_flags flags,
+ 		  unsigned long *scanned);
++int xe_ttm_bo_purge(struct ttm_buffer_object *ttm_bo, struct ttm_operation_ctx *ctx);
+ 
+ /**
+  * xe_bo_is_mem_type - Whether the bo currently resides in the given

--- a/backport/patches/base/0001-drm-xe-Guard-teardown-paths-against-purged-BOs.patch
+++ b/backport/patches/base/0001-drm-xe-Guard-teardown-paths-against-purged-BOs.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe: Guard teardown paths against purged BOs
+
+VRAM page offlining can purge BOs that are still referenced by page
+tables, exec queues, and DMA-buf exports. Add xe_bo_is_purged()
+guards in the teardown paths to prevent unpinning or mapping an
+already-purged BO:
+
+- xe_bo_unpin_map_no_vm(): skip unpin if purged
+- xe_dma_buf_map(): return -ENOENT early if purged
+- xe_exec_queue_update_run_ticks(): skip LRC timestamp read if purged
+- xe_pt_destroy(): skip unpin if purged
+
+v2(Himal):
+- take dma_resv lock before calling xe_bo_is_purged()
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe: Guard teardown paths against purged BOs)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+---
+ drivers/gpu/drm/xe/xe_bo.h         | 3 ++-
+ drivers/gpu/drm/xe/xe_dma_buf.c    | 3 +++
+ drivers/gpu/drm/xe/xe_exec_queue.c | 8 ++++++--
+ drivers/gpu/drm/xe/xe_pt.c         | 3 ++-
+ 4 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.h b/drivers/gpu/drm/xe/xe_bo.h
+index eede678ad303..dfcd0e57073b 100644
+--- a/drivers/gpu/drm/xe/xe_bo.h
++++ b/drivers/gpu/drm/xe/xe_bo.h
+@@ -364,7 +364,8 @@ static inline void xe_bo_unpin_map_no_vm(struct xe_bo *bo)
+ {
+ 	if (likely(bo)) {
+ 		xe_bo_lock(bo, false);
+-		xe_bo_unpin(bo);
++		if (!xe_bo_is_purged(bo))
++			xe_bo_unpin(bo);
+ 		xe_bo_unlock(bo);
+ 
+ 		xe_bo_put(bo);
+diff --git a/drivers/gpu/drm/xe/xe_dma_buf.c b/drivers/gpu/drm/xe/xe_dma_buf.c
+index bf0728838ead..5d9f1cd24b7f 100644
+--- a/drivers/gpu/drm/xe/xe_dma_buf.c
++++ b/drivers/gpu/drm/xe/xe_dma_buf.c
+@@ -104,6 +104,9 @@ static struct sg_table *xe_dma_buf_map(struct dma_buf_attachment *attach,
+ 	struct sg_table *sgt;
+ 	int r = 0;
+ 
++	if (xe_bo_is_purged(bo))
++		return ERR_PTR(-ENOENT);
++
+ 	if (!attach->peer2peer && !xe_bo_can_migrate(bo, XE_PL_TT))
+ 		return ERR_PTR(-EOPNOTSUPP);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index 91ed6c0fac84..91e4f3cb5617 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -1572,8 +1572,12 @@ void xe_exec_queue_update_run_ticks(struct xe_exec_queue *q)
+ 	 * errors.
+ 	 */
+ 	lrc = q->lrc[0];
+-	new_ts = xe_lrc_update_timestamp(lrc, &old_ts);
+-	q->xef->run_ticks[q->class] += (new_ts - old_ts) * q->width;
++	xe_bo_lock(lrc->bo, false);
++	if (!xe_bo_is_purged(lrc->bo)) {
++		new_ts = xe_lrc_update_timestamp(lrc, &old_ts);
++		q->xef->run_ticks[q->class] += (new_ts - old_ts) * q->width;
++	}
++	xe_bo_unlock(lrc->bo);
+ 
+ 	drm_dev_exit(idx);
+ }
+diff --git a/drivers/gpu/drm/xe/xe_pt.c b/drivers/gpu/drm/xe/xe_pt.c
+index 5d990c1c3740..dbf1aa26a21b 100644
+--- a/drivers/gpu/drm/xe/xe_pt.c
++++ b/drivers/gpu/drm/xe/xe_pt.c
+@@ -212,7 +212,8 @@ void xe_pt_destroy(struct xe_pt *pt, u32 flags, struct llist_head *deferred)
+ 		return;
+ 
+ 	XE_WARN_ON(!list_empty(&pt->bo->ttm.base.gpuva.list));
+-	xe_bo_unpin(pt->bo);
++	if (!xe_bo_is_purged(pt->bo))
++		xe_bo_unpin(pt->bo);
+ 	xe_bo_put_deferred(pt->bo, deferred);
+ 
+ 	if (pt->level > 0 && pt->num_live) {

--- a/backport/patches/base/0001-drm-xe-Link-LRC-BO-and-its-execution-Queue.patch
+++ b/backport/patches/base/0001-drm-xe-Link-LRC-BO-and-its-execution-Queue.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe: Link LRC BO and its execution Queue
+
+To establish a link between an LRC BO (Logical Ring Context
+Buffer Object) and its corresponding execution Queue in the
+drm/xe driver, you need to store a back-pointer to the queue
+within the BO's private data structure. This allows the
+driver to identify and take corrective action on the specific
+queue if the LRC BO encounters an error (e.g., memory
+corruption or eviction issues).
+
+V2(MattB):
+- Handle multiqueue
+
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Link:[V21] https://lore.kernel.org/all/20260519122817.45770-16-tejas.upadhyay@intel.com/
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_bo_types.h   | 3 +++
+ drivers/gpu/drm/xe/xe_exec_queue.c | 6 ++++++
+ drivers/gpu/drm/xe/xe_lrc.c        | 1 +
+ 3 files changed, 10 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo_types.h b/drivers/gpu/drm/xe/xe_bo_types.h
+index e45f24301050..a9c48e440669 100644
+--- a/drivers/gpu/drm/xe/xe_bo_types.h
++++ b/drivers/gpu/drm/xe/xe_bo_types.h
+@@ -20,6 +20,7 @@
+ struct xe_device;
+ struct xe_mem_pool_node;
+ struct xe_vm;
++struct xe_exec_queue;
+ 
+ #define XE_BO_MAX_PLACEMENTS	3
+ 
+@@ -42,6 +43,8 @@ struct xe_bo {
+ 	u32 flags;
+ 	/** @vm: VM this BO is attached to, for extobj this will be NULL */
+ 	struct xe_vm *vm;
++	/** @q: Queue this BO is attached to, mostly for LRC BO, NULL otherwise */
++	struct xe_exec_queue *q;
+ 	/** @tile: Tile this BO is attached to (kernel BO only) */
+ 	struct xe_tile *tile;
+ 	/** @placements: valid placements for this BO */
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue.c b/drivers/gpu/drm/xe/xe_exec_queue.c
+index c4213bb9c137..91ed6c0fac84 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue.c
++++ b/drivers/gpu/drm/xe/xe_exec_queue.c
+@@ -387,6 +387,12 @@ static int __xe_exec_queue_init(struct xe_exec_queue *q, u32 exec_queue_flags)
+ 				goto err_lrc;
+ 			}
+ 
++			/*
++			 * The queue ref counts the LRCs, thus it safe for the LRC BO to hold a
++			 * pointer to queue without reference.  The reader holds dma_resv (
++			 * xe_bo_lock) which serializes with xe_lrc_finish().
++			 */
++			WRITE_ONCE(lrc->bo->q, xe_exec_queue_multi_queue_primary(q));
+ 			xe_exec_queue_set_lrc(q, lrc, i);
+ 
+ 			if (__lrc)
+diff --git a/drivers/gpu/drm/xe/xe_lrc.c b/drivers/gpu/drm/xe/xe_lrc.c
+index 35b4e8289b5f..675902753735 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.c
++++ b/drivers/gpu/drm/xe/xe_lrc.c
+@@ -1066,6 +1066,7 @@ static void xe_lrc_set_ppgtt(struct xe_lrc *lrc, struct xe_vm *vm)
+ static void xe_lrc_finish(struct xe_lrc *lrc)
+ {
+ 	xe_hw_fence_ctx_finish(&lrc->fence_ctx);
++	WRITE_ONCE(lrc->bo->q, NULL);
+ 	xe_bo_unpin_map_no_vm(lrc->bo);
+ 	xe_bo_unpin_map_no_vm(lrc->seqno_bo);
+ }

--- a/backport/patches/base/0001-drm-xe-Link-VRAM-object-with-gpu-buddy.patch
+++ b/backport/patches/base/0001-drm-xe-Link-VRAM-object-with-gpu-buddy.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe/kunit: Setup driver data in the test device
+
+Setup to link TTM buffer object inside gpu buddy. This functionality
+is critical for supporting the memory page offline feature on CRI,
+where identified faulty pages must be traced back to their
+originating buffer for safe removal.
+
+V2(MattB): Clear block->private in xe_ttm_vram_mgr_del as well
+
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Link: [V21] https://lore.kernel.org/all/20260519122817.45770-13-tejas.upadhyay@intel.com/
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 05911904c1f9..51e983ee3bad 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -57,6 +57,7 @@ static int xe_ttm_vram_mgr_new(struct ttm_resource_manager *man,
+ 	struct xe_ttm_vram_mgr *mgr = to_xe_ttm_vram_mgr(man);
+ 	struct xe_ttm_vram_mgr_resource *vres;
+ 	struct gpu_buddy *mm = &mgr->mm;
++	struct gpu_buddy_block *block;
+ 	u64 size, min_page_size;
+ 	unsigned long lpfn;
+ 	int err;
+@@ -141,6 +142,8 @@ static int xe_ttm_vram_mgr_new(struct ttm_resource_manager *man,
+ 	}
+ 
+ 	mgr->visible_avail -= vres->used_visible_size;
++	list_for_each_entry(block, &vres->blocks, link)
++		block->private = tbo;
+ 	mutex_unlock(&mgr->lock);
+ 
+ 	if (!(vres->base.placement & TTM_PL_FLAG_CONTIGUOUS) &&
+@@ -179,8 +182,11 @@ static void xe_ttm_vram_mgr_del(struct ttm_resource_manager *man,
+ 		to_xe_ttm_vram_mgr_resource(res);
+ 	struct xe_ttm_vram_mgr *mgr = to_xe_ttm_vram_mgr(man);
+ 	struct gpu_buddy *mm = &mgr->mm;
++	struct gpu_buddy_block *block;
+ 
+ 	mutex_lock(&mgr->lock);
++	list_for_each_entry(block, &vres->blocks, link)
++		block->private = NULL;
+ 	gpu_buddy_free_list(mm, &vres->blocks, 0);
+ 	mgr->visible_avail += vres->used_visible_size;
+ 	mutex_unlock(&mgr->lock);

--- a/backport/patches/base/0001-drm-xe-bo-Make-xe_bo_is_user-public.patch
+++ b/backport/patches/base/0001-drm-xe-bo-Make-xe_bo_is_user-public.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe: Make xe_bo_is_user public
+
+Export xe_bo_is_user() so it can be used by the VRAM page offline
+code to distinguish user-created BOs from kernel BOs when deciding
+whether a faulty page can be safely purged or requires a full reset.
+
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe/bo: Make xe_bo_is_user() public)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_bo.c | 8 +++++++-
+ drivers/gpu/drm/xe/xe_bo.h | 1 +
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
+index 52f81e972ada..b077d137da57 100644
+--- a/drivers/gpu/drm/xe/xe_bo.c
++++ b/drivers/gpu/drm/xe/xe_bo.c
+@@ -158,7 +158,13 @@ bool xe_bo_is_vm_bound(struct xe_bo *bo)
+ 	return !list_empty(&bo->ttm.base.gpuva.list);
+ }
+ 
+-static bool xe_bo_is_user(struct xe_bo *bo)
++/**
++ * xe_bo_is_user - Check if BO is user-created
++ * @bo: The BO
++ *
++ * Returns: true if @bo was created by userspace
++ */
++bool xe_bo_is_user(struct xe_bo *bo)
+ {
+ 	return bo->flags & XE_BO_FLAG_USER;
+ }
+diff --git a/drivers/gpu/drm/xe/xe_bo.h b/drivers/gpu/drm/xe/xe_bo.h
+index 90b15fff36c7..eede678ad303 100644
+--- a/drivers/gpu/drm/xe/xe_bo.h
++++ b/drivers/gpu/drm/xe/xe_bo.h
+@@ -601,6 +601,7 @@ long xe_bo_shrink(struct ttm_operation_ctx *ctx, struct ttm_buffer_object *bo,
+ 		  const struct xe_bo_shrink_flags flags,
+ 		  unsigned long *scanned);
+ int xe_ttm_bo_purge(struct ttm_buffer_object *ttm_bo, struct ttm_operation_ctx *ctx);
++bool xe_bo_is_user(struct xe_bo *bo);
+ 
+ /**
+  * xe_bo_is_mem_type - Whether the bo currently resides in the given

--- a/backport/patches/base/0001-drm-xe-configfs-Add-bad_page_reservation-attribute.patch
+++ b/backport/patches/base/0001-drm-xe-configfs-Add-bad_page_reservation-attribute.patch
@@ -1,0 +1,178 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe/configfs: Add bad_page_reservation attribute
+
+Add a new configfs attribute 'bad_page_reservation' to control how bad
+VRAM pages are handled:
+  0 - Logging only (report in dmesg, no offlining)
+  1 - Offlining (default)
+
+The attribute can only be set before binding to the device and defaults
+to true (offlining enabled). This gives administrators control over
+whether corrupted VRAM pages detected by hardware (e.g., ECC errors)
+are actively offlined or only logged.
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe/configfs: Add bad_page_reservation attribute)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_configfs.c | 67 +++++++++++++++++++++++++++++++-
+ drivers/gpu/drm/xe/xe_configfs.h |  2 +
+ 2 files changed, 68 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_configfs.c b/drivers/gpu/drm/xe/xe_configfs.c
+index 052cce962161..80c4c5f66e4c 100644
+--- a/drivers/gpu/drm/xe/xe_configfs.c
++++ b/drivers/gpu/drm/xe/xe_configfs.c
+@@ -61,7 +61,8 @@
+  *	    ├── survivability_mode
+  *	    ├── gt_types_allowed
+  *	    ├── engines_allowed
+- *	    └── enable_psmi
++ *          ├── enable_psmi
++ *          └── bad_page_reservation
+  *
+  * After configuring the attributes as per next section, the device can be
+  * probed with::
+@@ -159,6 +160,19 @@
+  *
+  * This attribute can only be set before binding to the device.
+  *
++ * Bad pages reservation:
++ * ---------------------
++ *
++ * Controls how bad VRAM pages are handled:
++ *  0 - Logging only (report in dmesg, no offlining)
++ *  1 - Offlining (default)
++ *
++ *  Example to disable offlining::
++ *
++ *      # echo 0 > /sys/kernel/config/xe/0000:03:00.0/bad_page_reservation
++ *
++ * This attribute can only be set before binding to the device.
++ *
+  * Context restore BB
+  * ------------------
+  *
+@@ -275,6 +289,7 @@ struct xe_config_group_device {
+ 		bool survivability_mode;
+ 		bool enable_psmi;
+ 		bool enable_multi_queue;
++		bool bad_page_reservation;
+ 		struct {
+ 			unsigned int max_vfs;
+ 			bool admin_only_pf;
+@@ -295,6 +310,7 @@ static const struct xe_config_device device_defaults = {
+ 	.survivability_mode = false,
+ 	.enable_psmi = false,
+ 	.enable_multi_queue = true,
++	.bad_page_reservation = true,
+ 	.sriov = {
+ 		.max_vfs = XE_DEFAULT_MAX_VFS,
+ 		.admin_only_pf = XE_DEFAULT_ADMIN_ONLY_PF,
+@@ -616,6 +632,32 @@ static ssize_t enable_multi_queue_store(struct config_item *item, const char *pa
+ 	return len;
+ }
+ 
++static ssize_t bad_page_reservation_show(struct config_item *item, char *page)
++{
++	struct xe_config_device *dev = to_xe_config_device(item);
++
++	return sprintf(page, "%d\n", dev->bad_page_reservation);
++}
++
++static ssize_t bad_page_reservation_store(struct config_item *item, const char *page, size_t len)
++{
++	struct xe_config_group_device *dev = to_xe_config_group_device(item);
++	bool val;
++	int ret;
++
++	ret = kstrtobool(page, &val);
++	if (ret)
++		return ret;
++
++	guard(mutex)(&dev->lock);
++	if (is_bound(dev))
++		return -EBUSY;
++
++	dev->config.bad_page_reservation = val;
++
++	return len;
++}
++
+ static bool wa_bb_read_advance(bool dereference, char **p,
+ 			       const char *append, size_t len,
+ 			       size_t *max_size)
+@@ -855,6 +897,7 @@ CONFIGFS_ATTR(, ctx_restore_mid_bb);
+ CONFIGFS_ATTR(, ctx_restore_post_bb);
+ CONFIGFS_ATTR(, enable_multi_queue);
+ CONFIGFS_ATTR(, enable_psmi);
++CONFIGFS_ATTR(, bad_page_reservation);
+ CONFIGFS_ATTR(, engines_allowed);
+ CONFIGFS_ATTR(, gt_types_allowed);
+ CONFIGFS_ATTR(, survivability_mode);
+@@ -864,6 +907,7 @@ static struct configfs_attribute *xe_config_device_attrs[] = {
+ 	&attr_ctx_restore_post_bb,
+ 	&attr_enable_multi_queue,
+ 	&attr_enable_psmi,
++	&attr_bad_page_reservation,
+ 	&attr_engines_allowed,
+ 	&attr_gt_types_allowed,
+ 	&attr_survivability_mode,
+@@ -1142,6 +1186,7 @@ static void dump_custom_dev_config(struct pci_dev *pdev,
+ 	PRI_CUSTOM_ATTR("%llx", engines_allowed);
+ 	PRI_CUSTOM_ATTR("%d", enable_multi_queue);
+ 	PRI_CUSTOM_ATTR("%d", enable_psmi);
++	PRI_CUSTOM_ATTR("%d", bad_page_reservation);
+ 	PRI_CUSTOM_ATTR("%d", survivability_mode);
+ 	PRI_CUSTOM_ATTR("%u", sriov.admin_only_pf);
+ 
+@@ -1290,6 +1335,26 @@ bool xe_configfs_get_enable_multi_queue(struct pci_dev *pdev)
+ 	return ret;
+ }
+ 
++/**
++ * xe_configfs_get_bad_page_reservation - get configfs bad_page_reservation setting
++ * @pdev: pci device
++ *
++ * Return: bad_page_reservation setting in configfs
++ */
++bool xe_configfs_get_bad_page_reservation(struct pci_dev *pdev)
++{
++	struct xe_config_group_device *dev = find_xe_config_group_device(pdev);
++	bool ret;
++
++	if (!dev)
++		return device_defaults.bad_page_reservation;
++
++	ret = dev->config.bad_page_reservation;
++	config_group_put(&dev->group);
++
++	return ret;
++}
++
+ /**
+  * xe_configfs_get_ctx_restore_mid_bb - get configfs ctx_restore_mid_bb setting
+  * @pdev: pci device
+diff --git a/drivers/gpu/drm/xe/xe_configfs.h b/drivers/gpu/drm/xe/xe_configfs.h
+index 4fbbeafba473..7405cc5f3207 100644
+--- a/drivers/gpu/drm/xe/xe_configfs.h
++++ b/drivers/gpu/drm/xe/xe_configfs.h
+@@ -24,6 +24,7 @@ bool xe_configfs_media_gt_allowed(struct pci_dev *pdev);
+ u64 xe_configfs_get_engines_allowed(struct pci_dev *pdev);
+ bool xe_configfs_get_psmi_enabled(struct pci_dev *pdev);
+ bool xe_configfs_get_enable_multi_queue(struct pci_dev *pdev);
++bool xe_configfs_get_bad_page_reservation(struct pci_dev *pdev);
+ u32 xe_configfs_get_ctx_restore_mid_bb(struct pci_dev *pdev,
+ 				       enum xe_engine_class class,
+ 				       const u32 **cs);
+@@ -44,6 +45,7 @@ static inline bool xe_configfs_media_gt_allowed(struct pci_dev *pdev) { return t
+ static inline u64 xe_configfs_get_engines_allowed(struct pci_dev *pdev) { return U64_MAX; }
+ static inline bool xe_configfs_get_psmi_enabled(struct pci_dev *pdev) { return false; }
+ static inline bool xe_configfs_get_enable_multi_queue(struct pci_dev *pdev) { return true; }
++static inline bool xe_configfs_get_bad_page_reservation(struct pci_dev *pdev) { return true; }
+ static inline u32 xe_configfs_get_ctx_restore_mid_bb(struct pci_dev *pdev,
+ 						     enum xe_engine_class class,
+ 						     const u32 **cs) { return 0; }

--- a/backport/patches/base/0001-drm-xe-ras-Cache-bad_page_reservation-policy-at-init.patch
+++ b/backport/patches/base/0001-drm-xe-ras-Cache-bad_page_reservation-policy-at-init.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe/ras: Cache bad_page_reservation policy at init
+
+The configfs bad_page_reservation attribute can only be set before
+device bind, so its value is immutable at runtime. Cache it in
+struct xe_drm_ras during xe_drm_ras_init() to avoid repeated configfs
+lookups on every fault.
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(cherry-picked from [V21] https://lore.kernel.org/all/20260519122817.45770-22-tejas.upadhyay@intel.com/ )
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_drm_ras_types.h | 3 +++
+ drivers/gpu/drm/xe/xe_ras.c           | 5 +++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_drm_ras_types.h b/drivers/gpu/drm/xe/xe_drm_ras_types.h
+index 8d729ad6a264..83899cf04793 100644
+--- a/drivers/gpu/drm/xe/xe_drm_ras_types.h
++++ b/drivers/gpu/drm/xe/xe_drm_ras_types.h
+@@ -43,6 +43,9 @@ struct xe_drm_ras {
+ 
+ 	/** @info: info array for all types of errors */
+ 	struct xe_drm_ras_counter *info[DRM_XE_RAS_ERR_SEV_MAX];
++
++	/** @bad_page_reservation: cached configfs policy, immutable after init */
++	bool bad_page_reservation;
+ };
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_ras.c b/drivers/gpu/drm/xe/xe_ras.c
+index d25d25f77531..c7e86ae0e8ad 100644
+--- a/drivers/gpu/drm/xe/xe_ras.c
++++ b/drivers/gpu/drm/xe/xe_ras.c
+@@ -3,6 +3,7 @@
+  * Copyright © 2026 Intel Corporation
+  */
+ 
++#include "xe_configfs.h"
+ #include "xe_debugfs.h"
+ #include "xe_device.h"
+ #include "xe_drm_ras.h"
+@@ -775,9 +775,13 @@ void xe_ras_init(struct xe_device *xe)
+ {
+ 	int ret;
+ 
+ 	if (!xe->info.has_drm_ras)
+ 		return;
+ 
++	if (xe->info.platform == XE_CRESCENTISLAND)
++		xe->ras.bad_page_reservation =
++			xe_configfs_get_bad_page_reservation(to_pci_dev(xe->drm.dev));
++
+ 	xe_drm_ras_init(xe);
+ 
+ 	if (!xe->info.has_sysctrl)

--- a/backport/patches/base/0001-drm-xe-vram-Add-VRAM-page-offline-fault-handler.patch
+++ b/backport/patches/base/0001-drm-xe-vram-Add-VRAM-page-offline-fault-handler.patch
@@ -1,0 +1,374 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe/vram: Add VRAM page offline fault handler
+
+Add the core VRAM page offlining logic to handle HW-reported faulty
+physical addresses:
+
+- xe_ttm_vram_purge_page(): Purges the BO containing the faulty
+  address. Bans the associated VM (if page table BO) and exec queue
+  (if LRC BO). Moves xe_exec_queue_kill() outside xe_bo_lock() to
+  avoid AB-BA deadlock with vm->lock. Uses READ_ONCE(bo->q) to
+  safely access the exec queue pointer.
+
+- xe_ttm_vram_page_already_processed(): Checks if an address is
+  already tracked in offlined_pages or queued_pages lists to avoid
+  double-processing.
+
+- xe_ttm_vram_reserve_page_at_addr(): Two-phase reservation that
+  first queues the page, purges the BO outside the lock, then
+  reserves the buddy block. Handles both allocated (BO present)
+  and free page cases. Returns -EIO for critical kernel BOs to
+  trigger system reset.
+
+- xe_ttm_vram_addr_to_region(): Maps a DPA to its VRAM region.
+  Uses GSMBASE MMIO register to detect GSM addresses (returns NULL
+  for reset path). Returns ERR_PTR(-EOPNOTSUPP) for addresses
+  outside any known region.
+
+- xe_ttm_vram_handle_addr_fault(): Entry point called by RAS.
+  Returns -EEXIST if already processed, -EIO for GSM/critical BO,
+  -EOPNOTSUPP if out of bounds.
+
+v11(Himal):
+- match everywhere with enum vs bool for status member
+- Fix comment and remove unused var
+- if purge fail let next alloc confirm failure
+- pass absolute address, useful for multi tile
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe/vram: Add VRAM page offline fault handler)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+  drivers/gpu/drm/xe/xe_ttm_vram_mgr.c | 296 +++++++++++++++++++++++++++
+  drivers/gpu/drm/xe/xe_ttm_vram_mgr.h |   1 +
+  2 files changed, 297 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 1253989a8d06..b2b6c1bd2c55 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -11,9 +11,15 @@ #include <drm/ttm/ttm_range_manager.h>
+ #include <drm/ttm/ttm_placement.h>
+ #include <drm/ttm/ttm_range_manager.h>
+ 
++#include "regs/xe_regs.h"
+ #include "xe_bo.h"
++#include "xe_configfs.h"
+ #include "xe_device.h"
++#include "xe_exec_queue.h"
++#include "xe_lrc.h"
++#include "xe_mmio.h"
+ #include "xe_res_cursor.h"
++#include "xe_ttm_stolen_mgr.h"
+ #include "xe_ttm_vram_mgr.h"
+ #include "xe_vram_types.h"
+ 
+@@ -572,3 +578,293 @@ u64 xe_ttm_vram_get_avail(struct ttm_resource_manager *man)
+ 
+ 	return avail;
+ }
++
++static int xe_ttm_vram_purge_page(struct xe_device *xe, struct xe_bo *bo)
++{
++	struct ttm_operation_ctx ctx = {};
++	struct xe_exec_queue *q_to_put = NULL;
++	struct xe_exec_queue *q = NULL;
++	struct xe_vm *vm = NULL;
++	u32	flags;
++	int ret = 0;
++
++	xe_bo_lock(bo, false);
++	if (bo->vm)
++		vm = xe_vm_get(bo->vm);
++	flags = bo->flags;
++	xe_bo_unlock(bo);
++	/*  Ban VM if BO is PPGTT */
++	if (vm && (flags & XE_BO_FLAG_PAGETABLE)) {
++		down_write(&vm->lock);
++		xe_vm_kill(vm, true);
++		up_write(&vm->lock);
++	}
++	if (vm)
++		xe_vm_put(vm);
++
++	xe_bo_lock(bo, false);
++	q = READ_ONCE(bo->q);
++	/*  Ban exec queue if BO is lrc */
++	if (q && xe_exec_queue_get_unless_zero(q)) {
++		/* ban queue */
++		q_to_put = q;
++	}
++
++	if (bo->purgeable.state == XE_MADV_PURGEABLE_PURGED) {
++		/* Already purged by shrinker during unlocked window — nothing to do */
++		xe_bo_unlock(bo);
++		goto out;
++	}
++
++	xe_bo_set_purgeable_state(bo, XE_MADV_PURGEABLE_DONTNEED);
++	ttm_bo_unmap_virtual(&bo->ttm);   /* nuke CPU mmap + VRAM IO mappings */
++	if (xe_bo_is_pinned(bo))
++		xe_bo_unpin(bo);
++	ret = xe_ttm_bo_purge(&bo->ttm, &ctx);
++	xe_bo_unlock(bo);
++
++out:
++	if (q_to_put) {
++		xe_exec_queue_kill(q_to_put);
++		xe_exec_queue_put(q_to_put);
++	}
++
++	return ret;
++}
++
++static bool xe_ttm_vram_page_already_processed(struct xe_ttm_vram_mgr *mgr,
++					       u64 addr)
++{
++	struct xe_ttm_vram_offline_resource *pos;
++
++	lockdep_assert_held(&mgr->lock);
++
++	list_for_each_entry(pos, &mgr->offlined_pages, offlined_link) {
++		if (pos->addr == addr)
++			return true;
++	}
++
++	list_for_each_entry(pos, &mgr->queued_pages, queued_link) {
++		if (pos->addr == addr)
++			return true;
++	}
++
++	return false;
++}
++
++static int xe_ttm_vram_reserve_page_at_addr(struct xe_device *xe, u64 addr,
++					    struct xe_ttm_vram_mgr *vram_mgr, struct gpu_buddy *mm)
++{
++	struct xe_ttm_vram_offline_resource *nentry;
++	struct ttm_buffer_object *tbo = NULL;
++	struct xe_bo *pbo_to_put = NULL;
++	struct gpu_buddy_block *block;
++	u64 size = SZ_4K;
++	int ret = 0;
++
++	scoped_guard(mutex, &vram_mgr->lock) {
++		if (xe_ttm_vram_page_already_processed(vram_mgr, addr))
++			return -EEXIST;
++		block = gpu_buddy_allocated_addr_to_block(mm, addr);
++		if (WARN_ON(IS_ERR(block)))
++			return PTR_ERR(block);
++
++		nentry = kzalloc_obj(*nentry);
++		if (!nentry)
++			return -ENOMEM;
++		INIT_LIST_HEAD(&nentry->blocks);
++		nentry->status = XE_PAGE_RESERVE_PENDING;
++		nentry->addr = addr;
++
++		if (block) {
++			struct xe_bo *pbo;
++
++			if (!block->private) {
++				/* Race: another thread just reserved this block */
++				kfree(nentry);
++				return -EEXIST;
++			}
++			tbo = block->private;
++			pbo = ttm_to_xe_bo(tbo);
++
++			/* Get reference safely - BO may have zero refcount */
++			if (!xe_bo_get_unless_zero(pbo)) {
++				kfree(nentry);
++				return -ENOENT;
++			}
++			/*
++			 * Critical kernel BO? Best-effort check without resv lock;
++			 * worst case a concurrent pin causes reset path unnecessarily.
++			 */
++			if ((pbo->ttm.type == ttm_bo_type_kernel &&
++			     !(pbo->flags & XE_BO_FLAG_PINNED_LATE_RESTORE)) ||
++			    (xe_bo_is_user(pbo) && xe_bo_is_pinned(pbo))) {
++				kfree(nentry);
++				pbo_to_put = pbo;
++				drm_err(&xe->drm,
++					"%s: addr: 0x%llx is critical kernel bo, requesting SBR\n",
++					__func__, addr);
++				break;
++			}
++			++vram_mgr->n_queued_pages;
++			list_add_rcu(&nentry->queued_link, &vram_mgr->queued_pages);
++		}
++	}
++
++	/* Deferred put outside lock to avoid recursive deadlock */
++	if (pbo_to_put) {
++		xe_bo_put(pbo_to_put);
++		/* Hint System controller driver for reset with -EIO  */
++		return -EIO;
++	}
++
++	if (block) {
++		struct xe_ttm_vram_offline_resource *pos, *n;
++		struct xe_bo *pbo = ttm_to_xe_bo(tbo);
++
++		/*
++		 * Purge BO containing address - reference held from above.
++		 * Note: brief window between purge (freeing blocks) and re-reserve
++		 * below. If another allocation claims the block, buddy_alloc fails
++		 * and the status will be shown as failed reservation.
++		 */
++		ret = xe_ttm_vram_purge_page(xe, pbo);
++		xe_bo_put(pbo);
++		if (ret)
++			drm_warn(&xe->drm, "Purge failed at addr:0x%llx, ret:%d\n", addr, ret);
++
++		/* Reserve page at address addr*/
++		scoped_guard(mutex, &vram_mgr->lock) {
++			ret = xe_ttm_vram_buddy_alloc(vram_mgr, addr, addr + size,
++						      size, size, &nentry->blocks,
++						      GPU_BUDDY_RANGE_ALLOCATION,
++						      NULL, &nentry->used_visible_size);
++			if (ret) {
++				drm_warn(&xe->drm,
++					 "Could not reserve page at addr:0x%llx, ret:%d\n",
++					 addr, ret);
++				nentry->status = XE_PAGE_RESERVE_FAIL;
++				return ret;
++			}
++
++			list_for_each_entry_safe(pos, n, &vram_mgr->queued_pages, queued_link) {
++				if (pos->addr == nentry->addr) {
++					--vram_mgr->n_queued_pages;
++					list_del_rcu(&pos->queued_link);
++					break;
++				}
++			}
++			list_add_rcu(&nentry->offlined_link, &vram_mgr->offlined_pages);
++			/* RAS will send command to FW for offlining page based on ret value */
++			++vram_mgr->n_offlined_pages;
++			return ret;
++		}
++	} else {
++		struct xe_ttm_vram_offline_resource *pos, *n;
++
++		scoped_guard(mutex, &vram_mgr->lock) {
++			++vram_mgr->n_queued_pages;
++			list_add_rcu(&nentry->queued_link, &vram_mgr->queued_pages);
++			ret = xe_ttm_vram_buddy_alloc(vram_mgr, addr, addr + size,
++						      size, size, &nentry->blocks,
++						      GPU_BUDDY_RANGE_ALLOCATION,
++						      NULL, &nentry->used_visible_size);
++			if (ret) {
++				drm_warn(&xe->drm,
++					 "Could not reserve page at addr:0x%llx, ret:%d\n",
++					 addr, ret);
++				nentry->status = XE_PAGE_RESERVE_FAIL;
++				return ret;
++			}
++
++			list_for_each_entry_safe(pos, n, &vram_mgr->queued_pages, queued_link) {
++				if (pos->addr == nentry->addr) {
++					--vram_mgr->n_queued_pages;
++					list_del_rcu(&pos->queued_link);
++					break;
++				}
++			}
++			++vram_mgr->n_offlined_pages;
++			list_add_rcu(&nentry->offlined_link, &vram_mgr->offlined_pages);
++			/* RAS will send command to FW for offlining page based on ret value */
++		}
++	}
++	/* Success */
++	return ret;
++}
++
++static struct xe_vram_region *xe_ttm_vram_addr_to_region(struct xe_device *xe, u64 addr)
++{
++	struct xe_tile *tile;
++	u8 id;
++
++	for_each_tile(tile, xe, id) {
++		struct xe_vram_region *vr = tile->mem.vram;
++
++		if (!vr)
++			continue;
++
++		if (addr >= vr->dpa_base && addr < (vr->dpa_base + vr->usable_size))
++			return vr;
++
++		/* CCS, GSM, or DSM — infrastructure zone, needs reset */
++		if (addr >= (vr->dpa_base + vr->usable_size) &&
++		    addr < (vr->dpa_base + vr->actual_physical_size))
++			return NULL;
++	}
++
++	/*
++	 * Return an explicit error pointer so the caller knows the addr
++	 * is invalid and should be ignored, NOT SBR.
++	 */
++	return ERR_PTR(-EOPNOTSUPP);
++}
++
++/**
++ * xe_ttm_vram_handle_addr_fault - Handle vram physical address error flaged
++ * @xe: pointer to parent device
++ * @addr: physical faulty address
++ *
++ * Handle the physcial faulty address error on specific tile.
++ *
++ * Returns 0 for success, negative error code otherwise as follow:
++ * * %-EIO - critical BO or address outside any VRAM region; next action is reset.
++ * * %-EOPNOTSUPP - log-only policy or unknown address; no further action.
++ * * %-ENOMEM - allocation failure; next action is reset.
++ * * %-ENXIO - address not found in buddy; no further action.
++ * * %-EEXIST - address already processed; no further action.
++ */
++int xe_ttm_vram_handle_addr_fault(struct xe_device *xe, u64 addr)
++{
++	struct xe_ttm_vram_mgr *vram_mgr;
++	struct xe_vram_region *vr;
++	struct gpu_buddy *mm;
++
++	/* Assert that the address is 4K aligned */
++	if (WARN_ON_ONCE(!IS_ALIGNED(addr, SZ_4K))) {
++		drm_err(&xe->drm, "Address %llx is not 4K aligned!\n", addr);
++		return -EINVAL;
++	}
++
++	vr = xe_ttm_vram_addr_to_region(xe, addr);
++	if (IS_ERR(vr)) {
++		/*
++		 * The addr is outside VRAM and GSM.
++		 * Log a debug message if needed, and safely exit/ignore.
++		 */
++		drm_dbg(&xe->drm, "Address %llx is out of bounds, ignoring fault.\n", addr);
++		return PTR_ERR(vr);
++	}
++	if (!vr) {
++		drm_err(&xe->drm, "%s:%d GSM addr:%llx error requesting SBR\n",
++			__func__, __LINE__, addr);
++		/* Hint System controller driver for reset with -EIO  */
++		return -EIO;
++	}
++	vram_mgr = &vr->ttm;
++	mm = &vram_mgr->mm;
++
++	/* Reserve page at address */
++	return xe_ttm_vram_reserve_page_at_addr(xe, addr - vr->dpa_base, vram_mgr, mm);
++}
++EXPORT_SYMBOL(xe_ttm_vram_handle_addr_fault);
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
+index 87b7fae5edba..d5392beff30c 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.h
+@@ -31,6 +31,7 @@ u64 xe_ttm_vram_get_cpu_visible_size(struct ttm_resource_manager *man);
+ void xe_ttm_vram_get_used(struct ttm_resource_manager *man,
+ 			  u64 *used, u64 *used_visible);
+ 
++int xe_ttm_vram_handle_addr_fault(struct xe_device *xe, u64 addr);
+ static inline struct xe_ttm_vram_mgr_resource *
+ to_xe_ttm_vram_mgr_resource(struct ttm_resource *res)
+ {

--- a/backport/patches/base/0001-drm-xe-vram-Add-page-offline-data-structures-and-lifecycle.patch
+++ b/backport/patches/base/0001-drm-xe-vram-Add-page-offline-data-structures-and-lifecycle.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe/vram: Add page offline data structures and lifecycle
+
+Add xe_ttm_vram_offline_resource to track individual offlined VRAM
+pages, and extend xe_ttm_vram_mgr with offlined_pages/queued_pages
+lists and their counters.
+
+Initialize the lists in __xe_ttm_vram_mgr_init() and add
+xe_ttm_vram_free_bad_pages() to release all tracked pages during
+xe_ttm_vram_mgr_fini() teardown.
+
+v2(Himal):
+- Address possible leak in xe_ttm_vram_mgr_fini()
+- Remove unused dev and add comment for used_visible_size 0
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe/vram: Add page offline data structures and lifecycle)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.c       | 25 ++++++++++++++
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h | 38 ++++++++++++++++++++++
+ 2 files changed, 63 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 16ecea497780..1253989a8d06 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -301,13 +301,36 @@ static const struct ttm_resource_manager_func xe_ttm_vram_mgr_func = {
+ };
+ 
++static void xe_ttm_vram_free_bad_pages(struct xe_ttm_vram_mgr *mgr)
++{
++	struct xe_ttm_vram_offline_resource *pos, *n;
++
++	list_for_each_entry_safe(pos, n, &mgr->offlined_pages, offlined_link) {
++		list_del_rcu(&pos->offlined_link);
++		xe_ttm_vram_buddy_free(mgr, &pos->blocks, pos->used_visible_size);
++		--mgr->n_offlined_pages;
++		kfree_rcu(pos, rcu);
++	}
++	list_for_each_entry_safe(pos, n, &mgr->queued_pages, queued_link) {
++		list_del_rcu(&pos->queued_link);
++		/* queued entries have no buddy reservation yet */
++		xe_ttm_vram_buddy_free(mgr, &pos->blocks, 0);
++		--mgr->n_queued_pages;
++		kfree_rcu(pos, rcu);
++	}
++}
++
+ static void xe_ttm_vram_mgr_fini(struct drm_device *dev, void *arg)
+ {
+ 	struct xe_device *xe = to_xe_device(dev);
+ 	struct xe_ttm_vram_mgr *mgr = arg;
+ 	struct ttm_resource_manager *man = &mgr->manager;
+ 
++	mutex_lock(&mgr->lock);
++	xe_ttm_vram_free_bad_pages(mgr);
++	mutex_unlock(&mgr->lock);
++
+ 	ttm_resource_manager_set_used(man, false);
+ 
+ 	if (ttm_resource_manager_evict_all(&xe->ttm, man))
+ 		return;
+ 
+@@ -339,6 +362,8 @@ int __xe_ttm_vram_mgr_init(struct xe_device *xe, struct xe_ttm_vram_mgr *mgr,
+ 	man->func = &xe_ttm_vram_mgr_func;
+ 	mgr->mem_type = mem_type;
+ 	mutex_init(&mgr->lock);
++	INIT_LIST_HEAD(&mgr->offlined_pages);
++	INIT_LIST_HEAD(&mgr->queued_pages);
+ 	mgr->default_page_size = default_page_size;
+ 	mgr->visible_size = io_size;
+ 	mgr->visible_avail = io_size;
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h b/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
+index 9106da056b49..dc97b0ad0e51 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr_types.h
+@@ -19,6 +19,14 @@ struct xe_ttm_vram_mgr {
+ 	struct ttm_resource_manager manager;
+ 	/** @mm: DRM buddy allocator which manages the VRAM */
+ 	struct gpu_buddy mm;
++	/** @offlined_pages: List of offlined pages */
++	struct list_head offlined_pages;
++	/** @n_offlined_pages: Number of offlined pages */
++	u16 n_offlined_pages;
++	/** @queued_pages: List of queued pages */
++	struct list_head queued_pages;
++	/** @n_queued_pages: Number of queued pages */
++	u16 n_queued_pages;
+ 	/** @visible_size: Proped size of the CPU visible portion */
+ 	u64 visible_size;
+ 	/** @visible_avail: CPU visible portion still unallocated */
+@@ -45,4 +53,34 @@ struct xe_ttm_vram_mgr_resource {
+ 	unsigned long flags;
+ };
+ 
++/**
++ * enum xe_page_reserve_status - Buddy reservation status
++ * @XE_PAGE_RESERVE_PENDING: reservation in progress
++ * @XE_PAGE_RESERVE_FAIL: reservation failed
++ */
++enum xe_page_reserve_status {
++	XE_PAGE_RESERVE_PENDING = 0,
++	XE_PAGE_RESERVE_FAIL,
++};
++
++/**
++ * struct xe_ttm_vram_offline_resource - Tracks a single offlined VRAM page
++ */
++struct xe_ttm_vram_offline_resource {
++	/** @offlined_link: Link into mgr->offlined_pages */
++	struct list_head offlined_link;
++	/** @queued_link: Link into mgr->queued_pages */
++	struct list_head queued_link;
++	/** @blocks: Buddy blocks reserved for this page */
++	struct list_head blocks;
++	/** @used_visible_size: CPU-visible bytes consumed */
++	u64 used_visible_size;
++	/** @addr: Faulty DPA reported by HW */
++	u64 addr;
++	/** @status: buddy reservation status */
++	enum xe_page_reserve_status status;
++	/** @rcu: RCU head for deferred freeing */
++	struct rcu_head rcu;
++};
++
+ #endif

--- a/backport/patches/base/0001-drm-xe-vram-Check-bad_page_reservation-policy-in-fault-handler.patch
+++ b/backport/patches/base/0001-drm-xe-vram-Check-bad_page_reservation-policy-in-fault-handler.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe/vram: Check bad_page_reservation policy in fault handler
+
+Before reserving a page at a faulting address, check the cached
+bad_page_reservation policy from xe->ras. If the policy is disabled
+(logging only), log the corrupted address and return -EOPNOTSUPP so
+that RAS can report to firmware to drop the address from the SRAM
+queue without attempting to offline the page.
+
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe/vram: Check bad_page_reservation policy in fault handler)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index b2b6c1bd2c55..24d134754265 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -864,6 +864,12 @@ int xe_ttm_vram_handle_addr_fault(struct xe_device *xe, u64 addr)
+ 	vram_mgr = &vr->ttm;
+ 	mm = &vram_mgr->mm;
+ 
++	if (!xe->ras.bad_page_reservation) {
++		drm_err(&xe->drm, "0x%llx is reported as corrupted address by HW\n",
++			addr);
++		return -EOPNOTSUPP;
++	}
++
+ 	/* Reserve page at address */
+ 	return xe_ttm_vram_reserve_page_at_addr(xe, addr - vr->dpa_base, vram_mgr, mm);
+ }

--- a/backport/patches/base/0001-drm-xe-vram-Extract-buddy-alloc-and-free-helpers.patch
+++ b/backport/patches/base/0001-drm-xe-vram-Extract-buddy-alloc-and-free-helpers.patch
@@ -1,0 +1,146 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe/vram: Extract buddy alloc and free helpers
+
+Factor out xe_ttm_vram_buddy_alloc() and xe_ttm_vram_buddy_free()
+from xe_ttm_vram_mgr_new() and xe_ttm_vram_mgr_del(). These helpers
+consolidate block allocation with visible-size tracking and
+block->private tagging, making them reusable by the upcoming VRAM
+page offline reservation path.
+
+No functional change.
+
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe/vram: Extract buddy alloc and free helpers)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.c | 82 +++++++++++++++++-----------
+ 1 file changed, 51 insertions(+), 31 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index 51e983ee3bad..16ecea497780 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -49,6 +49,40 @@ static inline bool xe_is_vram_mgr_blocks_contiguous(struct gpu_buddy *mm,
+ 	return true;
+ }
+ 
++static int xe_ttm_vram_buddy_alloc(struct xe_ttm_vram_mgr *mgr, u64 start,
++				   u64 end, u64 size, u64 min_page_size,
++				   struct list_head *blocks, unsigned long flags,
++				   void *priv, u64 *used_visible)
++{
++	struct gpu_buddy *mm = &mgr->mm;
++	struct gpu_buddy_block *block;
++	int err;
++
++	err = gpu_buddy_alloc_blocks(mm, start, end, size, min_page_size, blocks, flags);
++	if (err)
++		return err;
++
++	list_for_each_entry(block, blocks, link)
++		block->private = priv;
++
++	if (end <= mgr->visible_size) {
++		*used_visible = size;
++	} else {
++		list_for_each_entry(block, blocks, link) {
++			u64 blk_start = gpu_buddy_block_offset(block);
++
++			if (blk_start < mgr->visible_size) {
++				u64 blk_end = blk_start + gpu_buddy_block_size(mm, block);
++
++				*used_visible += min(blk_end, mgr->visible_size) - blk_start;
++			}
++		}
++	}
++
++	mgr->visible_avail -= *used_visible;
++	return 0;
++}
++
+ static int xe_ttm_vram_mgr_new(struct ttm_resource_manager *man,
+ 			       struct ttm_buffer_object *tbo,
+ 			       const struct ttm_place *place,
+@@ -57,7 +91,6 @@ static int xe_ttm_vram_mgr_new(struct ttm_resource_manager *man,
+ 	struct xe_ttm_vram_mgr *mgr = to_xe_ttm_vram_mgr(man);
+ 	struct xe_ttm_vram_mgr_resource *vres;
+ 	struct gpu_buddy *mm = &mgr->mm;
+-	struct gpu_buddy_block *block;
+ 	u64 size, min_page_size;
+ 	unsigned long lpfn;
+ 	int err;
+@@ -118,32 +151,12 @@ static int xe_ttm_vram_mgr_new(struct ttm_resource_manager *man,
+ 		goto error_unlock;
+ 	}
+ 
+-	err = gpu_buddy_alloc_blocks(mm, (u64)place->fpfn << PAGE_SHIFT,
+-				     (u64)lpfn << PAGE_SHIFT, size,
+-				     min_page_size, &vres->blocks, vres->flags);
++	err = xe_ttm_vram_buddy_alloc(mgr, (u64)place->fpfn << PAGE_SHIFT,
++				      (u64)lpfn << PAGE_SHIFT, size,
++				      min_page_size, &vres->blocks, vres->flags,
++				      tbo, &vres->used_visible_size);
+ 	if (err)
+ 		goto error_unlock;
+-
+-	if (lpfn <= mgr->visible_size >> PAGE_SHIFT) {
+-		vres->used_visible_size = size;
+-	} else {
+-		struct gpu_buddy_block *block;
+-
+-		list_for_each_entry(block, &vres->blocks, link) {
+-			u64 start = gpu_buddy_block_offset(block);
+-
+-			if (start < mgr->visible_size) {
+-				u64 end = start + gpu_buddy_block_size(mm, block);
+-
+-				vres->used_visible_size +=
+-					min(end, mgr->visible_size) - start;
+-			}
+-		}
+-	}
+-
+-	mgr->visible_avail -= vres->used_visible_size;
+-	list_for_each_entry(block, &vres->blocks, link)
+-		block->private = tbo;
+ 	mutex_unlock(&mgr->lock);
+ 
+ 	if (!(vres->base.placement & TTM_PL_FLAG_CONTIGUOUS) &&
+@@ -175,20 +188,27 @@ static int xe_ttm_vram_mgr_new(struct ttm_resource_manager *man,
+ 	return err;
+ }
+ 
++static void xe_ttm_vram_buddy_free(struct xe_ttm_vram_mgr *mgr,
++				   struct list_head *blocks,
++				   u64 used_visible)
++{
++	struct gpu_buddy_block *block;
++
++	list_for_each_entry(block, blocks, link)
++		block->private = NULL;
++	gpu_buddy_free_list(&mgr->mm, blocks, 0);
++	mgr->visible_avail += used_visible;
++}
++
+ static void xe_ttm_vram_mgr_del(struct ttm_resource_manager *man,
+ 				struct ttm_resource *res)
+ {
+ 	struct xe_ttm_vram_mgr_resource *vres =
+ 		to_xe_ttm_vram_mgr_resource(res);
+ 	struct xe_ttm_vram_mgr *mgr = to_xe_ttm_vram_mgr(man);
+-	struct gpu_buddy *mm = &mgr->mm;
+-	struct gpu_buddy_block *block;
+ 
+ 	mutex_lock(&mgr->lock);
+-	list_for_each_entry(block, &vres->blocks, link)
+-		block->private = NULL;
+-	gpu_buddy_free_list(mm, &vres->blocks, 0);
+-	mgr->visible_avail += vres->used_visible_size;
++	xe_ttm_vram_buddy_free(mgr, &vres->blocks, vres->used_visible_size);
+ 	mutex_unlock(&mgr->lock);
+ 
+ 	ttm_resource_fini(man, res);

--- a/backport/patches/features/eu-debug/0001-drm-xe-uapi-Expose-ban-reason-in-EXEC_QUEUE_GET_PROPERTY_BAN.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-uapi-Expose-ban-reason-in-EXEC_QUEUE_GET_PROPERTY_BAN.patch
@@ -1,0 +1,246 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Date: Sat, 29 Aug 2026 19:17:41 +0200
+Subject: drm/xe/uapi: Expose ban reason in EXEC_QUEUE_GET_PROPERTY_BAN
+
+Extend DRM_XE_EXEC_QUEUE_GET_PROPERTY_BAN to return a bitmask indicating
+the reason for the ban, rather than a simple boolean. This allows
+userspace to distinguish between different ban causes:
+
+- DRM_XE_EXEC_QUEUE_BAN_REASON_GPU_HANG (bit 0): exec queue was banned
+  due to a GPU hang or job timeout detected by the TDR.
+- DRM_XE_EXEC_QUEUE_BAN_REASON_PAGE_OFFLINE (bit 1): exec queue was
+  banned because a VRAM page backing its resources was taken offline.
+
+The ban_reason field is added to struct xe_exec_queue and set at the
+point where the ban is triggered:
+- In guc_exec_queue_timedout_job() for GPU hang.
+- In xe_ttm_vram_purge_page() for memory page offline, before calling
+  xe_exec_queue_kill() or xe_vm_kill().
+
+The reset_status op is updated to return u64 with the reason bitmask.
+When a queue is banned but no explicit reason was recorded (e.g., from a
+generic CAT error), it defaults to GPU_HANG for backward compatibility.
+A value of 0 means the exec queue is not banned.
+
+v3(Rodrigo):
+- Add doc in xe_drm.h
+
+Assisted-by: Copilot:claude-opus-4.6
+Acked-by: José Roberto de Souza <jose.souza@intel.com>
+Acked-by: Michal Mrozek <michal.mrozek@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(backported from [V21] drm/xe/uapi: Expose ban reason in EXEC_QUEUE_GET_PROPERTY_BAN)
+Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
+
+---
+ drivers/gpu/drm/xe/xe_exec_queue_types.h |  7 +++--
+ drivers/gpu/drm/xe/xe_execlist.c         |  4 +--
+ drivers/gpu/drm/xe/xe_guc_submit.c       | 36 ++++++++++++++++++++----
+ drivers/gpu/drm/xe/xe_ttm_vram_mgr.c     | 19 +++++++++++++
+ include/uapi/drm/xe_drm.h                | 18 +++++++++++-
+ 5 files changed, 74 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_exec_queue_types.h b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+index 95f75d61a647..836f88fc0faa 100644
+--- a/drivers/gpu/drm/xe/xe_exec_queue_types.h
++++ b/drivers/gpu/drm/xe/xe_exec_queue_types.h
+@@ -152,5 +152,8 @@ struct xe_exec_queue {
+ 	unsigned long eudebug_flags;
+ 
++	/** @ban_reason: Bitmask of ban reasons (DRM_XE_EXEC_QUEUE_BAN_REASON_*) */
++	atomic_t ban_reason;
++
+ 	union {
+ 		/** @multi_gt_list: list head for VM bind engines if multi-GT */
+ 		struct list_head multi_gt_list;
+@@ -325,10 +325,10 @@ struct xe_exec_queue_ops {
+ 	 * signalled when this function is called.
+ 	 */
+ 	void (*resume)(struct xe_exec_queue *q);
+-	/** @reset_status: check exec queue reset status */
+-	bool (*reset_status)(struct xe_exec_queue *q);
++	/** @reset_status: check exec queue ban status, returns ban reason bitmask */
++	u64 (*reset_status)(struct xe_exec_queue *q);
+ 	/** @active: check exec queue is active */
+ 	bool (*active)(struct xe_exec_queue *q);
+ };
+ 
+ #endif
+diff --git a/drivers/gpu/drm/xe/xe_execlist.c b/drivers/gpu/drm/xe/xe_execlist.c
+index 0d0db66c6ea2..a36db39dcda8 100644
+--- a/drivers/gpu/drm/xe/xe_execlist.c
++++ b/drivers/gpu/drm/xe/xe_execlist.c
+@@ -462,8 +462,8 @@ static void execlist_exec_queue_resume(struct xe_exec_queue *q)
+ 	/* NIY */
+ }
+ 
+-static bool execlist_exec_queue_reset_status(struct xe_exec_queue *q)
++static u64 execlist_exec_queue_reset_status(struct xe_exec_queue *q)
+ {
+ 	/* NIY */
+-	return false;
++	return 0;
+ }
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index 99d8c807ff05..0a6e2b81b5a5 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -6,6 +6,7 @@
+ #include "xe_guc_submit.h"
+ 
+ #include <linux/bitfield.h>
++#include <uapi/drm/xe_drm.h>
+ #include <linux/bitmap.h>
+ #include <linux/circ_buf.h>
+ #include <linux/dma-fence-array.h>
+@@ -1580,6 +1580,12 @@ guc_exec_queue_timedout_job(struct drm_sched_job *drm_job)
+ 	if (!exec_queue_killed(q))
+ 		wedged = guc_submit_hint_wedged(exec_queue_to_guc(q));
+ 
++	/*
++	 * Only tag as GPU hang if this is the original timeout, not a
++	 * consequence of a prior kill (e.g., page-offline).
++	 */
++	if (!exec_queue_killed(q))
++		atomic_or(DRM_XE_EXEC_QUEUE_BAN_REASON_GPU_HANG, &q->ban_reason);
+ 	set_exec_queue_banned(q);
+ 
+ 	/* Kick job / queue off hardware */
+@@ -1682,6 +1689,9 @@ guc_exec_queue_timedout_job(struct drm_sched_job *drm_job)
+ 		if (timeout_needs_gt_reset(q, job, skip_timeout_check)) {
+ 			if (!xe_sched_invalidate_job(job, 2)) {
+ 				clear_exec_queue_banned(q);
++				/* protect concurrent page offline reasons */
++				atomic_andnot(DRM_XE_EXEC_QUEUE_BAN_REASON_GPU_HANG,
++					      &q->ban_reason);
+ 				xe_gt_reset_async(q->gt);
+ 				goto rearm;
+ 			}
+@@ -2298,14 +2298,30 @@ static void guc_exec_queue_resume(struct xe_exec_queue *q)
+ 	xe_sched_msg_lock(sched);
+ 	guc_exec_queue_try_add_msg(q, msg, RESUME);
+ 	xe_sched_msg_unlock(sched);
+ }
+ 
+-static bool guc_exec_queue_reset_status(struct xe_exec_queue *q)
++static u64 guc_exec_queue_reset_status(struct xe_exec_queue *q)
+ {
+-	if (xe_exec_queue_is_multi_queue_secondary(q) &&
+-	    guc_exec_queue_reset_status(xe_exec_queue_multi_queue_primary(q)))
+-		return true;
++	/* TODO: In case of multiqueue, if a secondary queue is banned due to
++	 * page offlining, checking only the primary queue's GuC reset status
++	 * may mask the true reason or race with it.
++	 */
++	if (xe_exec_queue_is_multi_queue_secondary(q)) {
++		u64 status = guc_exec_queue_reset_status(xe_exec_queue_multi_queue_primary(q));
+ 
+-	return exec_queue_reset(q) || exec_queue_killed_or_banned_or_wedged(q);
++		if (status)
++			return status;
++	}
++
++	if (exec_queue_reset(q) || exec_queue_killed_or_banned_or_wedged(q)) {
++		u64 reason = atomic_read_acquire(&q->ban_reason);
++
++		/* If no specific reason was recorded, default to GPU hang */
++		if (!reason)
++			reason = DRM_XE_EXEC_QUEUE_BAN_REASON_GPU_HANG;
++		return reason;
++	}
++
++	return 0;
+ }
+ 
+ 
+diff --git a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+index af9e1fa868d7..8f583f1631bf 100644
+--- a/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
++++ b/drivers/gpu/drm/xe/xe_ttm_vram_mgr.c
+@@ -10,6 +10,7 @@
+ #include <drm/drm_managed.h>
+ #include <drm/drm_drv.h>
+ #include <drm/drm_buddy.h>
++#include <uapi/drm/xe_drm.h>
+ 
+ #include <drm/ttm/ttm_placement.h>
+ #include <drm/ttm/ttm_range_manager.h>
+@@ -582,6 +583,7 @@ u64 xe_ttm_vram_get_avail(struct ttm_resource_manager *man)
+ 
+ static int xe_ttm_vram_purge_page(struct xe_device *xe, struct xe_bo *bo)
+ {
++	u32	q_flag = DRM_XE_EXEC_QUEUE_BAN_REASON_PAGE_OFFLINE;
+ 	struct ttm_operation_ctx ctx = {};
+ 	struct xe_exec_queue *q_to_put = NULL;
+ 	struct xe_exec_queue *q = NULL;
+@@ -596,7 +598,22 @@ static int xe_ttm_vram_purge_page(struct xe_device *xe, struct xe_bo *bo)
+ 	xe_bo_unlock(bo);
+ 	/*  Ban VM if BO is PPGTT */
+ 	if (vm && (flags & XE_BO_FLAG_PAGETABLE)) {
++		struct xe_exec_queue *eq;
++		int id;
++
+ 		down_write(&vm->lock);
++		if (xe->info.has_ctx_tlb_inval) {
++			down_read(&vm->exec_queues.lock);
++			for (id = 0; id < ARRAY_SIZE(vm->exec_queues.list); id++)
++				list_for_each_entry(eq, &vm->exec_queues.list[id],
++						    vm_exec_queue_link)
++					atomic_or(q_flag, &eq->ban_reason);
++			up_read(&vm->exec_queues.lock);
++		} else {
++			list_for_each_entry(eq, &vm->preempt.exec_queues, lr.link)
++				atomic_or(q_flag, &eq->ban_reason);
++		}
++		smp_wmb(); /* Force all queue bits to be visible before killing the VM */
+ 		xe_vm_kill(vm, true);
+ 		up_write(&vm->lock);
+ 	}
+@@ -608,6 +625,8 @@ static int xe_ttm_vram_purge_page(struct xe_device *xe, struct xe_bo *bo)
+ 	/*  Ban exec queue if BO is lrc */
+ 	if (q && xe_exec_queue_get_unless_zero(q)) {
+ 		/* ban queue */
++		atomic_or(q_flag, &q->ban_reason);
++		smp_wmb(); /* Force bit change to finish before state change triggers */
+ 		q_to_put = q;
+ 	}
+ 
+diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
+index 509202a7b13e..ee4a921b2e6e 100644
+--- a/include/uapi/drm/xe_drm.h
++++ b/include/uapi/drm/xe_drm.h
+@@ -1491,6 +1491,12 @@ struct drm_xe_exec_queue_destroy {
+  *
+  * The @property can be:
+  *  - %DRM_XE_EXEC_QUEUE_GET_PROPERTY_BAN
++ *
++ * For %DRM_XE_EXEC_QUEUE_GET_PROPERTY_BAN, @value is a bitmask of ban reasons:
++ *  - %DRM_XE_EXEC_QUEUE_BAN_REASON_GPU_HANG - banned due to GPU hang/timeout
++ *  - %DRM_XE_EXEC_QUEUE_BAN_REASON_PAGE_OFFLINE - banned due to memory page offline
++ *
++ * A @value of 0 means the exec queue is not banned.
+  */
+ struct drm_xe_exec_queue_get_property {
+ 	/** @extensions: Pointer to the first extension struct, if any */
+@@ -1503,7 +1509,17 @@ struct drm_xe_exec_queue_get_property {
+ 	/** @property: property to get */
+ 	__u32 property;
+ 
+-	/** @value: property value */
++	/**
++	 * @value: property value
++	 *
++	 * For %DRM_XE_EXEC_QUEUE_GET_PROPERTY_BAN, this is a bitmask of:
++	 *  - %DRM_XE_EXEC_QUEUE_BAN_REASON_GPU_HANG - banned due to GPU hang/timeout
++	 *  - %DRM_XE_EXEC_QUEUE_BAN_REASON_PAGE_OFFLINE - banned due to memory page offline
++	 *
++	 * Value of 0 means the exec queue is not banned.
++	 */
++#define DRM_XE_EXEC_QUEUE_BAN_REASON_GPU_HANG		(1 << 0)
++#define DRM_XE_EXEC_QUEUE_BAN_REASON_PAGE_OFFLINE	(1 << 1)
+ 	__u64 value;
+ 
+ 	/** @reserved: Reserved */

--- a/series
+++ b/series
@@ -226,6 +226,19 @@ backport/patches/base/0001-drm-xe-vsec-Update-PMT-internal-access-for-CRI.patch
 backport/patches/base/0001-drm-xe-hwmon-Detect-unavailable-temperature-sensors.patch
 backport/patches/base/0001-drm-xe-hwmon-Use-VRAM-temperature-sensor-count-from-.patch
 backport/patches/base/0001-drm-xe-hwmon-Correct-group-selection-for-memory-cont.patch
+backport/patches/base/0001-drm-xe-Link-VRAM-object-with-gpu-buddy.patch
+backport/patches/base/0001-drm-xe-Link-LRC-BO-and-its-execution-Queue.patch
+backport/patches/base/0001-drm-xe-Extend-BO-purge-to-handle-vram-pages-as-well.patch
+backport/patches/base/0001-drm-xe-bo-Make-xe_bo_is_user-public.patch
+backport/patches/base/0001-drm-xe-Guard-teardown-paths-against-purged-BOs.patch
+backport/patches/base/0001-drm-xe-vram-Extract-buddy-alloc-and-free-helpers.patch
+backport/patches/base/0001-drm-xe-vram-Add-page-offline-data-structures-and-lifecycle.patch
+backport/patches/base/0001-drm-xe-vram-Add-VRAM-page-offline-fault-handler.patch
+backport/patches/base/0001-drm-xe-configfs-Add-bad_page_reservation-attribute.patch
+backport/patches/base/0001-drm-xe-ras-Cache-bad_page_reservation-policy-at-init.patch
+backport/patches/base/0001-drm-xe-vram-Check-bad_page_reservation-policy-in-fault-handler.patch
+backport/patches/base/0001-drm-xe-Expose-bad-VRAM-pages-via-debugfs.patch
+backport/patches/base/0001-drm-xe-Add-fault-inject-based-VRAM-page-offline-injection.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch
@@ -273,5 +286,6 @@ backport/patches/features/eu-debug/0001-fixup-drm-xe-eudebug-Introduce-EU-contro
 backport/patches/features/eu-debug/0001-fixup-drm-xe-eudebug-Introduce-per-device-attention-.patch
 backport/patches/features/eu-debug/0001-fixup-drm-xe-eudebug-Introduce-EU-pagefault-handling.patch
 backport/patches/features/eu-debug/0001-xe-prelim-eudebug-Avoid-taking-discovery-lock-on-tea.patch
+backport/patches/features/eu-debug/0001-drm-xe-uapi-Expose-ban-reason-in-EXEC_QUEUE_GET_PROPERTY_BAN.patch
 # oot
 backport/patches/oot/0001-drm-xe-pf-Handle-VF-BAR-resize-without-PCI-VF-REBAR-.patch


### PR DESCRIPTION
This functionality represents a significant step in making the xe driver gracefully handle hardware memory degradation. By integrating with the DRM Buddy allocator, the driver can permanently "carve out" faulty memory so it isn't reused by subsequent allocations.