### PR TITLE
xekmd-backports: align the entries in series file and resolve conflicts

### DIFF
--- a/backport/patches/base/0001-drm-xe-drm_ras-Move-has_drm_ras-check-to-drm_ras-layer.patch
+++ b/backport/patches/base/0001-drm-xe-drm_ras-Move-has_drm_ras-check-to-drm_ras-layer.patch
@@ -36,13 +36,17 @@ diff --git a/drivers/gpu/drm/xe/xe_ras.c b/drivers/gpu/drm/xe/xe_ras.c
 index 8c2aa14d2..543a0fde1 100644
 --- a/drivers/gpu/drm/xe/xe_ras.c
 +++ b/drivers/gpu/drm/xe/xe_ras.c
-@@ -905,9 +905,6 @@ void xe_ras_init(struct xe_device *xe)
+@@ -879,13 +879,10 @@ void xe_ras_init(struct xe_device *xe)
  {
  	int ret;
  
 -	if (!xe->info.has_drm_ras)
 -		return;
 -
+ 	if (xe->info.platform == XE_CRESCENTISLAND)
+ 		xe->ras.bad_page_reservation =
+ 			xe_configfs_get_bad_page_reservation(to_pci_dev(xe->drm.dev));
+ 
  	xe_drm_ras_init(xe);
  
  	if (!xe->info.has_sysctrl)

--- a/series
+++ b/series
@@ -215,13 +215,6 @@ backport/patches/base/0001-platform-x86-intel-pmc-ssram-Add-ACPI-discovery-scaf.
 backport/patches/base/0001-platform-x86-intel-pmc-ssram-Make-PMT-registration-o.patch
 backport/patches/base/0001-drm-xe-i2c-Fix-the-interrupt-handling.patch
 backport/patches/base/0001-drm-xe-i2c-Keep-the-i2c-controller-always-enabled.patch
-backport/patches/base/0001-drm-ras-Cancel-and-free-message-on-get-counter-failure.patch
-backport/patches/base/0001-drm-ras-Introduce-error-threshold.patch
-backport/patches/base/0001-drm-xe-ras-Add-support-for-error-threshold.patch
-backport/patches/base/0001-drm-xe-drm_ras-Wire-up-error-threshold-callbacks.patch
-backport/patches/base/0001-drm-xe-sysctrl-Reuse-xe_sysctrl_create_command.patch
-backport/patches/base/0001-drm-xe-ras-Fix-boot-time-ras-error-processing.patch
-backport/patches/base/0001-drm-xe-drm_ras-Move-has_drm_ras-check-to-drm_ras-layer.patch
 backport/patches/base/0001-platform-x86-intel-pmt-complete-pcidev-to-device-upd.patch
 backport/patches/base/0001-platform-x86-intel-pmt-Add-register-access-callbacks.patch
 backport/patches/base/0001-drm-xe-vsec-Protect-against-missing-config.patch
@@ -248,6 +241,13 @@ backport/patches/base/0001-drm-xe-ras-Cache-bad_page_reservation-policy-at-init.
 backport/patches/base/0001-drm-xe-vram-Check-bad_page_reservation-policy-in-fault-handler.patch
 backport/patches/base/0001-drm-xe-Expose-bad-VRAM-pages-via-debugfs.patch
 backport/patches/base/0001-drm-xe-Add-fault-inject-based-VRAM-page-offline-injection.patch
+backport/patches/base/0001-drm-ras-Cancel-and-free-message-on-get-counter-failure.patch
+backport/patches/base/0001-drm-ras-Introduce-error-threshold.patch
+backport/patches/base/0001-drm-xe-ras-Add-support-for-error-threshold.patch
+backport/patches/base/0001-drm-xe-drm_ras-Wire-up-error-threshold-callbacks.patch
+backport/patches/base/0001-drm-xe-sysctrl-Reuse-xe_sysctrl_create_command.patch
+backport/patches/base/0001-drm-xe-ras-Fix-boot-time-ras-error-processing.patch
+backport/patches/base/0001-drm-xe-drm_ras-Move-has_drm_ras-check-to-drm_ras-layer.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Fixes: https://github.com/intel-gpu/xekmd-backports/commit/a632d70efb335aab536f44025ef2ef10cfe634a1 ("backport RAS error threshold patches")