### PR TITLE
drm/xe: fix timeout handling and context timestamp warnings

### DIFF
--- a/backport/patches/base/0001-drm-xe-lrc-fix-spurious-warning-when-reading-context.patch
+++ b/backport/patches/base/0001-drm-xe-lrc-fix-spurious-warning-when-reading-context.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Date: Wed, 10 Jun 2026 11:25:50 -0400
+Subject: drm/xe/lrc: fix spurious warning when reading context
+ timestamp
+
+Fixes the following warning that fires during timeout handling for a
+context running on the USM-reserved copy engine:
+
+  xe 0000:03:00.0: [drm] Tile0: GT0: Unexpected engine class:instance 3:8 for utilization
+  WARNING: at engine_id_to_hwe+0x88/0xc0 [xe]
+    xe_lrc_context_timestamp+0x61/0xb0 [xe]
+    guc_exec_queue_timedout_job+0x713/0x1020 [xe]
+
+class:instance 3:8 is XE_ENGINE_CLASS_COPY on the highest BCS instance,
+which xe_hw_engine.c reserves for USM (gt->usm.reserved_bcs_instance) and
+on which the migrate engine runs kernel contexts. When such a context's
+utilization is read - e.g. from the TDR path - engine_id_to_hwe()
+rejected it because xe_hw_engine_is_reserved() is true, firing WARN_ONCE
+and returning NULL, which made the timestamp read silently fall back to
+stale data.
+
+The reserved-engine guard was added defensively with the original WA BB
+utilization support and simply overlooked that the migrate engine is a
+valid, present engine whose CTX_TIMESTAMP can legitimately be read.
+
+Allow the USM-reserved copy engine specifically (xe_gt_is_usm_hwe()),
+while still rejecting the other reserved cases (GSCCS / XE_ENGINE_CLASS_
+OTHER and ccs_mode-disabled compute engines), which would indeed be
+unexpected on this path. The dynamic engine resolution via the ENGINE_ID
+stashed in the PPHWSP by the WA BB is kept intact, so utilization for
+load-balanced/virtual exec queues still resolves the engine the context
+is actually running on.
+
+Cc: Matthew Auld <matthew.auld@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Sanjay Yadav <sanjay.kumar.yadav@intel.com>
+Cc: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Assisted-by: GitHub-Copilot:claude-sonnet-4.6
+Assisted-by: GitHub-Copilot:claude-opus-4.8
+Reviewed-by: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Link: https://patch.msgid.link/20260610152548.404575-4-rodrigo.vivi@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(backported from commit 0cfa716f19c046b2862eb758200965c5b77b4dce drm-tip)
+Signed-off-by:  Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_lrc.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_lrc.c b/drivers/gpu/drm/xe/xe_lrc.c
+index bb530d029..0f799ab62 100644
+--- a/drivers/gpu/drm/xe/xe_lrc.c
++++ b/drivers/gpu/drm/xe/xe_lrc.c
+@@ -2629,6 +2629,12 @@ void xe_lrc_snapshot_free(struct xe_lrc_snapshot *snapshot)
+ 	kfree(snapshot);
+ }
+ 
++static bool engine_valid_for_utilization(struct xe_gt *gt, struct xe_hw_engine *hwe)
++{
++	/* The USM-reserved copy engine runs kernel migrate contexts queried here */
++	return hwe && (!xe_hw_engine_is_reserved(hwe) || xe_gt_is_usm_hwe(gt, hwe));
++}
++
+ static int get_ctx_timestamp(struct xe_lrc *lrc, u32 engine_id, u64 *reg_ctx_ts)
+ {
+ 	u16 class = REG_FIELD_GET(ENGINE_CLASS_ID, engine_id);
+@@ -2637,7 +2643,7 @@ static int get_ctx_timestamp(struct xe_lrc *lrc, u32 engine_id, u64 *reg_ctx_ts)
+ 	u64 val;
+ 
+ 	hwe = xe_gt_hw_engine(lrc->gt, class, instance, false);
+-	if (xe_gt_WARN_ONCE(lrc->gt, !hwe || xe_hw_engine_is_reserved(hwe),
++	if (xe_gt_WARN_ONCE(lrc->gt, !engine_valid_for_utilization(lrc->gt, hwe),
+ 			    "Unexpected engine class:instance %d:%d for context utilization\n",
+ 			    class, instance))
+ 		return -1;
+-- 
+2.43.0
+

--- a/backport/patches/fixes/0001-drm-xe-don-t-WARN-on-kernel-job-timeout-when-device-.patch
+++ b/backport/patches/fixes/0001-drm-xe-don-t-WARN-on-kernel-job-timeout-when-device-.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nitin Gote <nitin.r.gote@intel.com>
+Date: Fri, 14 Aug 2026 13:11:07 +0530
+Subject: drm/xe: don't WARN on kernel job timeout when device
+ already wedged
+
+igt@xe_wedged@wedged-at-any-timeout wedges the device in mode 2
+(UPON_ANY_HANG_NO_RESET) and then rebinds the driver. During unbind,
+a GSC proxy kernel submission can still time out; with the device wedged
+and the GuC CT stopped it can never complete, so its kernel job times out.
+
+  Tile0: GT1: Kernel-submitted job timed out
+  WARNING: drivers/gpu/drm/xe/xe_guc_submit.c:...
+	   at guc_exec_queue_timedout_job()
+  Workqueue: gt-ordered-wq drm_sched_job_timedout
+
+Killed queues skip guc_submit_hint_wedged(), leaving 'wedged' false even
+though the device is already wedged. The timeout handler then treats the
+kernel queue timeout as unexpected and taints the kernel.
+
+Honour an already-wedged device even for killed queues so the expected
+teardown timeout no longer trips the WARN.
+
+Fixes: 5a2f117a80c2 ("drm/xe: Do not wedge device on killed exec queues")
+Cc: Matthew Brost <matthew.brost@intel.com>
+Signed-off-by: Nitin Gote <nitin.r.gote@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Link: https://patch.msgid.link/20260814074106.92670-2-nitin.r.gote@intel.com
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+(cherry picked from commit a1c1dbd0f047bb05de6aaf6abe9103031179bf19)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit 13087ad7817e6e5f210064518bfc4d6d58a9c2f3 drm-tip)
+Signed-off-by:  Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc_submit.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index 0205360cf..f847c0f26 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -1577,8 +1577,14 @@ guc_exec_queue_timedout_job(struct drm_sched_job *drm_job)
+ 	if (!skip_timeout_check && !check_timeout(q, job))
+ 		goto rearm;
+ 
++	/*
++	 * Killed queues must not newly wedge the device, but preserve an
++	 * already-wedged state to avoid warning on teardown timeouts.
++	 */
+ 	if (!exec_queue_killed(q))
+ 		wedged = guc_submit_hint_wedged(exec_queue_to_guc(q));
++	else
++		wedged = xe_device_wedged(xe);
+ 
+ 	set_exec_queue_banned(q);
+ 
+-- 
+2.43.0
+

--- a/backport/patches/fixes/0001-drm-xe-wedge-from-the-timeout-handler-only-after-rel.patch
+++ b/backport/patches/fixes/0001-drm-xe-wedge-from-the-timeout-handler-only-after-rel.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Date: Fri, 12 Jun 2026 12:24:15 -0400
+Subject: drm/xe: wedge from the timeout handler only after
+ releasing the queue
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A kernel job that exhausts its recovery attempts called
+xe_device_declare_wedged() directly from guc_exec_queue_timedout_job(),
+while the handler still owned the timed-out job and the queue scheduler
+(sched = &q->guc->sched, stopped at the top of the handler).
+
+In the default wedged mode (XE_WEDGED_MODE_UPON_CRITICAL_ERROR),
+xe_device_declare_wedged() takes the destructive path in
+xe_guc_submit_wedge(): guc_submit_reset_prepare(), xe_guc_submit_stop()
+- which calls guc_exec_queue_stop() on every queue, including this one -
+softreset and pause-abort. That tears submission down, signals the
+in-flight fences and restarts the schedulers. This is the correct
+behaviour when the wedge originates outside the TDR, but not when the
+TDR itself triggers it: every queue should be torn down except the one
+the TDR is currently operating on, which it still owns.
+
+Control then returned to the handler, which kept using the now stale job
+and scheduler:
+
+  xe_sched_job_set_error(job, err);
+  drm_sched_for_each_pending_job(tmp_job, &sched->base, NULL)
+          xe_sched_job_set_error(to_xe_sched_job(tmp_job), -ECANCELED);
+
+drm_sched_for_each_pending_job() warns because the scheduler is no
+longer stopped (WARN_ON(!drm_sched_is_stopped())) and the iteration then
+dereferences a freed job, faulting on the slab poison:
+
+  Oops: general protection fault ... 0x6b6b6b6b6b6b6c3b
+  RIP: guc_exec_queue_timedout_job+...
+
+Defer the wedge until the handler has finished operating on the queue,
+right before returning DRM_GPU_SCHED_STAT_NO_HANG, so the teardown no
+longer races with this handler's use of @q.
+
+Fixes: b1107d085e7e ("drm/xe: fix job timeout recovery for unstarted jobs and kernel queues")
+Suggested-by: Matthew Brost <matthew.brost@intel.com>
+Cc: Matthew Brost <matthew.brost@intel.com>
+Cc: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+Cc: Himal Prasad Ghimiray <himal.prasad.ghimiray@intel.com>
+Cc: Sanjay Yadav <sanjay.kumar.yadav@intel.com>
+Assisted-by: GitHub-Copilot:claude-opus-4.8
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Link: https://patch.msgid.link/20260612162414.287971-2-rodrigo.vivi@intel.com
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+(cherry-picked from commit d42df9dce7b374079c5c41691bd62d8765768a80 drm-tip)
+Signed-off-by:  Pravalika Gurram <pravalika.gurram@intel.com>
+---
+ drivers/gpu/drm/xe/xe_guc_submit.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index f847c0f26..0ac9ec6cf 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -1522,7 +1522,7 @@ guc_exec_queue_timedout_job(struct drm_sched_job *drm_job)
+ 	struct xe_device *xe = guc_to_xe(guc);
+ 	int err = -ETIME;
+ 	pid_t pid = -1;
+-	bool wedged = false, skip_timeout_check;
++	bool wedged = false, wedge_device = false, skip_timeout_check;
+ 
+ 	xe_gt_assert(guc_to_gt(guc), !exec_queue_destroyed(q));
+ 
+@@ -1674,7 +1674,7 @@ guc_exec_queue_timedout_job(struct drm_sched_job *drm_job)
+ 			}
+ 			if (q->flags & EXEC_QUEUE_FLAG_KERNEL) {
+ 				xe_gt_WARN(q->gt, true, "Kernel-submitted job timed out\n");
+-				xe_device_declare_wedged(gt_to_xe(q->gt));
++				wedge_device = true;
+ 			}
+ 		} else if (q->flags & EXEC_QUEUE_FLAG_VM && !exec_queue_killed(q)) {
+ 			xe_gt_WARN(q->gt, true, "VM job timed out on non-killed execqueue\n");
+@@ -1694,6 +1694,9 @@ guc_exec_queue_timedout_job(struct drm_sched_job *drm_job)
+ 		xe_guc_exec_queue_trigger_cleanup(q);
+ 	}
+ 
++	if (wedge_device)
++		xe_device_declare_wedged(gt_to_xe(q->gt));
++
+ 	/*
+ 	 * We want the job added back to the pending list so it gets freed; this
+ 	 * is what DRM_GPU_SCHED_STAT_NO_HANG does.
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -208,6 +208,9 @@ backport/patches/base/0001-drm-xe-drm_ras-Wire-up-error-threshold-callbacks.patc
 backport/patches/base/0001-drm-xe-sysctrl-Reuse-xe_sysctrl_create_command.patch
 backport/patches/base/0001-drm-xe-ras-Fix-boot-time-ras-error-processing.patch
 backport/patches/base/0001-drm-xe-drm_ras-Move-has_drm_ras-check-to-drm_ras-layer.patch
+backport/patches/fixes/0001-drm-xe-don-t-WARN-on-kernel-job-timeout-when-device-.patch
+backport/patches/fixes/0001-drm-xe-wedge-from-the-timeout-handler-only-after-rel.patch
+backport/patches/base/0001-drm-xe-lrc-fix-spurious-warning-when-reading-context.patch
 backport/patches/base/0001-drm-xe-hwmon-Detect-unavailable-temperature-sensors.patch
 backport/patches/base/0001-drm-xe-hwmon-Use-VRAM-temperature-sensor-count-from-.patch
 backport/patches/base/0001-drm-xe-hwmon-Correct-group-selection-for-memory-cont.patch


### PR DESCRIPTION
These fixes address kernel job timeout warnings and the reported failure
during xe_lrc_timestamp() in the GPU scheduler timeout workqueue.

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>