### PR TITLE
drm/xe: Backport PCI error handling fixes

### DIFF
--- a/backport/patches/base/0001-drm-xe-xe_guc-Skip-GuC-reset-post-SBR.patch
+++ b/backport/patches/base/0001-drm-xe-xe_guc-Skip-GuC-reset-post-SBR.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Fri, 28 Aug 2026 17:01:07 +0530
+Subject: drm/xe/xe_guc: Skip GuC reset post SBR
+
+Secondary Bus Reset causes all VRAM state to be lost along with hardware
+state. The goal is to keep the device in reset till the teardown is
+complete to avoid device accesses such as GuC reset in an unknown state.
+
+Fixes: e46ee82f120f ("drm/xe: Skip device access during PCI error recovery")
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+(backported from [rev1 drm/xe/xe_guc: Skip GuC reset post SBR])
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_device.h    | 5 -----
+ drivers/gpu/drm/xe/xe_guc.c       | 5 +++++
+ drivers/gpu/drm/xe/xe_pci_error.c | 1 -
+ 3 files changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_device.h b/drivers/gpu/drm/xe/xe_device.h
+index 9fa92d56f..1435b463c 100644
+--- a/drivers/gpu/drm/xe/xe_device.h
++++ b/drivers/gpu/drm/xe/xe_device.h
+@@ -197,11 +197,6 @@ static inline void xe_device_set_in_reset(struct xe_device *xe)
+ 	atomic_set(&xe->in_reset, 1);
+ }
+ 
+-static inline void xe_device_clear_in_reset(struct xe_device *xe)
+-{
+-	atomic_set(&xe->in_reset, 0);
+-}
+-
+ u32 xe_device_ccs_bytes(struct xe_device *xe, u64 size);
+ 
+ void xe_device_snapshot_print(struct xe_device *xe, struct drm_printer *p);
+diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
+index 445ea6e36..e899d2172 100644
+--- a/drivers/gpu/drm/xe/xe_guc.c
++++ b/drivers/gpu/drm/xe/xe_guc.c
+@@ -978,6 +978,11 @@ int xe_guc_reset(struct xe_guc *guc)
+ 	u32 guc_status, gdrst;
+ 	int ret;
+ 
++	if (xe_device_is_in_reset(gt_to_xe(gt))) {
++		xe_gt_dbg(gt, "Skipping GuC reset, device is in reset\n");
++		return 0;
++	}
++
+ 	xe_force_wake_assert_held(gt_to_fw(gt), XE_FW_GT);
+ 
+ 	if (IS_SRIOV_VF(gt_to_xe(gt)))
+diff --git a/drivers/gpu/drm/xe/xe_pci_error.c b/drivers/gpu/drm/xe/xe_pci_error.c
+index 3e9c77f84..b7ac33965 100644
+--- a/drivers/gpu/drm/xe/xe_pci_error.c
++++ b/drivers/gpu/drm/xe/xe_pci_error.c
+@@ -121,7 +121,6 @@ static pci_ers_result_t xe_pci_error_slot_reset(struct pci_dev *pdev)
+ 	 * TODO: optimize by re-initializing only the hardware state and re-creating
+ 	 * kernel BOs.
+ 	 */
+-	xe_device_clear_in_reset(xe);
+ 	pdev->driver->remove(pdev);
+ 	devres_release_group(&pdev->dev, xe->devres_group);
+ 
+-- 
+2.43.0
+

--- a/backport/patches/base/0001-drm-xe-xe_pci_error-Wait-for-pcode-init-post-SBR.patch
+++ b/backport/patches/base/0001-drm-xe-xe_pci_error-Wait-for-pcode-init-post-SBR.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riana Tauro <riana.tauro@intel.com>
+Date: Fri, 28 Aug 2026 17:01:06 +0530
+Subject: drm/xe/xe_pci_error: Wait for pcode init post SBR
+
+Pcode init complete indicates the device is ready, with device memory
+initialization complete. Wait for Pcode init before accessing the
+device post Secondary Bus Reset (SBR).
+
+Signed-off-by: Riana Tauro <riana.tauro@intel.com>
+Reviewed-by: Anshuman Gupta <anshuman.gupta@intel.com>
+(backported from [rev1 drm/xe/xe_pci_error: Wait for pcode init post SBR])
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pci_error.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/gpu/drm/xe/xe_pci_error.c b/drivers/gpu/drm/xe/xe_pci_error.c
+index 79ce0c671..3e9c77f84 100644
+--- a/drivers/gpu/drm/xe/xe_pci_error.c
++++ b/drivers/gpu/drm/xe/xe_pci_error.c
+@@ -9,6 +9,7 @@
+ #include "xe_gt.h"
+ #include "xe_log.h"
+ #include "xe_pci.h"
++#include "xe_pcode.h"
+ #include "xe_pm.h"
+ #include "xe_printk.h"
+ #include "xe_ras.h"
+@@ -109,6 +110,10 @@ static pci_ers_result_t xe_pci_error_slot_reset(struct pci_dev *pdev)
+ 		return PCI_ERS_RESULT_DISCONNECT;
+ 	}
+ 
++	err = xe_pcode_probe_early(xe);
++	if (err)
++		return PCI_ERS_RESULT_DISCONNECT;
++
+ 	/*
+ 	 * Secondary Bus Reset causes all VRAM state to be lost along with
+ 	 * hardware state. As an initial step, re-probe the device to
+-- 
+2.43.0


### PR DESCRIPTION
These fixes are required for xe pci error recovery after Secondary
Bus Reset. They wait for PCODE initialization and skip GuC reset while
the device remains in reset, preventing unsafe MMIO access and GuC
reset failures during PCI recovery.

PW: https://patchwork.freedesktop.org/series/172960/

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>