### PR TITLE
Rebase bad page reservation cache patch

### DIFF
--- a/backport/patches/base/0001-drm-xe-ras-Cache-bad_page_reservation-policy-at-init.patch
+++ b/backport/patches/base/0001-drm-xe-ras-Cache-bad_page_reservation-policy-at-init.patch
@@ -11,14 +11,14 @@ lookups on every fault.
 Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
 (cherry-picked from [V21] https://lore.kernel.org/all/20260519122817.45770-22-tejas.upadhyay@intel.com/ )
 Signed-off-by: Akanksha Hotta <akanksha.hotta@intel.com>
-
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
 ---
  drivers/gpu/drm/xe/xe_drm_ras_types.h | 3 +++
  drivers/gpu/drm/xe/xe_ras.c           | 5 +++++
  2 files changed, 8 insertions(+)
 
 diff --git a/drivers/gpu/drm/xe/xe_drm_ras_types.h b/drivers/gpu/drm/xe/xe_drm_ras_types.h
-index 8d729ad6a264..83899cf04793 100644
+index 8d729ad6a..83899cf04 100644
 --- a/drivers/gpu/drm/xe/xe_drm_ras_types.h
 +++ b/drivers/gpu/drm/xe/xe_drm_ras_types.h
 @@ -43,6 +43,9 @@ struct xe_drm_ras {
@@ -32,23 +32,20 @@ index 8d729ad6a264..83899cf04793 100644
  
  #endif
 diff --git a/drivers/gpu/drm/xe/xe_ras.c b/drivers/gpu/drm/xe/xe_ras.c
-index d25d25f77531..c7e86ae0e8ad 100644
+index bd5a20630..3eb597b15 100644
 --- a/drivers/gpu/drm/xe/xe_ras.c
 +++ b/drivers/gpu/drm/xe/xe_ras.c
-@@ -3,6 +3,7 @@
-  * Copyright © 2026 Intel Corporation
+@@ -4,6 +4,7 @@
   */
  
-+#include "xe_configfs.h"
  #include "xe_debugfs.h"
++#include "xe_configfs.h"
  #include "xe_device.h"
  #include "xe_drm_ras.h"
-@@ -775,9 +775,13 @@ void xe_ras_init(struct xe_device *xe)
+ #include "xe_log.h"
+@@ -879,6 +880,10 @@ void xe_ras_init(struct xe_device *xe)
  {
  	int ret;
- 
- 	if (!xe->info.has_drm_ras)
- 		return;
  
 +	if (xe->info.platform == XE_CRESCENTISLAND)
 +		xe->ras.bad_page_reservation =
@@ -57,3 +54,5 @@ index d25d25f77531..c7e86ae0e8ad 100644
  	xe_drm_ras_init(xe);
  
  	if (!xe->info.has_sysctrl)
+
+


### PR DESCRIPTION
The RAS threshold series changes xe_ras initialization before
the bad page reservation cache patch is applied. Update the patch
context to preserve the cache initialization after the threshold series.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>