### PR TITLE
series: Add missing i2c fix

### DIFF
--- a/series
+++ b/series
@@ -217,6 +217,7 @@ backport/patches/base/0001-drm-xe-hwmon-Use-VRAM-temperature-sensor-count-from-.
 backport/patches/base/0001-drm-xe-hwmon-Correct-group-selection-for-memory-cont.patch
 backport/patches/base/0001-drm-xe-xe_guc-Skip-GuC-reset-post-SBR.patch
 backport/patches/base/0001-drm-xe-xe_pci_error-Wait-for-pcode-init-post-SBR.patch
+backport/patches/base/0001-drm-xe-i2c-cancel-the-client-work-on-remove.patch
 # features/eu-debug
 backport/patches/features/eu-debug/0001-ptrace-export-ptrace_may_access.patch
 backport/patches/features/eu-debug/0001-drm-xe-eudebug-Introduce-eudebug-support.patch


### PR DESCRIPTION
Add missing i2c fix "drm/xe/i2c: Backport xe i2c fix"
patch in series

Signed-off-by: Nitin Gote <nitin.r.gote@intel.com>