### PR TITLE
drm/xe: guard page-fault worker with runtime PM check

### DIFF
--- a/backport/patches/base/0001-drm-xe-gt-Report-Fault-response-pagefault-error-usin.patch
+++ b/backport/patches/base/0001-drm-xe-gt-Report-Fault-response-pagefault-error-usin.patch
@@ -25,13 +25,14 @@ diff --git a/drivers/gpu/drm/xe/xe_pagefault.c b/drivers/gpu/drm/xe/xe_pagefault
 index dd3c068e1a39..a0832f3e0ecc 100644
 --- a/drivers/gpu/drm/xe/xe_pagefault.c
 +++ b/drivers/gpu/drm/xe/xe_pagefault.c
-@@ -14,6 +14,7 @@
+@@ -14,7 +14,8 @@
  #include "xe_gt_types.h"
  #include "xe_gt_stats.h"
  #include "xe_hw_engine.h"
 +#include "xe_log.h"
  #include "xe_pagefault.h"
  #include "xe_pagefault_types.h"
+ #include "xe_pm.h"
  #include "xe_svm.h"
 @@ -309,8 +310,7 @@ static void xe_pagefault_queue_work(struct work_struct *w)
  			xe_pagefault_save_to_vm(gt_to_xe(pf.gt), &pf);

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Enable-EU-pagefault-handling.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Enable-EU-pagefault-handling.patch
@@ -45,7 +45,6 @@ Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>
 ---
  drivers/gpu/drm/xe/xe_pagefault.c | 42 +++++++++++++++++++++++++++----
  1 file changed, 37 insertions(+), 5 deletions(-)
-
 diff --git a/drivers/gpu/drm/xe/xe_pagefault.c b/drivers/gpu/drm/xe/xe_pagefault.c
 index dd3c068e1..f12636fb7 100644
 --- a/drivers/gpu/drm/xe/xe_pagefault.c
@@ -59,7 +58,7 @@ index dd3c068e1..f12636fb7 100644
  /**
   * DOC: Xe page faults
   *
-@@ -167,12 +167,15 @@ static struct xe_vm *xe_pagefault_asid_to_vm(struct xe_device *xe, u32 asid)
+@@ -172,12 +172,15 @@ static struct xe_vm *xe_pagefault_asid_to_vm(struct xe_device *xe, u32 asid)
  	return vm;
  }
  
@@ -132,7 +131,7 @@ index dd3c068e1..f12636fb7 100644
  	xe_vm_put(vm);
  
  	return err;
-@@ -299,12 +328,13 @@ static void xe_pagefault_queue_work(struct work_struct *w)
+@@ -293,12 +318,13 @@ static void xe_pagefault_queue_work(struct work_struct *w)
  	threshold = jiffies + msecs_to_jiffies(USM_QUEUE_MAX_RUNTIME_MS);
  
  	while (xe_pagefault_queue_pop(pf_queue, &pf)) {
@@ -154,8 +153,10 @@ index dd3c068e1..f12636fb7 100644
 +		xe_eudebug_pagefault_finalize(eudbg_pf, !!err);
 +
  		if (time_after(jiffies, threshold)) {
- 			queue_work(gt_to_xe(pf.gt)->usm.pf_wq, w);
+ 			queue_work(xe->usm.pf_wq, w);
  			break;
+ 		}
+ 	}
 -- 
 2.43.0
 

--- a/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
+++ b/backport/patches/features/eu-debug/0001-drm-xe-eudebug-Prelim-rework-for-Xe-EU-debug.patch
@@ -2976,7 +2976,10 @@ index aba376c59..61989c421 100644
 +		prelim_xe_eudebug_pagefault_finalize(eudbg_pf, !!err);
  
  		if (time_after(jiffies, threshold)) {
- 			queue_work(gt_to_xe(pf.gt)->usm.pf_wq, w);
+ 			queue_work(xe->usm.pf_wq, w);
+ 			break;
+ 		}
+ 	}
 diff --git a/drivers/gpu/drm/xe/xe_sync.c b/drivers/gpu/drm/xe/xe_sync.c
 index e715ee0cc..cc7261ee4 100644
 --- a/drivers/gpu/drm/xe/xe_sync.c

--- a/backport/patches/fixes/base/0001-drm-xe-Guard-page-fault-worker-with-runtime-PM-check.patch
+++ b/backport/patches/fixes/base/0001-drm-xe-Guard-page-fault-worker-with-runtime-PM-check.patch
@@ -1,0 +1,119 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Varun Gupta <varun.gupta@intel.com>
+Date: Wed, 9 Sep 2026 14:25:21 +0530
+Subject: [BACKPORT-ONLY] drm/xe: Guard page-fault worker with runtime PM check
+
+During VM teardown, the VM's runtime PM reference is dropped
+asynchronously, allowing the device to autosuspend while stale page
+faults belonging to the now-dead VM are still queued. When the
+page-fault worker later tries to ack one of these, it calls into
+guc_ct_send_locked() on an already-suspended device, tripping:
+
+ Assertion `!xe_pm_runtime_suspended(xe)` failed!
+ WARNING at xe_device.c:1267 xe_device_assert_mem_access+0x11c/0x140 [xe]
+
+A live VM/exec queue always holds a PM reference while it has
+outstanding work, so if the device is suspended at ack time, the
+owning context is already gone and the fault is stale.
+
+Take a runtime PM reference across the entire pagefault
+queue worker to safely deliver acks for torn-down VMs.
+
+v3:
+ - Move PM ref to the generic xe_pagefault_queue_work using
+   guard(xe_pm_runtime)(xe) instead of tracking it in the GuC
+   backend(Matt Brost).
+
+v2:
+ - Hold PM ref across the entire batch (begin/end) instead of per-ack.
+   This prevents the device from autosuspending mid-batch, which would
+   leave write_only acks written but the end flush skipped, and skip
+   counter++, desyncing the cadence check.(Himal)
+ - Add a comment explaining stale faults.(Himal)
+
+Fixes: f289f7807119 ("drm/xe: Add xe_guc_pagefault layer")
+Signed-off-by: Varun Gupta <varun.gupta@intel.com>
+Reviewed-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+Link: https://patch.msgid.link/20260907050011.497181-2-varun.gupta@intel.com
+Signed-off-by: Tejas Upadhyay <tejas.upadhyay@intel.com>
+
+(backported from commit fcc2431d2213dc4d04250c4f1ae87d9c3ae0d455 drm-xe-next)
+Signed-off-by: Varun Gupta <varun.gupta@intel.com>
+---
+ drivers/gpu/drm/xe/xe_pagefault.c       | 13 ++++++++++++-
+ drivers/gpu/drm/xe/xe_pagefault_types.h |  3 +++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_pagefault.c b/drivers/gpu/drm/xe/xe_pagefault.c
+index dd3c068e1..116153f34 100644
+--- a/drivers/gpu/drm/xe/xe_pagefault.c
++++ b/drivers/gpu/drm/xe/xe_pagefault.c
+@@ -16,6 +16,7 @@
+ #include "xe_hw_engine.h"
+ #include "xe_pagefault.h"
+ #include "xe_pagefault_types.h"
++#include "xe_pm.h"
+ #include "xe_svm.h"
+ #include "xe_trace_bo.h"
+ #include "xe_vm.h"
+@@ -292,9 +293,18 @@ static void xe_pagefault_queue_work(struct work_struct *w)
+ {
+ 	struct xe_pagefault_queue *pf_queue =
+ 		container_of(w, typeof(*pf_queue), worker);
++	struct xe_device *xe = pf_queue->xe;
+ 	struct xe_pagefault pf;
+ 	unsigned long threshold;
+ 
++	/*
++	 * A live VM holds a PM reference, but a torn-down VM does not.
++	 * Guard the entire worker loop to safely drain stale faults and
++	 * prevent autosuspends from desyncing batched CT flushes.
++	 */
++	guard(xe_pm_runtime)(xe);
++
++
+ #define USM_QUEUE_MAX_RUNTIME_MS      20
+ 	threshold = jiffies + msecs_to_jiffies(USM_QUEUE_MAX_RUNTIME_MS);
+ 
+@@ -321,7 +331,7 @@ static void xe_pagefault_queue_work(struct work_struct *w)
+ 		pf.producer.ops->ack_fault(&pf, err);
+ 
+ 		if (time_after(jiffies, threshold)) {
+-			queue_work(gt_to_xe(pf.gt)->usm.pf_wq, w);
++			queue_work(xe->usm.pf_wq, w);
+ 			break;
+ 		}
+ 	}
+@@ -367,6 +377,7 @@ static int xe_pagefault_queue_init(struct xe_device *xe,
+ 
+ 	spin_lock_init(&pf_queue->lock);
+ 	INIT_WORK(&pf_queue->worker, xe_pagefault_queue_work);
++	pf_queue->xe = xe;
+ 
+ 	pf_queue->data = drmm_kzalloc(&xe->drm, pf_queue->size, GFP_KERNEL);
+ 	if (!pf_queue->data)
+diff --git a/drivers/gpu/drm/xe/xe_pagefault_types.h b/drivers/gpu/drm/xe/xe_pagefault_types.h
+index b3289219b..419c690a7 100644
+--- a/drivers/gpu/drm/xe/xe_pagefault_types.h
++++ b/drivers/gpu/drm/xe/xe_pagefault_types.h
+@@ -9,6 +9,7 @@
+ #include <linux/workqueue.h>
+ 
+ struct xe_gt;
++struct xe_device;
+ struct xe_pagefault;
+ 
+ /** enum xe_pagefault_access_type - Xe page fault access type */
+@@ -118,6 +119,8 @@ struct xe_pagefault {
+  * queue to absorb the device’s worst-case number of outstanding faults.
+  */
+ struct xe_pagefault_queue {
++	/** @xe: Xe device owning this page-fault queue */
++	struct xe_device *xe;
+ 	/**
+ 	 * @data: Data in queue containing struct xe_pagefault, protected by
+ 	 * @lock
+-- 
+2.43.0
+

--- a/series
+++ b/series
@@ -108,6 +108,7 @@ backport/patches/fixes/base/0001-drm-xe-pxp-add-termination-on-resume.patch
 backport/patches/fixes/base/0001-drm-xe-Fix-xe_device_probe-failure.patch
 backport/patches/fixes/base/0001-drm-xe-Fix-a-bug-in-pc_adjust_freq_bounds.patch
 backport/patches/fixes/base/0001-drm-xe-tests-fix-error-message-in-xe_migrate_sanity_.patch
+backport/patches/fixes/base/0001-drm-xe-Guard-page-fault-worker-with-runtime-PM-check.patch
 backport/patches/base/0001-drm-xe-guc-Handle-GuC-local-uncorrectable-error-noti.patch
 backport/patches/base/0001-drm-xe-Add-support-for-WA-22022079272.patch
 backport/patches/base/0001-drm-xe-Add-support-for-WA-16029897822.patch


### PR DESCRIPTION
This fix guards the page-fault worker with runtime PM protection. It avoids stale-fault ack processing on a suspended device.