### PR TITLE
mei: backport mei-csc pci error handling and polling fixes

### DIFF
--- a/backport/patches/base/0001-mei-csc-add-option-for-polling-and-enable-it.patch
+++ b/backport/patches/base/0001-mei-csc-add-option-for-polling-and-enable-it.patch
@@ -1,0 +1,148 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Usyskin <alexander.usyskin@intel.com>
+Date: Mon, 31 Aug 2026 14:38:32 +0300
+Subject: mei: csc: add option for polling and enable it
+
+Add option to poll instead of waiting for the interrupt
+to wallpaper over hardware not releasing the interrupt line.
+
+Enable this workaround and leave option to use interrupts when
+hardware is fixed.
+
+Reviewed-by: Menachem Adin <menachem.adin@intel.com>
+Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
+(backported from [mei: csc: add option for polling and enable it via char-misc-next])
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/misc/mei/pci-csc.c | 69 +++++++++++++++++++++++++++++---------
+ 1 file changed, 54 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/misc/mei/pci-csc.c b/drivers/misc/mei/pci-csc.c
+index 40658b72e..57eb71306 100644
+--- a/drivers/misc/mei/pci-csc.c
++++ b/drivers/misc/mei/pci-csc.c
+@@ -11,6 +11,7 @@
+ #include <linux/err.h>
+ #include <linux/errno.h>
+ #include <linux/interrupt.h>
++#include <linux/kthread.h>
+ #include <linux/module.h>
+ #include <linux/mutex.h>
+ #include <linux/pci.h>
+@@ -26,6 +27,10 @@
+ 
+ #define MEI_CSC_HECI2_OFFSET 0x1000
+ 
++static bool use_polling = true;
++module_param(use_polling, bool, 0600);
++MODULE_PARM_DESC(use_polling, "Use polling instead of interrupts");
++
+ static int mei_csc_read_fws(const struct mei_device *mdev, int where, const char *name, u32 *val)
+ {
+ 	struct mei_me_hw *hw = to_me_hw(mdev);
+@@ -87,20 +92,40 @@ static int mei_csc_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 
+ 	pci_set_drvdata(pdev, mdev);
+ 
+-	err = pci_alloc_irq_vectors(pdev, 1, 1, PCI_IRQ_INTX | PCI_IRQ_MSI);
+-	if (err < 0) {
+-		dev_err_probe(dev, err, "Failed to allocate IRQ.\n");
+-		goto err_mei_unreg;
++	if (use_polling) {
++		dev_dbg(dev, "Using polling thread\n");
++		hw->irq = -1;
+ 	}
+ 
+-	hw->irq = pci_irq_vector(pdev, 0);
++	/* use polling */
++	if (mei_me_hw_use_polling(hw)) {
++		mei_disable_interrupts(mdev);
++		mei_clear_interrupts(mdev);
++		init_waitqueue_head(&hw->wait_active);
++		hw->is_active = true; /* start in active mode for initialization */
++		hw->polling_thread = kthread_run(mei_me_polling_thread, mdev,
++						 "kmecscirqd/%s", dev_name(dev));
++		if (IS_ERR(hw->polling_thread)) {
++			err = PTR_ERR(hw->polling_thread);
++			dev_err_probe(dev, err, "unable to create kernel thread.\n");
++			goto err_mei_unreg;
++		}
++	} else {
++		err = pci_alloc_irq_vectors(pdev, 1, 1, PCI_IRQ_INTX | PCI_IRQ_MSI);
++		if (err < 0) {
++			dev_err_probe(dev, err, "Failed to allocate IRQ.\n");
++			goto err_mei_unreg;
++		}
+ 
+-	/* request and enable interrupt */
+-	err = request_threaded_irq(hw->irq,
+-				   mei_me_irq_quick_handler, mei_me_irq_thread_handler,
+-				   IRQF_SHARED | IRQF_ONESHOT, KBUILD_MODNAME, mdev);
+-	if (err)
+-		goto err_free_irq_vectors;
++		hw->irq = pci_irq_vector(pdev, 0);
++
++		/* request and enable interrupt */
++		err = request_threaded_irq(hw->irq,
++					   mei_me_irq_quick_handler, mei_me_irq_thread_handler,
++					   IRQF_SHARED | IRQF_ONESHOT, KBUILD_MODNAME, mdev);
++		if (err)
++			goto err_free_irq_vectors;
++	}
+ 
+ 	/*
+ 	 * Continue to char device setup in spite of firmware handshake failure.
+@@ -126,7 +151,8 @@ static int mei_csc_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 	return 0;
+ 
+ err_free_irq_vectors:
+-	pci_free_irq_vectors(pdev);
++	if (!mei_me_hw_use_polling(hw))
++		pci_free_irq_vectors(pdev);
+ err_mei_unreg:
+ 	mei_deregister(mdev);
+ 	return err;
+@@ -141,9 +167,14 @@ static void mei_csc_shutdown(struct pci_dev *pdev)
+ 
+ 	mei_stop(mdev);
+ 
++	if (mei_me_hw_use_polling(hw))
++		kthread_stop(hw->polling_thread);
++
+ 	mei_disable_interrupts(mdev);
+-	free_irq(hw->irq, mdev);
+-	pci_free_irq_vectors(pdev);
++	if (!mei_me_hw_use_polling(hw)) {
++		free_irq(hw->irq, mdev);
++		pci_free_irq_vectors(pdev);
++	}
+ }
+ 
+ static void mei_csc_remove(struct pci_dev *pdev)
+@@ -210,6 +241,9 @@ static int mei_csc_pm_runtime_suspend(struct device *dev)
+ 		return -EAGAIN;
+ 
+ 	hw->pg_state = MEI_PG_ON;
++	if (mei_me_hw_use_polling(hw))
++		hw->is_active = false;
++
+ 	return 0;
+ }
+ 
+@@ -219,8 +253,13 @@ static int mei_csc_pm_runtime_resume(struct device *dev)
+ 	struct mei_me_hw *hw = to_me_hw(mdev);
+ 	irqreturn_t irq_ret;
+ 
+-	scoped_guard(mutex, &mdev->device_lock)
++	scoped_guard(mutex, &mdev->device_lock) {
+ 		hw->pg_state = MEI_PG_OFF;
++		if (mei_me_hw_use_polling(hw)) {
++			hw->is_active = true;
++			wake_up_interruptible(&hw->wait_active);
++		}
++	}
+ 
+ 	/* Process all queues that wait for resume */
+ 	irq_ret = mei_me_irq_thread_handler(1, mdev);
+-- 
+2.34.1

--- a/backport/patches/base/0001-mei-csc-add-pci-error-handling.patch
+++ b/backport/patches/base/0001-mei-csc-add-pci-error-handling.patch
@@ -1,0 +1,177 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Usyskin <alexander.usyskin@intel.com>
+Date: Wed, 2 Sep 2026 15:05:50 +0300
+Subject: mei: csc: add pci error handling
+
+Add PCI error handler callbacks.
+Stop and disable communication when error is detected;
+reset the link and re-enable communication then device is
+restored.
+
+Co-developed-by: Menachem Adin <menachem.adin@intel.com>
+Signed-off-by: Menachem Adin <menachem.adin@intel.com>
+Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
+(backported from [mei: csc: add pci error handling via char-misc-next])
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/misc/mei/init.c    | 33 +++++++++++++++--
+ drivers/misc/mei/mei_dev.h |  1 +
+ drivers/misc/mei/pci-csc.c | 72 ++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 103 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/misc/mei/init.c b/drivers/misc/mei/init.c
+index 766f119f7..82444d67d 100644
+--- a/drivers/misc/mei/init.c
++++ b/drivers/misc/mei/init.c
+@@ -305,10 +305,8 @@ static void mei_reset_work(struct work_struct *work)
+ 		schedule_work(&dev->reset_work);
+ }
+ 
+-void mei_stop(struct mei_device *dev)
++static void __mei_stop(struct mei_device *dev)
+ {
+-	dev_dbg(&dev->dev, "stopping the device.\n");
+-
+ 	mutex_lock(&dev->device_lock);
+ 	mei_set_devstate(dev, MEI_DEV_POWERING_DOWN);
+ 	mutex_unlock(&dev->device_lock);
+@@ -318,6 +316,35 @@ void mei_stop(struct mei_device *dev)
+ 	mutex_unlock(&dev->device_lock);
+ 
+ 	mei_cancel_work(dev);
++}
++
++/**
++ * mei_stop_fast - stop driver, clean bus and disable driver without resetting HW link
++ *
++ * @dev: the device structure
++ */
++void mei_stop_fast(struct mei_device *dev)
++{
++	dev_dbg(&dev->dev, "stopping the device fast.\n");
++
++	__mei_stop(dev);
++
++	mutex_lock(&dev->device_lock);
++	mei_set_devstate(dev, MEI_DEV_DISABLED);
++	mutex_unlock(&dev->device_lock);
++}
++EXPORT_SYMBOL_GPL(mei_stop_fast);
++
++/**
++ * mei_stop - stop driver, clean bus and disable driver with resetting HW link
++ *
++ * @dev: the device structure
++ */
++void mei_stop(struct mei_device *dev)
++{
++	dev_dbg(&dev->dev, "stopping the device.\n");
++
++	__mei_stop(dev);
+ 
+ 	mei_clear_interrupts(dev);
+ 	mei_synchronize_irq(dev);
+diff --git a/drivers/misc/mei/mei_dev.h b/drivers/misc/mei/mei_dev.h
+index d8634a726..9b12e6a6d 100644
+--- a/drivers/misc/mei/mei_dev.h
++++ b/drivers/misc/mei/mei_dev.h
+@@ -715,6 +715,7 @@ int mei_reset(struct mei_device *dev);
+ int mei_start(struct mei_device *dev);
+ int mei_restart(struct mei_device *dev);
+ void mei_stop(struct mei_device *dev);
++void mei_stop_fast(struct mei_device *dev);
+ void mei_cancel_work(struct mei_device *dev);
+ 
+ void mei_set_devstate(struct mei_device *dev, enum mei_dev_state state);
+diff --git a/drivers/misc/mei/pci-csc.c b/drivers/misc/mei/pci-csc.c
+index 70792bf9b..40658b72e 100644
+--- a/drivers/misc/mei/pci-csc.c
++++ b/drivers/misc/mei/pci-csc.c
+@@ -230,6 +230,77 @@ static int mei_csc_pm_runtime_resume(struct device *dev)
+ 	return 0;
+ }
+ 
++static pci_ers_result_t mei_csc_pci_error_detected(struct pci_dev *pdev, pci_channel_state_t state)
++{
++	struct mei_device *mdev = pci_get_drvdata(pdev);
++	struct mei_me_hw *hw = to_me_hw(mdev);
++
++	dev_info(&pdev->dev, "error recovery: error detected. state %d\n", state);
++
++	scoped_guard(mutex, &mdev->device_lock)
++		if (mei_me_hw_use_polling(hw))
++			hw->is_active = false;
++
++	mei_synchronize_irq(mdev);
++	mei_stop_fast(mdev);
++	pci_disable_device(pdev);
++
++	switch (state) {
++	case pci_channel_io_normal:
++		return PCI_ERS_RESULT_CAN_RECOVER;
++	case pci_channel_io_perm_failure:
++		return PCI_ERS_RESULT_DISCONNECT;
++	case pci_channel_io_frozen:
++		return PCI_ERS_RESULT_NEED_RESET;
++	default:
++		dev_err(&pdev->dev, "Unknown state %d\n", state);
++		return PCI_ERS_RESULT_NEED_RESET;
++	}
++}
++
++static pci_ers_result_t mei_csc_pci_error_slot_reset(struct pci_dev *pdev)
++{
++	int err;
++
++	pci_restore_state(pdev);
++	pci_set_master(pdev);
++
++	err = pci_enable_device(pdev);
++	if (err < 0) {
++		dev_err(&pdev->dev, "Cannot re-enable PCI device after reset. err = %d\n", err);
++		return PCI_ERS_RESULT_DISCONNECT;
++	}
++
++	return PCI_ERS_RESULT_RECOVERED;
++}
++
++static void mei_csc_pci_error_resume(struct pci_dev *pdev)
++{
++	struct mei_device *mdev = pci_get_drvdata(pdev);
++	struct mei_me_hw *hw = to_me_hw(mdev);
++
++	dev_info(&pdev->dev, "error recovery: resume\n");
++
++	scoped_guard(mutex, &mdev->device_lock) {
++		if (mei_me_hw_use_polling(hw)) {
++			hw->is_active = true;
++			wake_up_interruptible(&hw->wait_active);
++		}
++	}
++
++	if (mei_restart(mdev))
++		return;
++
++	/* Start timer if stopped in error */
++	schedule_delayed_work(&mdev->timer_work, HZ);
++}
++
++static const struct pci_error_handlers mei_csc_pci_error_handlers = {
++	.error_detected = mei_csc_pci_error_detected,
++	.slot_reset     = mei_csc_pci_error_slot_reset,
++	.resume         = mei_csc_pci_error_resume,
++};
++
+ static const struct dev_pm_ops mei_csc_pm_ops = {
+ 	.prepare = pm_sleep_ptr(mei_csc_pci_prepare),
+ 	.complete = pm_sleep_ptr(mei_csc_pci_complete),
+@@ -250,6 +321,7 @@ static struct pci_driver mei_csc_driver = {
+ 	.probe = mei_csc_probe,
+ 	.remove = mei_csc_remove,
+ 	.shutdown = mei_csc_shutdown,
++	.err_handler = &mei_csc_pci_error_handlers,
+ 	.driver = {
+ 		.pm = &mei_csc_pm_ops,
+ 		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
+-- 
+2.34.1

--- a/backport/patches/base/0001-mei-make-polling-wait-interruptible.patch
+++ b/backport/patches/base/0001-mei-make-polling-wait-interruptible.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+Date: Wed, 9 Sep 2026 20:22:25 +0530
+Subject: mei: make polling wait interruptible
+
+Polling thread wait should be interruptible to avoid stuck task.
+
+Reviewed-by: Menachem Adin <menachem.adin@intel.com>
+Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
+(backported from [mei: make polling wait interruptible via char-misc-next])
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/misc/mei/gsc-me.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/misc/mei/gsc-me.c b/drivers/misc/mei/gsc-me.c
+index 73d5beeb9..1deee6594 100644
+--- a/drivers/misc/mei/gsc-me.c
++++ b/drivers/misc/mei/gsc-me.c
+@@ -244,7 +244,7 @@ static int __maybe_unused mei_gsc_pm_runtime_resume(struct device *device)
+ 
+ 	if (mei_me_hw_use_polling(hw)) {
+ 		hw->is_active = true;
+-		wake_up(&hw->wait_active);
++		wake_up_interruptible(&hw->wait_active);
+ 	}
+ 
+ 	mutex_unlock(&dev->device_lock);
+-- 
+2.34.1

--- a/backport/patches/base/0001-mei-me-avoid-hw-access-in-polling-when-not-active.patch
+++ b/backport/patches/base/0001-mei-me-avoid-hw-access-in-polling-when-not-active.patch
@@ -1,0 +1,178 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Usyskin <alexander.usyskin@intel.com>
+Date: Mon, 31 Aug 2026 14:38:33 +0300
+Subject: mei: me: avoid hw access in polling when not active
+
+Polling thread should not access hardware when not active.
+Check for active state under device lock to avoid such
+access when hardware is powered down.
+
+Reviewed-by: Menachem Adin <menachem.adin@intel.com>
+Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
+(backported from [mei: me: avoid hw access in polling when not active via char-misc-next])
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/misc/mei/hw-me.c | 99 +++++++++++++++++++++++-----------------
+ 1 file changed, 58 insertions(+), 41 deletions(-)
+
+diff --git a/drivers/misc/mei/hw-me.c b/drivers/misc/mei/hw-me.c
+index e286763b5..5f571e6b6 100644
+--- a/drivers/misc/mei/hw-me.c
++++ b/drivers/misc/mei/hw-me.c
+@@ -6,6 +6,7 @@
+ 
+ #include <linux/pci.h>
+ 
++#include <linux/cleanup.h>
+ #include <linux/kthread.h>
+ #include <linux/interrupt.h>
+ #include <linux/pm_runtime.h>
+@@ -1290,29 +1291,14 @@ irqreturn_t mei_me_irq_quick_handler(int irq, void *dev_id)
+ }
+ EXPORT_SYMBOL_GPL(mei_me_irq_quick_handler);
+ 
+-/**
+- * mei_me_irq_thread_handler - function called after ISR to handle the interrupt
+- * processing.
+- *
+- * @irq: The irq number
+- * @dev_id: pointer to the device structure
+- *
+- * Return: irqreturn_t
+- *
+- */
+-irqreturn_t mei_me_irq_thread_handler(int irq, void *dev_id)
++static irqreturn_t __mei_me_irq_thread_handler(struct mei_device *dev)
+ {
+-	struct mei_device *dev = (struct mei_device *) dev_id;
+ 	struct list_head cmpl_list;
+ 	bool pg_blocked;
+ 	s32 slots;
+ 	u32 hcsr;
+ 	int rets = 0;
+ 
+-	dev_dbg(&dev->dev, "function called after ISR to handle the interrupt processing.\n");
+-	/* initialize our complete list */
+-	mutex_lock(&dev->device_lock);
+-
+ 	hcsr = mei_hcsr_read(dev);
+ 	me_intr_clear(dev, hcsr);
+ 
+@@ -1406,13 +1392,33 @@ irqreturn_t mei_me_irq_thread_handler(int irq, void *dev_id)
+ end:
+ 	dev_dbg(&dev->dev, "interrupt thread end ret = %d\n", rets);
+ 	mei_me_intr_enable(dev);
+-	mutex_unlock(&dev->device_lock);
+ 	return IRQ_HANDLED;
+ }
++
++/**
++ * mei_me_irq_thread_handler - function called after ISR to handle the interrupt
++ * processing.
++ *
++ * @irq: The irq number
++ * @dev_id: pointer to the device structure
++ *
++ * Return: irqreturn_t
++ *
++ */
++irqreturn_t mei_me_irq_thread_handler(int irq, void *dev_id)
++{
++	struct mei_device *dev = (struct mei_device *) dev_id;
++
++	dev_dbg(&dev->dev, "function called after ISR to handle the interrupt processing.\n");
++
++	guard(mutex)(&dev->device_lock);
++
++	return __mei_me_irq_thread_handler(dev);
++}
+ EXPORT_SYMBOL_GPL(mei_me_irq_thread_handler);
+ 
+-#define MEI_POLLING_TIMEOUT_ACTIVE 100
+-#define MEI_POLLING_TIMEOUT_IDLE   500
++#define MEI_POLL_ACTIVE_MS 100
++#define MEI_POLL_IDLE_MS   500
+ 
+ /**
+  * mei_me_polling_thread - interrupt register polling thread
+@@ -1423,45 +1429,56 @@ EXPORT_SYMBOL_GPL(mei_me_irq_thread_handler);
+  * mei_me_irq_thread_handler() to handle the firmware
+  * input.
+  *
+- * The function polls in MEI_POLLING_TIMEOUT_ACTIVE timeout
++ * The function polls in MEI_POLL_ACTIVE_MS timeout
+  * in case there was an event, in idle case the polling
+- * time increases yet again by MEI_POLLING_TIMEOUT_ACTIVE
+- * up to MEI_POLLING_TIMEOUT_IDLE.
++ * time increases yet again by MEI_POLL_ACTIVE_MS
++ * up to MEI_POLL_IDLE_MS.
+  *
+  * Return: always 0
+  */
+ int mei_me_polling_thread(void *_dev)
+ {
+ 	struct mei_device *dev = _dev;
+-	irqreturn_t irq_ret;
+-	long polling_timeout = MEI_POLLING_TIMEOUT_ACTIVE;
++	long polling_timeout = MEI_POLL_ACTIVE_MS;
++	bool have_interrupt;
+ 
+ 	dev_dbg(&dev->dev, "kernel thread is running\n");
+ 	while (!kthread_should_stop()) {
+ 		struct mei_me_hw *hw = to_me_hw(dev);
+ 		u32 hcsr;
+ 
+-		wait_event_timeout(hw->wait_active,
+-				   hw->is_active || kthread_should_stop(),
+-				   msecs_to_jiffies(MEI_POLLING_TIMEOUT_IDLE));
++		if (!hw->is_active)
++			wait_event_interruptible(hw->wait_active,
++						 hw->is_active || kthread_should_stop());
++		else
++			wait_event_interruptible_timeout(hw->wait_active,
++						 hw->is_active || kthread_should_stop(),
++						 msecs_to_jiffies(MEI_POLL_IDLE_MS));
+ 
+ 		if (kthread_should_stop())
+ 			break;
+ 
+-		hcsr = mei_hcsr_read(dev);
+-		if (me_intr_src(hcsr)) {
+-			polling_timeout = MEI_POLLING_TIMEOUT_ACTIVE;
+-			irq_ret = mei_me_irq_thread_handler(1, dev);
+-			if (irq_ret != IRQ_HANDLED)
+-				dev_err(&dev->dev, "irq_ret %d\n", irq_ret);
+-		} else {
+-			/*
+-			 * Increase timeout by MEI_POLLING_TIMEOUT_ACTIVE
+-			 * up to MEI_POLLING_TIMEOUT_IDLE
+-			 */
+-			polling_timeout = clamp_val(polling_timeout + MEI_POLLING_TIMEOUT_ACTIVE,
+-						    MEI_POLLING_TIMEOUT_ACTIVE,
+-						    MEI_POLLING_TIMEOUT_IDLE);
++		scoped_guard(mutex, &dev->device_lock) {
++			if (!hw->is_active) {
++				have_interrupt = false;
++			} else {
++				hcsr = mei_hcsr_read(dev);
++				have_interrupt = !!me_intr_src(hcsr);
++			}
++
++			if (have_interrupt) {
++				polling_timeout = MEI_POLL_ACTIVE_MS;
++				dev_dbg(&dev->dev, "polling interrupt processing\n");
++				__mei_me_irq_thread_handler(dev);
++			} else {
++				/*
++				 * Increase timeout by MEI_POLL_ACTIVE_MS
++				 * up to MEI_POLL_IDLE_MS
++				 */
++				polling_timeout = clamp_val(polling_timeout + MEI_POLL_ACTIVE_MS,
++							    MEI_POLL_ACTIVE_MS,
++							    MEI_POLL_IDLE_MS);
++			}
+ 		}
+ 
+ 		schedule_timeout_interruptible(msecs_to_jiffies(polling_timeout));
+-- 
+2.34.1

--- a/backport/patches/base/0001-mei-me-reduce-active-polling-timeout-to-20-ms.patch
+++ b/backport/patches/base/0001-mei-me-reduce-active-polling-timeout-to-20-ms.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Usyskin <alexander.usyskin@intel.com>
+Date: Mon, 31 Aug 2026 14:38:34 +0300
+Subject: mei: me: reduce active polling timeout to 20 ms
+
+Improve performance of polling by reducing active timeout.
+20 ms active timeout helps increase channel throughtput
+and significately reduces data transfer times.
+
+Our tests have prooved that timeout decrease does no ill effects
+for core CPU utilization.
+
+Reviewed-by: Menachem Adin <menachem.adin@intel.com>
+Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
+(backported from [mei: me: reduce active polling timeout to 20 ms via char-misc-next])
+Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>
+---
+ drivers/misc/mei/hw-me.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/misc/mei/hw-me.c b/drivers/misc/mei/hw-me.c
+index 5f571e6b6..ae061c133 100644
+--- a/drivers/misc/mei/hw-me.c
++++ b/drivers/misc/mei/hw-me.c
+@@ -1417,7 +1417,7 @@ irqreturn_t mei_me_irq_thread_handler(int irq, void *dev_id)
+ }
+ EXPORT_SYMBOL_GPL(mei_me_irq_thread_handler);
+ 
+-#define MEI_POLL_ACTIVE_MS 100
++#define MEI_POLL_ACTIVE_MS 20
+ #define MEI_POLL_IDLE_MS   500
+ 
+ /**
+-- 
+2.34.1

--- a/series
+++ b/series
@@ -217,6 +217,11 @@ backport/patches/base/0001-drm-xe-hwmon-Use-VRAM-temperature-sensor-count-from-.
 backport/patches/base/0001-drm-xe-hwmon-Correct-group-selection-for-memory-cont.patch
 backport/patches/base/0001-drm-xe-xe_guc-Skip-GuC-reset-post-SBR.patch
 backport/patches/base/0001-drm-xe-xe_pci_error-Wait-for-pcode-init-post-SBR.patch
+backport/patches/base/0001-mei-csc-add-pci-error-handling.patch
+backport/patches/base/0001-mei-make-polling-wait-interruptible.patch
+backport/patches/base/0001-mei-csc-add-option-for-polling-and-enable-it.patch
+backport/patches/base/0001-mei-me-avoid-hw-access-in-polling-when-not-active.patch
+backport/patches/base/0001-mei-me-reduce-active-polling-timeout-to-20-ms.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
These fixes are required for mei-csc pci error handling and polling support.

Links:
https://lore.kernel.org/lkml/20260831-cri_polling-v1-0-d927315e6598@intel.com/
https://lore.kernel.org/lkml/20260902-cri_aer-v1-1-b0571c399265@intel.com/

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>