### PR TITLE
backport RAS error threshold patches

### DIFF
--- a/backport/patches/base/0001-drm-ras-Cancel-and-free-message-on-get-counter-failure.patch
+++ b/backport/patches/base/0001-drm-ras-Cancel-and-free-message-on-get-counter-failure.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Tue, 18 Aug 2026 19:22:05 +0530
+Subject: drm/ras: Cancel and free message on get counter failure
+
+doit_reply_value() directly returns on get counter failure, which results
+in stale sk_buff and genetlink header that aren't cleaned up. Fix it and
+while at it, consolidate error handling using goto.
+
+Fixes: c36218dc49f5 ("drm/ras: Introduce the DRM RAS infrastructure over generic netlink")
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://patch.msgid.link/20260818135304.497098-2-raag.jadav@intel.com
+Acked-by: Maarten Lankhorst <maarten.lankhorst@linux.intel.com>
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 9cc19bb8f2f6886392b9185b96bbef91b2f1a50f linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/drm_ras.c | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_ras.c b/drivers/gpu/drm/drm_ras.c
+index 39155fb51..4fa1a257b 100644
+--- a/drivers/gpu/drm/drm_ras.c
++++ b/drivers/gpu/drm/drm_ras.c
+@@ -234,25 +234,28 @@ static int doit_reply_value(struct genl_info *info, u32 node_id,
+ 
+ 	hdr = genlmsg_iput(msg, info);
+ 	if (!hdr) {
+-		nlmsg_free(msg);
+-		return -EMSGSIZE;
++		ret = -EMSGSIZE;
++		goto free_msg;
+ 	}
+ 
+ 	ret = get_node_error_counter(node_id, error_id,
+ 				     &error_name, &value);
+ 	if (ret)
+-		return ret;
++		goto cancel_msg;
+ 
+ 	ret = msg_reply_value(msg, error_id, error_name, value);
+-	if (ret) {
+-		genlmsg_cancel(msg, hdr);
+-		nlmsg_free(msg);
+-		return ret;
+-	}
++	if (ret)
++		goto cancel_msg;
+ 
+ 	genlmsg_end(msg, hdr);
+ 
+ 	return genlmsg_reply(msg, info);
++
++cancel_msg:
++	genlmsg_cancel(msg, hdr);
++free_msg:
++	nlmsg_free(msg);
++	return ret;
+ }
+ 
+ /**

--- a/backport/patches/base/0001-drm-ras-Introduce-error-threshold.patch
+++ b/backport/patches/base/0001-drm-ras-Introduce-error-threshold.patch
@@ -1,0 +1,444 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Tue, 18 Aug 2026 19:22:06 +0530
+Subject: drm/ras: Introduce error threshold
+
+Add get-error-threshold and set-error-threshold command support which
+allows querying/setting error threshold of the counter. Threshold in RAS
+context means the number of errors the hardware is expected to accumulate
+before it raises them to software. This is to have a fine grained control
+over error notifications that are raised by the hardware.
+
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Acked-by: Joshua Santhosh Ranjan <joshua.santosh.ranjan@intel.com>
+Link: https://patch.msgid.link/20260818135304.497098-3-raag.jadav@intel.com
+Acked-by: Maarten Lankhorst <maarten.lankhorst@linux.intel.com>
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit b2207d4c4e84347a3a6b26b77e218cfc606d0109 linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ Documentation/gpu/drm-ras.rst            |  18 +++
+ Documentation/netlink/specs/drm_ras.yaml |  32 +++++
+ drivers/gpu/drm/drm_ras.c                | 158 +++++++++++++++++++++++
+ drivers/gpu/drm/drm_ras_nl.c             |  27 ++++
+ drivers/gpu/drm/drm_ras_nl.h             |   4 +
+ include/drm/drm_ras.h                    |  29 +++++
+ include/uapi/drm/drm_ras.h               |   3 +
+ 7 files changed, 271 insertions(+)
+
+diff --git a/Documentation/gpu/drm-ras.rst b/Documentation/gpu/drm-ras.rst
+index de07e9ae0..7a51ced2b 100644
+--- a/Documentation/gpu/drm-ras.rst
++++ b/Documentation/gpu/drm-ras.rst
+@@ -55,6 +55,10 @@ User space tools can:
+ * Clear specific error counters with the ``clear-error-counter`` command, using both
+   ``node-id`` and ``error-id`` as parameters.
+ * Subscribe to the ``error-report`` multicast group to receive ``error-event``.
++* Query specific error counter threshold with the ``get-error-threshold`` command, using both
++  ``node-id`` and ``error-id`` as parameters.
++* Set specific error counter threshold with the ``set-error-threshold`` command, using
++  ``node-id``, ``error-id`` and ``error-threshold`` as parameters.
+ 
+ YAML-based Interface
+ --------------------
+@@ -130,3 +134,17 @@ Example: Subscribe to ``error-report`` multicast group
+             "error-value": 1
+         }
+     }
++
++Example: Query error threshold of a given counter
++
++.. code-block:: bash
++
++    sudo ynl --family drm_ras --do get-error-threshold --json '{"node-id":0, "error-id":1}'
++    {'error-id': 1, 'error-name': 'error_name1', 'error-threshold': 16}
++
++Example: Set error threshold of a given counter
++
++.. code-block:: bash
++
++    sudo ynl --family drm_ras --do set-error-threshold --json '{"node-id":0, "error-id":1, "error-threshold":8}'
++    None
+diff --git a/Documentation/netlink/specs/drm_ras.yaml b/Documentation/netlink/specs/drm_ras.yaml
+index 8aed3d451..4c2ac9a1b 100644
+--- a/Documentation/netlink/specs/drm_ras.yaml
++++ b/Documentation/netlink/specs/drm_ras.yaml
+@@ -69,6 +69,10 @@ attribute-sets:
+         name: error-value
+         type: u32
+         doc: Current value of the requested error counter.
++      -
++        name: error-threshold
++        type: u32
++        doc: Error threshold of the counter.
+   -
+     name: error-event-attrs
+     attributes:
+@@ -167,6 +171,34 @@ operations:
+           - error-id
+           - error-name
+           - error-value
++    -
++      name: get-error-threshold
++      doc: >-
++           Retrieve error threshold of a given counter.
++           The response includes the id, the name, and current threshold
++           of the counter.
++      attribute-set: error-counter-attrs
++      flags: [admin-perm]
++      do:
++        request:
++          attributes: *id-attrs
++        reply:
++          attributes:
++            - error-id
++            - error-name
++            - error-threshold
++    -
++      name: set-error-threshold
++      doc: >-
++           Set error threshold of a given counter.
++      attribute-set: error-counter-attrs
++      flags: [admin-perm]
++      do:
++        request:
++          attributes:
++            - node-id
++            - error-id
++            - error-threshold
+ 
+ mcast-groups:
+   list:
+diff --git a/drivers/gpu/drm/drm_ras.c b/drivers/gpu/drm/drm_ras.c
+index 4fa1a257b..b099eb678 100644
+--- a/drivers/gpu/drm/drm_ras.c
++++ b/drivers/gpu/drm/drm_ras.c
+@@ -46,6 +46,13 @@
+  * 5. ERROR_EVENT: Report an error event to userspace. The event contains device, node
+  *    and error information that triggered the event.
+  *
++ * 6. GET_ERROR_THRESHOLD: Query error threshold of a given counter.
++ *    Userspace must provide Node ID and Error ID.
++ *    Returns the error threshold of a specific counter.
++ *
++ * 7. SET_ERROR_THRESHOLD: Set error threshold of a given counter.
++ *    Userspace must provide Node ID, Error ID and threshold to be set.
++ *
+  * Node registration:
+  *
+  * - drm_ras_node_register(): Registers a new node and assigns
+@@ -66,6 +73,13 @@
+  *     + The error counters in the driver doesn't need to be contiguous, but the
+  *       driver must return -ENOENT to the query_error_counter as an indication
+  *       that the ID should be skipped and not listed in the netlink API.
++ *     + The driver can optionally implement query_error_threshold() and
++ *       set_error_threshold() callbacks to facilitate getting/setting error
++ *       threshold of the counter. Threshold in RAS context means the number of
++ *       errors the hardware is expected to accumulate before it raises them to
++ *       software. This is to have a fine grained control over error notifications
++ *       that are raised by the hardware.
++ *     + The driver is responsible for error threshold bounds checking.
+  *
+  * Netlink handlers:
+  *
+@@ -77,6 +91,10 @@
+  *   operation, fetching a counter value from a specific node.
+  * - drm_ras_nl_clear_error_counter_doit(): Implements the CLEAR_ERROR_COUNTER doit
+  *   operation, clearing a counter value from a specific node.
++ * - drm_ras_nl_get_error_threshold_doit(): Implements the GET_ERROR_THRESHOLD doit
++ *   operation, fetching the error threshold of a specific counter.
++ * - drm_ras_nl_set_error_threshold_doit(): Implements the SET_ERROR_THRESHOLD doit
++ *   operation, setting the error threshold of a specific counter.
+  */
+ 
+ static DEFINE_XARRAY_ALLOC(drm_ras_xa);
+@@ -173,6 +191,40 @@ static int get_node_error_counter(u32 node_id, u32 error_id,
+ 	return node->query_error_counter(node, error_id, name, value);
+ }
+ 
++static int get_node_error_threshold(u32 node_id, u32 error_id, const char **name, u32 *threshold)
++{
++	struct drm_ras_node *node;
++
++	node = xa_load(&drm_ras_xa, node_id);
++	if (!node)
++		return -ENOENT;
++
++	if (!node->query_error_threshold)
++		return -EOPNOTSUPP;
++
++	if (error_id < node->error_counter_range.first || error_id > node->error_counter_range.last)
++		return -EINVAL;
++
++	return node->query_error_threshold(node, error_id, name, threshold);
++}
++
++static int set_node_error_threshold(u32 node_id, u32 error_id, u32 threshold)
++{
++	struct drm_ras_node *node;
++
++	node = xa_load(&drm_ras_xa, node_id);
++	if (!node)
++		return -ENOENT;
++
++	if (!node->set_error_threshold)
++		return -EOPNOTSUPP;
++
++	if (error_id < node->error_counter_range.first || error_id > node->error_counter_range.last)
++		return -EINVAL;
++
++	return node->set_error_threshold(node, error_id, threshold);
++}
++
+ static int msg_reply_value(struct sk_buff *msg, u32 error_id,
+ 			   const char *error_name, u32 value)
+ {
+@@ -219,6 +271,22 @@ static int msg_put_error_event_attrs(struct sk_buff *msg, struct drm_ras_node *n
+ 	return nla_put_u32(msg, DRM_RAS_A_ERROR_EVENT_ATTRS_ERROR_VALUE, value);
+ }
+ 
++static int msg_reply_threshold(struct sk_buff *msg, u32 error_id, const char *error_name,
++			       u32 threshold)
++{
++	int ret;
++
++	ret = nla_put_u32(msg, DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID, error_id);
++	if (ret)
++		return ret;
++
++	ret = nla_put_string(msg, DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_NAME, error_name);
++	if (ret)
++		return ret;
++
++	return nla_put_u32(msg, DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_THRESHOLD, threshold);
++}
++
+ static int doit_reply_value(struct genl_info *info, u32 node_id,
+ 			    u32 error_id)
+ {
+@@ -258,6 +326,43 @@ static int doit_reply_value(struct genl_info *info, u32 node_id,
+ 	return ret;
+ }
+ 
++static int doit_reply_threshold(struct genl_info *info, u32 node_id, u32 error_id)
++{
++	const char *error_name;
++	struct sk_buff *msg;
++	struct nlattr *hdr;
++	u32 threshold;
++	int ret;
++
++	msg = genlmsg_new(NLMSG_GOODSIZE, GFP_KERNEL);
++	if (!msg)
++		return -ENOMEM;
++
++	hdr = genlmsg_iput(msg, info);
++	if (!hdr) {
++		ret = -EMSGSIZE;
++		goto free_msg;
++	}
++
++	ret = get_node_error_threshold(node_id, error_id, &error_name, &threshold);
++	if (ret)
++		goto cancel_msg;
++
++	ret = msg_reply_threshold(msg, error_id, error_name, threshold);
++	if (ret)
++		goto cancel_msg;
++
++	genlmsg_end(msg, hdr);
++
++	return genlmsg_reply(msg, info);
++
++cancel_msg:
++	genlmsg_cancel(msg, hdr);
++free_msg:
++	nlmsg_free(msg);
++	return ret;
++}
++
+ /**
+  * drm_ras_nl_error_event() - Report an error event
+  * @node: Node structure
+@@ -459,6 +564,59 @@ int drm_ras_nl_clear_error_counter_doit(struct sk_buff *skb,
+ 	return node->clear_error_counter(node, error_id);
+ }
+ 
++/**
++ * drm_ras_nl_get_error_threshold_doit() - Query error threshold of a counter
++ * @skb: Netlink message buffer
++ * @info: Generic Netlink info containing attributes of the request
++ *
++ * Extracts the Node ID and Error ID from the netlink attributes and retrieves
++ * the error threshold of the corresponding counter. Sends the result back to
++ * the requesting user via the standard Genl reply.
++ *
++ * Return: 0 on success, or negative errno on failure.
++ */
++int drm_ras_nl_get_error_threshold_doit(struct sk_buff *skb, struct genl_info *info)
++{
++	u32 node_id, error_id;
++
++	if (!info->attrs ||
++	    GENL_REQ_ATTR_CHECK(info, DRM_RAS_A_ERROR_COUNTER_ATTRS_NODE_ID) ||
++	    GENL_REQ_ATTR_CHECK(info, DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID))
++		return -EINVAL;
++
++	node_id = nla_get_u32(info->attrs[DRM_RAS_A_ERROR_COUNTER_ATTRS_NODE_ID]);
++	error_id = nla_get_u32(info->attrs[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID]);
++
++	return doit_reply_threshold(info, node_id, error_id);
++}
++
++/**
++ * drm_ras_nl_set_error_threshold_doit() - Set error threshold of a counter
++ * @skb: Netlink message buffer
++ * @info: Generic Netlink info containing attributes of the request
++ *
++ * Extracts the Node ID, Error ID and threshold from the netlink attributes and
++ * sets the error threshold of the corresponding counter.
++ *
++ * Return: 0 on success, or negative errno on failure.
++ */
++int drm_ras_nl_set_error_threshold_doit(struct sk_buff *skb, struct genl_info *info)
++{
++	u32 node_id, error_id, threshold;
++
++	if (!info->attrs ||
++	    GENL_REQ_ATTR_CHECK(info, DRM_RAS_A_ERROR_COUNTER_ATTRS_NODE_ID) ||
++	    GENL_REQ_ATTR_CHECK(info, DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID) ||
++	    GENL_REQ_ATTR_CHECK(info, DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_THRESHOLD))
++		return -EINVAL;
++
++	node_id = nla_get_u32(info->attrs[DRM_RAS_A_ERROR_COUNTER_ATTRS_NODE_ID]);
++	error_id = nla_get_u32(info->attrs[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID]);
++	threshold = nla_get_u32(info->attrs[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_THRESHOLD]);
++
++	return set_node_error_threshold(node_id, error_id, threshold);
++}
++
+ /**
+  * drm_ras_node_register() - Register a new RAS node
+  * @node: Node structure to register
+diff --git a/drivers/gpu/drm/drm_ras_nl.c b/drivers/gpu/drm/drm_ras_nl.c
+index 9d3123cc9..c9f5e0ceb 100644
+--- a/drivers/gpu/drm/drm_ras_nl.c
++++ b/drivers/gpu/drm/drm_ras_nl.c
+@@ -28,6 +28,19 @@ static const struct nla_policy drm_ras_clear_error_counter_nl_policy[DRM_RAS_A_E
+ 	[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID] = { .type = NLA_U32, },
+ };
+ 
++/* DRM_RAS_CMD_GET_ERROR_THRESHOLD - do */
++static const struct nla_policy drm_ras_get_error_threshold_nl_policy[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID + 1] = {
++	[DRM_RAS_A_ERROR_COUNTER_ATTRS_NODE_ID] = { .type = NLA_U32, },
++	[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID] = { .type = NLA_U32, },
++};
++
++/* DRM_RAS_CMD_SET_ERROR_THRESHOLD - do */
++static const struct nla_policy drm_ras_set_error_threshold_nl_policy[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_THRESHOLD + 1] = {
++	[DRM_RAS_A_ERROR_COUNTER_ATTRS_NODE_ID] = { .type = NLA_U32, },
++	[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID] = { .type = NLA_U32, },
++	[DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_THRESHOLD] = { .type = NLA_U32, },
++};
++
+ /* Ops table for drm_ras */
+ static const struct genl_split_ops drm_ras_nl_ops[] = {
+ 	{
+@@ -56,6 +69,20 @@ static const struct genl_split_ops drm_ras_nl_ops[] = {
+ 		.maxattr	= DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID,
+ 		.flags		= GENL_ADMIN_PERM | GENL_CMD_CAP_DO,
+ 	},
++	{
++		.cmd		= DRM_RAS_CMD_GET_ERROR_THRESHOLD,
++		.doit		= drm_ras_nl_get_error_threshold_doit,
++		.policy		= drm_ras_get_error_threshold_nl_policy,
++		.maxattr	= DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID,
++		.flags		= GENL_ADMIN_PERM | GENL_CMD_CAP_DO,
++	},
++	{
++		.cmd		= DRM_RAS_CMD_SET_ERROR_THRESHOLD,
++		.doit		= drm_ras_nl_set_error_threshold_doit,
++		.policy		= drm_ras_set_error_threshold_nl_policy,
++		.maxattr	= DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_THRESHOLD,
++		.flags		= GENL_ADMIN_PERM | GENL_CMD_CAP_DO,
++	},
+ };
+ 
+ static const struct genl_multicast_group drm_ras_nl_mcgrps[] = {
+diff --git a/drivers/gpu/drm/drm_ras_nl.h b/drivers/gpu/drm/drm_ras_nl.h
+index 03ec275ac..9aef097ea 100644
+--- a/drivers/gpu/drm/drm_ras_nl.h
++++ b/drivers/gpu/drm/drm_ras_nl.h
+@@ -20,6 +20,10 @@ int drm_ras_nl_get_error_counter_dumpit(struct sk_buff *skb,
+ 					struct netlink_callback *cb);
+ int drm_ras_nl_clear_error_counter_doit(struct sk_buff *skb,
+ 					struct genl_info *info);
++int drm_ras_nl_get_error_threshold_doit(struct sk_buff *skb,
++					struct genl_info *info);
++int drm_ras_nl_set_error_threshold_doit(struct sk_buff *skb,
++					struct genl_info *info);
+ 
+ enum {
+ 	DRM_RAS_NLGRP_ERROR_REPORT,
+diff --git a/include/drm/drm_ras.h b/include/drm/drm_ras.h
+index ed8175f62..aa9a9e93d 100644
+--- a/include/drm/drm_ras.h
++++ b/include/drm/drm_ras.h
+@@ -69,6 +69,35 @@ struct drm_ras_node {
+ 	 */
+ 	int (*clear_error_counter)(struct drm_ras_node *node, u32 error_id);
+ 
++	/**
++	 * @query_error_threshold:
++	 *
++	 * This callback is used by drm-ras to query error threshold of a
++	 * specific counter.
++	 *
++	 * Driver should expect query_error_threshold() to be called with
++	 * error_id from `error_counter_range.first` to
++	 * `error_counter_range.last`.
++	 *
++	 * Returns: 0 on success, negative error code on failure.
++	 */
++	int (*query_error_threshold)(struct drm_ras_node *node, u32 error_id, const char **name,
++				     u32 *threshold);
++
++	/**
++	 * @set_error_threshold:
++	 *
++	 * This callback is used by drm-ras to set error threshold of a specific
++	 * counter.
++	 *
++	 * Driver should expect set_error_threshold() to be called with error_id
++	 * from `error_counter_range.first` to `error_counter_range.last`.
++	 * Driver is responsible for error threshold bounds checking.
++	 *
++	 * Returns: 0 on success, negative error code on failure.
++	 */
++	int (*set_error_threshold)(struct drm_ras_node *node, u32 error_id, u32 threshold);
++
+ 	/** @priv: Driver private data */
+ 	void *priv;
+ };
+diff --git a/include/uapi/drm/drm_ras.h b/include/uapi/drm/drm_ras.h
+index eab8231aa..2f832275e 100644
+--- a/include/uapi/drm/drm_ras.h
++++ b/include/uapi/drm/drm_ras.h
+@@ -33,6 +33,7 @@ enum {
+ 	DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_ID,
+ 	DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_NAME,
+ 	DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_VALUE,
++	DRM_RAS_A_ERROR_COUNTER_ATTRS_ERROR_THRESHOLD,
+ 
+ 	__DRM_RAS_A_ERROR_COUNTER_ATTRS_MAX,
+ 	DRM_RAS_A_ERROR_COUNTER_ATTRS_MAX = (__DRM_RAS_A_ERROR_COUNTER_ATTRS_MAX - 1)
+@@ -55,6 +56,8 @@ enum {
+ 	DRM_RAS_CMD_GET_ERROR_COUNTER,
+ 	DRM_RAS_CMD_CLEAR_ERROR_COUNTER,
+ 	DRM_RAS_CMD_ERROR_EVENT,
++	DRM_RAS_CMD_GET_ERROR_THRESHOLD,
++	DRM_RAS_CMD_SET_ERROR_THRESHOLD,
+ 
+ 	__DRM_RAS_CMD_MAX,
+ 	DRM_RAS_CMD_MAX = (__DRM_RAS_CMD_MAX - 1)

--- a/backport/patches/base/0001-drm-xe-drm_ras-Move-has_drm_ras-check-to-drm_ras-layer.patch
+++ b/backport/patches/base/0001-drm-xe-drm_ras-Move-has_drm_ras-check-to-drm_ras-layer.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Mon, 10 Aug 2026 18:11:01 +0530
+Subject: drm/xe/drm_ras: Move has_drm_ras check to drm_ras layer
+
+has_drm_ras flag is meant to facilitate drm_ras feature. Move it to the
+correct layer where it belongs.
+
+Fixes: 63dfab5786ca ("drm/xe/xe_ras: Add drm_ras feature flag")
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://patch.msgid.link/20260810124101.105832-1-raag.jadav@intel.com
+Signed-off-by: Matt Roper <matthew.d.roper@intel.com>
+(backported from commit f3c0140332fdb8f343a384570f01b879794ddae8 linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_drm_ras.c | 3 +++
+ drivers/gpu/drm/xe/xe_ras.c     | 3 ---
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_drm_ras.c b/drivers/gpu/drm/xe/xe_drm_ras.c
+index 8b6be1da7..7f3695707 100644
+--- a/drivers/gpu/drm/xe/xe_drm_ras.c
++++ b/drivers/gpu/drm/xe/xe_drm_ras.c
+@@ -264,6 +264,9 @@ int xe_drm_ras_init(struct xe_device *xe)
+ 	struct drm_ras_node *node;
+ 	int err;
+ 
++	if (!xe->info.has_drm_ras)
++		return 0;
++
+ 	node = drmm_kcalloc(&xe->drm, DRM_XE_RAS_ERR_SEV_MAX, sizeof(*node), GFP_KERNEL);
+ 	if (!node)
+ 		return -ENOMEM;
+diff --git a/drivers/gpu/drm/xe/xe_ras.c b/drivers/gpu/drm/xe/xe_ras.c
+index 8c2aa14d2..543a0fde1 100644
+--- a/drivers/gpu/drm/xe/xe_ras.c
++++ b/drivers/gpu/drm/xe/xe_ras.c
+@@ -905,9 +905,6 @@ void xe_ras_init(struct xe_device *xe)
+ {
+ 	int ret;
+ 
+-	if (!xe->info.has_drm_ras)
+-		return;
+-
+ 	xe_drm_ras_init(xe);
+ 
+ 	if (!xe->info.has_sysctrl)
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-drm_ras-Wire-up-error-threshold-callbacks.patch
+++ b/backport/patches/base/0001-drm-xe-drm_ras-Wire-up-error-threshold-callbacks.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Tue, 18 Aug 2026 19:22:08 +0530
+Subject: drm/xe/drm_ras: Wire up error threshold callbacks
+
+Now that we have get/set error threshold support in xe driver, wire them
+up to drm_ras so that userspace can make use of the functionality.
+
+$ sudo ynl --family drm_ras --do get-error-threshold \
+--json '{"node-id":0, "error-id":2}'
+{'error-id': 2, 'error-name': 'soc-internal', 'error-threshold': 16}
+
+$ sudo ynl --family drm_ras --do set-error-threshold \
+--json '{"node-id":0, "error-id":2, "error-threshold":8}'
+None
+
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://patch.msgid.link/20260818135304.497098-5-raag.jadav@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 1b2a3db0049b4512737abd98d11e4abcc9be079c linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_drm_ras.c | 34 +++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_drm_ras.c b/drivers/gpu/drm/xe/xe_drm_ras.c
+index bf1b921f4..8b6be1da7 100644
+--- a/drivers/gpu/drm/xe/xe_drm_ras.c
++++ b/drivers/gpu/drm/xe/xe_drm_ras.c
+@@ -86,6 +86,38 @@ static int clear_correctable_error_counter(struct drm_ras_node *node, u32 error_
+ 	return clear_error_counter(xe, DRM_XE_RAS_ERR_SEV_CORRECTABLE, error_id);
+ }
+ 
++static int query_correctable_error_threshold(struct drm_ras_node *ep, u32 error_id,
++					     const char **name, u32 *threshold)
++{
++	struct xe_device *xe = ep->priv;
++	struct xe_drm_ras *ras = &xe->ras;
++	struct xe_drm_ras_counter *info = ras->info[DRM_XE_RAS_ERR_SEV_CORRECTABLE];
++
++	if (!info || !info[error_id].name)
++		return -ENOENT;
++
++	if (!xe->info.has_sysctrl)
++		return -EOPNOTSUPP;
++
++	*name = info[error_id].name;
++	return xe_ras_get_threshold(xe, DRM_XE_RAS_ERR_SEV_CORRECTABLE, error_id, threshold);
++}
++
++static int set_correctable_error_threshold(struct drm_ras_node *ep, u32 error_id, u32 threshold)
++{
++	struct xe_device *xe = ep->priv;
++	struct xe_drm_ras *ras = &xe->ras;
++	struct xe_drm_ras_counter *info = ras->info[DRM_XE_RAS_ERR_SEV_CORRECTABLE];
++
++	if (!info || !info[error_id].name)
++		return -ENOENT;
++
++	if (!xe->info.has_sysctrl)
++		return -EOPNOTSUPP;
++
++	return xe_ras_set_threshold(xe, DRM_XE_RAS_ERR_SEV_CORRECTABLE, error_id, threshold);
++}
++
+ static struct xe_drm_ras_counter *allocate_and_copy_counters(struct xe_device *xe)
+ {
+ 	struct xe_drm_ras_counter *counter;
+@@ -134,6 +166,8 @@ static int assign_node_params(struct xe_device *xe, struct drm_ras_node *node,
+ 	if (severity == DRM_XE_RAS_ERR_SEV_CORRECTABLE) {
+ 		node->query_error_counter = query_correctable_error_counter;
+ 		node->clear_error_counter = clear_correctable_error_counter;
++		node->query_error_threshold = query_correctable_error_threshold;
++		node->set_error_threshold = set_correctable_error_threshold;
+ 	} else {
+ 		node->query_error_counter = query_uncorrectable_error_counter;
+ 		node->clear_error_counter = clear_uncorrectable_error_counter;

--- a/backport/patches/base/0001-drm-xe-ras-Add-support-for-error-threshold.patch
+++ b/backport/patches/base/0001-drm-xe-ras-Add-support-for-error-threshold.patch
@@ -1,0 +1,243 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Tue, 18 Aug 2026 19:22:07 +0530
+Subject: drm/xe/ras: Add support for error threshold
+
+System controller allows getting/setting per counter threshold for
+correctable errors, which it uses to raise error events to the driver.
+Get/set it using the respective mailbox command.
+
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://patch.msgid.link/20260818135304.497098-4-raag.jadav@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 5a2b1a5fb42946ad04cdb5fdd764588f2e2e13dd linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_ras.c                   | 104 ++++++++++++++++++
+ drivers/gpu/drm/xe/xe_ras.h                   |   2 +
+ drivers/gpu/drm/xe/xe_ras_types.h             |  50 +++++++++
+ drivers/gpu/drm/xe/xe_sysctrl_mailbox_types.h |   4 +
+ 4 files changed, 160 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_ras.c b/drivers/gpu/drm/xe/xe_ras.c
+index 0e73e770c..0e3de8c87 100644
+--- a/drivers/gpu/drm/xe/xe_ras.c
++++ b/drivers/gpu/drm/xe/xe_ras.c
+@@ -200,6 +200,24 @@ static inline const char *comp_to_str(u8 component)
+ 	return xe_ras_components[component];
+ }
+ 
++static bool ras_counter_is_valid(struct xe_device *xe, struct xe_ras_error_class *counter)
++{
++	u8 severity = counter->common.severity;
++	u8 component = counter->common.component;
++
++	if (!in_range(severity, XE_RAS_SEV_NOT_SUPPORTED + 1, XE_RAS_SEV_MAX - 1)) {
++		xe_err(xe, "sysctrl: unexpected severity %u\n", severity);
++		return false;
++	}
++
++	if (!in_range(component, XE_RAS_COMP_NOT_SUPPORTED + 1, XE_RAS_COMP_MAX - 1)) {
++		xe_err(xe, "sysctrl: unexpected component %u\n", component);
++		return false;
++	}
++
++	return true;
++}
++
+ static struct pci_dev *find_usp_dev(struct pci_dev *pdev)
+ {
+ 	struct pci_dev *vsp;
+@@ -632,6 +650,92 @@ int xe_ras_clear_counter(struct xe_device *xe, u8 severity, u8 component)
+ 	return 0;
+ }
+ 
++int xe_ras_get_threshold(struct xe_device *xe, u8 severity, u8 component, u32 *threshold)
++{
++	struct xe_ras_get_threshold_response response = {};
++	struct xe_ras_get_threshold_request request = {};
++	struct xe_sysctrl_mailbox_command command = {};
++	struct xe_ras_error_class *counter;
++	size_t len;
++	int ret;
++
++	counter = &request.counter;
++	counter->common.severity = drm_to_xe_ras_severity(severity);
++	counter->common.component = drm_to_xe_ras_component(component);
++
++	xe_sysctrl_create_command(&command, XE_SYSCTRL_GROUP_GFSP, XE_SYSCTRL_CMD_GET_THRESHOLD,
++				  &request, sizeof(request), &response, sizeof(response));
++
++	guard(xe_pm_runtime)(xe);
++	ret = xe_sysctrl_send_command(&xe->sc, &command, &len);
++	if (ret) {
++		xe_err(xe, "sysctrl: failed to get threshold %d\n", ret);
++		return ret;
++	}
++
++	if (len != sizeof(response)) {
++		xe_err(xe, "sysctrl: unexpected get threshold response length %zu (expected %zu)\n",
++		       len, sizeof(response));
++		return -EIO;
++	}
++
++	if (!ras_counter_is_valid(xe, &response.counter))
++		return -EBADMSG;
++
++	counter = &response.counter;
++	*threshold = response.threshold;
++
++	xe_dbg(xe, "[RAS]: get threshold %u for %s %s\n", *threshold,
++	       comp_to_str(counter->common.component), sev_to_str(counter->common.severity));
++	return 0;
++}
++
++int xe_ras_set_threshold(struct xe_device *xe, u8 severity, u8 component, u32 threshold)
++{
++	struct xe_ras_set_threshold_response response = {};
++	struct xe_ras_set_threshold_request request = {};
++	struct xe_sysctrl_mailbox_command command = {};
++	struct xe_ras_error_class *counter;
++	size_t len;
++	int ret;
++
++	counter = &request.counter;
++	counter->common.severity = drm_to_xe_ras_severity(severity);
++	counter->common.component = drm_to_xe_ras_component(component);
++	request.threshold = threshold;
++
++	xe_sysctrl_create_command(&command, XE_SYSCTRL_GROUP_GFSP, XE_SYSCTRL_CMD_SET_THRESHOLD,
++				  &request, sizeof(request), &response, sizeof(response));
++
++	guard(xe_pm_runtime)(xe);
++	ret = xe_sysctrl_send_command(&xe->sc, &command, &len);
++	if (ret) {
++		xe_err(xe, "sysctrl: failed to set threshold %d\n", ret);
++		return ret;
++	}
++
++	if (len != sizeof(response)) {
++		xe_err(xe, "sysctrl: unexpected set threshold response length %zu (expected %zu)\n",
++		       len, sizeof(response));
++		return -EIO;
++	}
++
++	ret = ras_status_to_errno(response.status);
++	if (ret) {
++		xe_err(xe, "sysctrl: set threshold command failed with status %#x\n",
++		       response.status);
++		return ret;
++	}
++
++	counter = &response.counter;
++	if (!ras_counter_is_valid(xe, counter))
++		return -EBADMSG;
++
++	xe_dbg(xe, "[RAS]: set threshold %u for %s %s\n", response.threshold,
++	       comp_to_str(counter->common.component), sev_to_str(counter->common.severity));
++	return 0;
++}
++
+ static ssize_t gpu_health_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+ 	struct xe_ras_get_health_response response = {0};
+diff --git a/drivers/gpu/drm/xe/xe_ras.h b/drivers/gpu/drm/xe/xe_ras.h
+index 618364734..0b8669f28 100644
+--- a/drivers/gpu/drm/xe/xe_ras.h
++++ b/drivers/gpu/drm/xe/xe_ras.h
+@@ -16,6 +16,8 @@ void xe_ras_counter_threshold_crossed(struct xe_device *xe,
+ 				      struct xe_sysctrl_event_response *response);
+ int xe_ras_get_counter(struct xe_device *xe, u8 severity, u8 component, u32 *value);
+ int xe_ras_clear_counter(struct xe_device *xe, u8 severity, u8 component);
++int xe_ras_get_threshold(struct xe_device *xe, u8 severity, u8 component, u32 *threshold);
++int xe_ras_set_threshold(struct xe_device *xe, u8 severity, u8 component, u32 threshold);
+ void xe_ras_init(struct xe_device *xe);
+ enum xe_ras_recovery_action xe_ras_process_errors(struct xe_device *xe);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_ras_types.h b/drivers/gpu/drm/xe/xe_ras_types.h
+index 8acc975aa..99b4ae3ac 100644
+--- a/drivers/gpu/drm/xe/xe_ras_types.h
++++ b/drivers/gpu/drm/xe/xe_ras_types.h
+@@ -147,6 +147,56 @@ struct xe_ras_clear_counter_response {
+ 	u32 reserved1[3];
+ } __packed;
+ 
++/**
++ * struct xe_ras_get_threshold_request - Request structure for get threshold
++ */
++struct xe_ras_get_threshold_request {
++	/** @counter: Counter to get threshold for */
++	struct xe_ras_error_class counter;
++	/** @reserved: Reserved for future use */
++	u32 reserved;
++} __packed;
++
++/**
++ * struct xe_ras_get_threshold_response - Response structure for get threshold
++ */
++struct xe_ras_get_threshold_response {
++	/** @counter: Counter ID */
++	struct xe_ras_error_class counter;
++	/** @threshold: Current threshold of the counter */
++	u32 threshold;
++	/** @reserved: Reserved for future use */
++	u32 reserved[4];
++} __packed;
++
++/**
++ * struct xe_ras_set_threshold_request - Request structure for set threshold
++ */
++struct xe_ras_set_threshold_request {
++	/** @counter: Counter to set threshold for */
++	struct xe_ras_error_class counter;
++	/** @threshold: Threshold to be set */
++	u32 threshold;
++	/** @reserved: Reserved for future use */
++	u32 reserved;
++} __packed;
++
++/**
++ * struct xe_ras_set_threshold_response - Response structure for set threshold
++ */
++struct xe_ras_set_threshold_response {
++	/** @counter: Counter ID */
++	struct xe_ras_error_class counter;
++	/** @reserved: Reserved */
++	u32 reserved;
++	/** @threshold: Updated threshold */
++	u32 threshold;
++	/** @status: Operation status */
++	u32 status;
++	/** @reserved1: Reserved for future use */
++	u32 reserved1[2];
++} __packed;
++
+ /**
+  * struct xe_ras_error_array - Details of the error types
+  */
+diff --git a/drivers/gpu/drm/xe/xe_sysctrl_mailbox_types.h b/drivers/gpu/drm/xe/xe_sysctrl_mailbox_types.h
+index d0341538a..66e7cbcc3 100644
+--- a/drivers/gpu/drm/xe/xe_sysctrl_mailbox_types.h
++++ b/drivers/gpu/drm/xe/xe_sysctrl_mailbox_types.h
+@@ -25,6 +25,8 @@ enum xe_sysctrl_group {
+  * @XE_SYSCTRL_CMD_GET_SOC_ERROR: Retrieve basic error information
+  * @XE_SYSCTRL_CMD_GET_COUNTER: Get error counter value
+  * @XE_SYSCTRL_CMD_CLEAR_COUNTER: Clear error counter value
++ * @XE_SYSCTRL_CMD_GET_THRESHOLD: Retrieve error threshold
++ * @XE_SYSCTRL_CMD_SET_THRESHOLD: Set error threshold
+  * @XE_SYSCTRL_CMD_GET_PENDING_EVENT: Retrieve pending event
+  * @XE_SYSCTRL_CMD_GET_HEALTH: Retrieve gpu health
+  * @XE_SYSCTRL_CMD_SET_HEALTH: Set gpu health
+@@ -33,6 +35,8 @@ enum xe_sysctrl_gfsp_cmd {
+ 	XE_SYSCTRL_CMD_GET_SOC_ERROR		= 0x01,
+ 	XE_SYSCTRL_CMD_GET_COUNTER		= 0x03,
+ 	XE_SYSCTRL_CMD_CLEAR_COUNTER		= 0x04,
++	XE_SYSCTRL_CMD_GET_THRESHOLD		= 0x05,
++	XE_SYSCTRL_CMD_SET_THRESHOLD		= 0x06,
+ 	XE_SYSCTRL_CMD_GET_PENDING_EVENT	= 0x07,
+ 	XE_SYSCTRL_CMD_GET_HEALTH		= 0x0B,
+ 	XE_SYSCTRL_CMD_SET_HEALTH		= 0x0C,
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-ras-Fix-boot-time-ras-error-processing.patch
+++ b/backport/patches/base/0001-drm-xe-ras-Fix-boot-time-ras-error-processing.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Thu, 30 Jul 2026 16:36:34 +0530
+Subject: drm/xe/ras: Fix boot-time ras error processing
+
+Currently, we xe_ras_process_errors() inside xe_ras_init() to handle boot
+time errors. But this can potentially result in declaring the device as
+wedged quite early in the driver load sequence, which is problematic due to
+the lack of registered drm device or required wedged cleanup hooks at this
+point.
+
+Call xe_ras_process_errors() only after the prerequisites are available.
+
+Fixes: d9732e498f5f ("drm/xe/xe_ras: Query errors from system controller on probe")
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Tested-by: Mallesh Koujalagi <mallesh.koujalagi@intel.com>
+Link: https://patch.msgid.link/20260730110635.925537-1-raag.jadav@intel.com
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+(backported from commit 3799dc5d778552e20bc5894d80df54b30fe764c8 linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.c | 7 +++++++
+ drivers/gpu/drm/xe/xe_ras.c    | 6 ------
+ 2 files changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.c b/drivers/gpu/drm/xe/xe_device.c
+index b072acd91..64385ef34 100644
+--- a/drivers/gpu/drm/xe/xe_device.c
++++ b/drivers/gpu/drm/xe/xe_device.c
+@@ -1083,6 +1083,13 @@ int xe_device_probe(struct xe_device *xe)
+ 	if (err)
+ 		goto err_unregister_display;
+ 
++	/*
++	 * Process and log any errors detected by hardware. Possible results can
++	 * include declaring the device as wedged, which must be done only after
++	 * xe_device_wedged_fini() is registered.
++	 */
++	xe_ras_process_errors(xe);
++
+ 	err = devm_add_action_or_reset(xe->drm.dev, xe_device_sanitize, xe);
+ 	if (err)
+ 		goto err_unregister_display;
+diff --git a/drivers/gpu/drm/xe/xe_ras.c b/drivers/gpu/drm/xe/xe_ras.c
+index c96e77f83..8c2aa14d2 100644
+--- a/drivers/gpu/drm/xe/xe_ras.c
++++ b/drivers/gpu/drm/xe/xe_ras.c
+@@ -916,12 +916,6 @@ void xe_ras_init(struct xe_device *xe)
+ 	if (IS_ENABLED(CONFIG_PCIEAER))
+ 		ras_usp_aer_init(xe);
+ 
+-	/*
+-	 * During probe, process and log any errors detected by firmware while the driver was not
+-	 * loaded. Critical errors such as Punit and CSC are reported through Pcode init failure,
+-	 * causing the driver to enter survivability mode.
+-	 */
+-	xe_ras_process_errors(xe);
+ 	ret = devm_device_add_group(xe->drm.dev, &gpu_health_group);
+ 	if (ret)
+ 		xe_err(xe, "Failed to create GPU health sysfs, err=%d\n", ret);
+-- 
+2.34.1
+

--- a/backport/patches/base/0001-drm-xe-sysctrl-Reuse-xe_sysctrl_create_command.patch
+++ b/backport/patches/base/0001-drm-xe-sysctrl-Reuse-xe_sysctrl_create_command.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raag Jadav <raag.jadav@intel.com>
+Date: Tue, 18 Aug 2026 19:22:09 +0530
+Subject: drm/xe/sysctrl: Reuse xe_sysctrl_create_command()
+
+Now that we have a helper to create sysctrl command, reuse it for
+threshold crossed events.
+
+Signed-off-by: Raag Jadav <raag.jadav@intel.com>
+Reviewed-by: Riana Tauro <riana.tauro@intel.com>
+Link: https://patch.msgid.link/20260818135304.497098-6-raag.jadav@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 4686fcca694c00fd73eee0f453f32b197baccf9b linux-next)
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_sysctrl_event.c | 28 ++++++++-------------------
+ 1 file changed, 8 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_sysctrl_event.c b/drivers/gpu/drm/xe/xe_sysctrl_event.c
+index da395148e..15ddd2d8b 100644
+--- a/drivers/gpu/drm/xe/xe_sysctrl_event.c
++++ b/drivers/gpu/drm/xe/xe_sysctrl_event.c
+@@ -49,18 +49,6 @@ static void get_pending_event(struct xe_sysctrl *sc, struct xe_sysctrl_mailbox_c
+ 	} while (response->count);
+ }
+ 
+-static void event_request_prepare(struct xe_device *xe, struct xe_sysctrl_app_msg_hdr *header,
+-				  struct xe_sysctrl_event_request *request)
+-{
+-	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
+-
+-	header->data = REG_FIELD_PREP(APP_HDR_GROUP_ID_MASK, XE_SYSCTRL_GROUP_GFSP) |
+-		       REG_FIELD_PREP(APP_HDR_COMMAND_MASK, XE_SYSCTRL_CMD_GET_PENDING_EVENT);
+-
+-	request->vector = xe_device_has_msix(xe) ? XE_IRQ_DEFAULT_MSIX : 0;
+-	request->fn = PCI_FUNC(pdev->devfn);
+-}
+-
+ /**
+  * xe_sysctrl_event() - Handler for System Controller events
+  * @sc: System Controller instance
+@@ -72,16 +60,16 @@ void xe_sysctrl_event(struct xe_sysctrl *sc)
+ 	struct xe_sysctrl_mailbox_command command = {};
+ 	struct xe_sysctrl_event_response response = {};
+ 	struct xe_sysctrl_event_request request = {};
+-	struct xe_sysctrl_app_msg_hdr header = {};
++	struct xe_device *xe = sc_to_xe(sc);
++	struct pci_dev *pdev = to_pci_dev(xe->drm.dev);
++
++	xe_device_assert_mem_access(xe);
+ 
+-	xe_device_assert_mem_access(sc_to_xe(sc));
+-	event_request_prepare(sc_to_xe(sc), &header, &request);
++	request.vector = xe_device_has_msix(xe) ? XE_IRQ_DEFAULT_MSIX : 0;
++	request.fn = PCI_FUNC(pdev->devfn);
+ 
+-	command.header = header;
+-	command.data_in = &request;
+-	command.data_in_len = sizeof(request);
+-	command.data_out = &response;
+-	command.data_out_len = sizeof(response);
++	xe_sysctrl_create_command(&command, XE_SYSCTRL_GROUP_GFSP, XE_SYSCTRL_CMD_GET_PENDING_EVENT,
++				  &request, sizeof(request), &response, sizeof(response));
+ 
+ 	guard(mutex)(&sc->event_lock);
+ 	get_pending_event(sc, &command);

--- a/series
+++ b/series
@@ -215,6 +215,13 @@ backport/patches/base/0001-platform-x86-intel-pmc-ssram-Add-ACPI-discovery-scaf.
 backport/patches/base/0001-platform-x86-intel-pmc-ssram-Make-PMT-registration-o.patch
 backport/patches/base/0001-drm-xe-i2c-Fix-the-interrupt-handling.patch
 backport/patches/base/0001-drm-xe-i2c-Keep-the-i2c-controller-always-enabled.patch
+backport/patches/base/0001-drm-ras-Cancel-and-free-message-on-get-counter-failure.patch
+backport/patches/base/0001-drm-ras-Introduce-error-threshold.patch
+backport/patches/base/0001-drm-xe-ras-Add-support-for-error-threshold.patch
+backport/patches/base/0001-drm-xe-drm_ras-Wire-up-error-threshold-callbacks.patch
+backport/patches/base/0001-drm-xe-sysctrl-Reuse-xe_sysctrl_create_command.patch
+backport/patches/base/0001-drm-xe-ras-Fix-boot-time-ras-error-processing.patch
+backport/patches/base/0001-drm-xe-drm_ras-Move-has_drm_ras-check-to-drm_ras-layer.patch
 backport/patches/base/0001-platform-x86-intel-pmt-complete-pcidev-to-device-upd.patch
 backport/patches/base/0001-platform-x86-intel-pmt-Add-register-access-callbacks.patch
 backport/patches/base/0001-drm-xe-vsec-Protect-against-missing-config.patch


### PR DESCRIPTION
Backport patches from drm-tip for DRM RAS error threshold
support, including Generic Netlink get/set threshold operations, xe
system-controller mailbox handling, DRM RAS callback registration, and
RAS initialization fixes.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>