### PR TITLE
series: drm/xe: Add missing entry for PCI error handling fixes

### DIFF
--- a/series
+++ b/series
@@ -215,6 +215,8 @@ backport/patches/base/0001-drm-xe-lrc-fix-spurious-warning-when-reading-context.
 backport/patches/base/0001-drm-xe-hwmon-Detect-unavailable-temperature-sensors.patch
 backport/patches/base/0001-drm-xe-hwmon-Use-VRAM-temperature-sensor-count-from-.patch
 backport/patches/base/0001-drm-xe-hwmon-Correct-group-selection-for-memory-cont.patch
+backport/patches/base/0001-drm-xe-xe_guc-Skip-GuC-reset-post-SBR.patch
+backport/patches/base/0001-drm-xe-xe_pci_error-Wait-for-pcode-init-post-SBR.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Add the missing series entries for the PCI error handling fix
patches, which were committed without updating series.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>